### PR TITLE
c7000: Manage bmc blade users through chassis.

### DIFF
--- a/cfgresources/cfgresources.go
+++ b/cfgresources/cfgresources.go
@@ -1,12 +1,16 @@
 package cfgresources
 
+// SetupChassis struct holds attributes for one time chassis setup.
 type SetupChassis struct {
-	FlexAddress  *flexAddress  `yaml:"flexAddress"`
-	IpmiOverLan  *ipmiOverLan  `yaml:"ipmiOverLan"`
-	DynamicPower *dynamicPower `yaml:"dynamicPower"`
-	BladesPower  *bladesPower  `yaml:"bladesPower"`
+	FlexAddress         *flexAddress       `yaml:"flexAddress"`
+	IpmiOverLan         *ipmiOverLan       `yaml:"ipmiOverLan"`
+	DynamicPower        *dynamicPower      `yaml:"dynamicPower"`
+	BladesPower         *bladesPower       `yaml:"bladesPower"`
+	AddBladeBmcAdmins   []*BladeBmcAccount `yaml:"addBladeBmcAdmins"`
+	RemoveBladeBmcUsers []*BladeBmcAccount `yaml:"removeBladeBmcUsers"`
 }
 
+// ResourcesConfig struct holds all the configuration to be applied.
 type ResourcesConfig struct {
 	Ldap         *Ldap         `yaml:"ldap"`
 	LdapGroup    []*LdapGroup  `yaml:"ldapGroup"`
@@ -19,6 +23,12 @@ type ResourcesConfig struct {
 	Supermicro   *Supermicro   `yaml:"supermicro"` //supermicro specific config, example of issue #34
 	Dell         *Dell         `yaml:"dell"`
 	SetupChassis *SetupChassis `yaml:"setupChassis"`
+}
+
+// BladeBmcAccount declares attributes for a Blade BMC user to be managed through the chassis.
+type BladeBmcAccount struct {
+	Name     string `yaml:"name"`
+	Password string `yaml:"password"`
 }
 
 //Enable/Disable Virtual Mac addresses for blades in a chassis.
@@ -44,6 +54,7 @@ type bladesPower struct {
 	Enable bool `yaml:"enable"`
 }
 
+// User struct holds a BMC user account configuration.
 type User struct {
 	Name     string `yaml:"name"`
 	Password string `yaml:"password"`
@@ -51,12 +62,14 @@ type User struct {
 	Enable   bool   `yaml:"enable,omitempty"`
 }
 
+// Syslog struct holds BMC syslog configuration.
 type Syslog struct {
 	Server string `yaml:"server"`
-	Port   int    `yaml:"port",omitempty`
-	Enable bool   `yaml:"enable",omitempty`
+	Port   int    `yaml:"port,omitempty"`
+	Enable bool   `yaml:"enable,omitempty"`
 }
 
+// Ldap struct holds BMC LDAP configuration.
 type Ldap struct {
 	Server         string `yaml:"server"`
 	Port           int    `yaml:"port"`
@@ -71,10 +84,12 @@ type Ldap struct {
 	SearchFilter   string `yaml:"searchFilter"`
 }
 
+// License struct holds BMC licencing configuration.
 type License struct {
 	Key string `yaml:"key"`
 }
 
+// LdapGroup struct holds BMC LDAP role group configuration.
 type LdapGroup struct {
 	Role        string `yaml:"role"`
 	Group       string `yaml:"group"`
@@ -82,11 +97,13 @@ type LdapGroup struct {
 	Enable      bool   `yaml:"enable"`
 }
 
+// Ssl struct holds BMC SSL configuration.
 type Ssl struct {
 	CertFile string `yaml:"certfile"`
 	KeyFile  string `yaml:"keyfile"`
 }
 
+// Network struct holds BMC network configuration.
 type Network struct {
 	Hostname    string `yaml:"hostname"`
 	DNSFromDHCP bool   `yaml:"dnsFromDhcp"`

--- a/devices/interfaces.go
+++ b/devices/interfaces.go
@@ -63,6 +63,9 @@ type BmcChassis interface {
 	PxeOnceBlade(int) (bool, error)
 	ReseatBlade(int) (bool, error)
 	Serial() (string, error)
+	RemoveBladeBmcUser(string) error
+	AddBladeBmcAdmin(string, string) error
+	ModBladeBmcUser(string, string) error
 	SetDynamicPower(bool) (bool, error)
 	SetIpmiOverLan(int, bool) (bool, error)
 	SetFlexAddressState(int, bool) (bool, error)

--- a/providers/dell/m1000e/actions.go
+++ b/providers/dell/m1000e/actions.go
@@ -245,7 +245,7 @@ func (m *M1000e) PxeOnceBlade(position int) (status bool, err error) {
 	return status, fmt.Errorf(output)
 }
 
-// Enable/Disable IPMI over lan parameter per blade in chassis
+// SetIpmiOverLan Enable/Disable IPMI over lan parameter per blade in chassis
 func (m *M1000e) SetIpmiOverLan(position int, enable bool) (status bool, err error) {
 	err = m.sshLogin()
 	if err != nil {
@@ -273,7 +273,7 @@ func (m *M1000e) SetIpmiOverLan(position int, enable bool) (status bool, err err
 
 }
 
-// Enable/Disable Dynamic Power - Dynamic Power Supply Engagement (DPSE) in Dell jargon.
+// SetDynamicPower Enable/Disable Dynamic Power - Dynamic Power Supply Engagement (DPSE) in Dell jargon.
 // Dynamic Power Supply Engagement (DPSE) mode is disabled by default.
 // DPSE saves power by optimizing the power efficiency of the PSUs supplying power to the chassis.
 // This also increases the PSU life, and reduces heat generation.
@@ -340,7 +340,7 @@ func (m *M1000e) SetFlexAddressState(position int, enable bool) (status bool, er
 	return status, fmt.Errorf(output)
 }
 
-// FirmwareVersion returns the chassis firmware version
+// GetFirmwareVersion returns the chassis firmware version
 func (m *M1000e) GetFirmwareVersion() (version string, err error) {
 	err = m.sshLogin()
 	if err != nil {
@@ -388,4 +388,19 @@ func (m *M1000e) UpdateFirmware(host, filepath string) (status bool, err error) 
 func (m *M1000e) UpdateFirmwareBmcBlade(position int, host, filepath string) (status bool, err error) {
 	// iDRAC 7 or later is not supported by fwupdate on the M1000e
 	return status, errors.ErrNotImplemented
+}
+
+// AddBladeBmcAdmin adds BMC Admin user accounts through the chassis.
+func (m *M1000e) AddBladeBmcAdmin(username string, password string) (err error) {
+	return errors.ErrNotImplemented
+}
+
+// RemoveBladeBmcUser removes BMC Admin user accounts through the chassis.
+func (m *M1000e) RemoveBladeBmcUser(username string) (err error) {
+	return errors.ErrNotImplemented
+}
+
+// ModBladeBmcUser modifies a BMC Admin user password through the chassis.
+func (m *M1000e) ModBladeBmcUser(username string) (err error) {
+	return errors.ErrNotImplemented
 }


### PR DESCRIPTION
This implements support to manage BMC user accounts through the chassis.