### PR TITLE
supermicrox10: fix bug where credentials in the bmc instance would not

### DIFF
--- a/providers/supermicro/supermicrox10/supermicrox10.go
+++ b/providers/supermicro/supermicrox10/supermicrox10.go
@@ -432,7 +432,7 @@ func (s *SupermicroX10) Disks() (disks []*devices.Disk, err error) {
 }
 
 // UpdateCredentials updates login credentials
-func (s SupermicroX10) UpdateCredentials(username string, password string) {
+func (s *SupermicroX10) UpdateCredentials(username string, password string) {
 	s.username = username
 	s.password = password
 }

--- a/providers/supermicro/supermicrox10/supermicrox10_test.go
+++ b/providers/supermicro/supermicrox10/supermicrox10_test.go
@@ -479,3 +479,22 @@ func TestIBmcInterface(t *testing.T) {
 	_ = devices.Bmc(bmc)
 	tearDown()
 }
+
+func TestUpdateCredentials(t *testing.T) {
+	bmc, err := setup()
+	if err != nil {
+		t.Fatalf("Found errors during the test setup %v", err)
+	}
+
+	bmc.UpdateCredentials("newUsername", "newPassword")
+
+	if bmc.username != "newUsername" {
+		t.Fatalf("Expected username to be updated to 'newUsername' but is: %s", bmc.username)
+	}
+
+	if bmc.password != "newPassword" {
+		t.Fatalf("Expected password to be updated to 'newPassword' but is: %s", bmc.password)
+	}
+
+	tearDown()
+}


### PR DESCRIPTION
update, when calling UpdateCredentials.