### PR TITLE
c7000: Add a deadline context to cancel requests that take too long.

### DIFF
--- a/providers/hp/c7000/xmlhelpers.go
+++ b/providers/hp/c7000/xmlhelpers.go
@@ -2,6 +2,7 @@ package c7000
 
 import (
 	"bytes"
+	"context"
 	"encoding/xml"
 	"fmt"
 	"io/ioutil"
@@ -9,6 +10,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -71,6 +73,13 @@ func (c *C7000) postXML(data interface{}) (statusCode int, body []byte, err erro
 	if err != nil {
 		return 0, []byte{}, err
 	}
+
+	//Setup a context to cancel the request if it takes long,
+	//this prevents the http.Client.Timeout Deadline from kicking in and causing a panic.
+	ctx, cancel := context.WithTimeout(req.Context(), 10*time.Second)
+	defer cancel()
+
+	req = req.WithContext(ctx)
 
 	//	req.Header.Add("Content-Type", "application/soap+xml; charset=utf-8")
 	req.Header.Add("Content-Type", "text/plain;charset=UTF-8")


### PR DESCRIPTION
This fixes the panic where the http.Client.Timeout Deadline timer kicks in and causes a panic.

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x6776b2]

goroutine 15 [running]:
net/http.(*Client).deadline(0x0, 0xc4203de110, 0x0, 0x0)
        /usr/lib/go/src/net/http/client.go:189 +0x22
net/http.(*Client).Do(0x0, 0xc420354800, 0xc4204e6a30, 0x1, 0x1)
        /usr/lib/go/src/net/http/client.go:500 +0x86
github.com/bmc-toolbox/bmclib/providers/hp/c7000.(*C7000).postXML(0xc420184070, 0xa89040, 0xc4204440b0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/jrebello/go/src/github.com/bmc-toolbox/bmclib/providers/hp/c7000/xmlhelpers.go:85 +0x5af