### PR TITLE
Configure interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,20 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Supermicro X10 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | 
 
 
 ## Debugging
-export DEBUG_BMCLIB=1 for bmclib to verbose log.
+export DEBUG_BMCLIB=1 for bmclib to verbose log
+export BMCLIB_TEST=1 to run on a dummy bmc (dry run).
 
 #### Acknowledgment
 

--- a/cfgresources/cfgresources.go
+++ b/cfgresources/cfgresources.go
@@ -20,9 +20,14 @@ type ResourcesConfig struct {
 	User         []*User       `yaml:"user"`
 	Ssl          *Ssl          `yaml:"ssl"`
 	Ntp          *Ntp          `yaml:"ntp"`
+	Bios         *Bios         `yaml:"bios"`
 	Supermicro   *Supermicro   `yaml:"supermicro"` //supermicro specific config, example of issue #34
-	Dell         *Dell         `yaml:"dell"`
 	SetupChassis *SetupChassis `yaml:"setupChassis"`
+}
+
+// Bios struct holds bios configuration for each vendor.
+type Bios struct {
+	Dell *Dell `yaml:"dell"`
 }
 
 // BladeBmcAccount declares attributes for a Blade BMC user to be managed through the chassis.

--- a/devices/interfaces.go
+++ b/devices/interfaces.go
@@ -7,6 +7,7 @@ import (
 // Bmc represents the requirement of items to be collected a server
 type Bmc interface {
 	ApplyCfg(*cfgresources.ResourcesConfig) error
+	// embed Configure interface
 	Configure
 	BiosVersion() (string, error)
 	BmcType() string
@@ -80,11 +81,12 @@ type BmcChassis interface {
 // Configure interface declares methods implemented
 // to apply configuration to BMCs.
 type Configure interface {
+	Resources() []string
 	User([]*cfgresources.User) error
 	Syslog(*cfgresources.Syslog) error
 	Ntp(*cfgresources.Ntp) error
 	Ldap(*cfgresources.Ldap) error
 	LdapGroup([]*cfgresources.LdapGroup, *cfgresources.Ldap) error
-	Timezone(string) error
 	Network(*cfgresources.Network) error
+	SetLicense(*cfgresources.License) error
 }

--- a/devices/interfaces.go
+++ b/devices/interfaces.go
@@ -7,6 +7,7 @@ import (
 // Bmc represents the requirement of items to be collected a server
 type Bmc interface {
 	ApplyCfg(*cfgresources.ResourcesConfig) error
+	Configure
 	BiosVersion() (string, error)
 	BmcType() string
 	BmcVersion() (string, error)
@@ -74,4 +75,16 @@ type BmcChassis interface {
 	TempC() (int, error)
 	UpdateCredentials(string, string)
 	Vendor() string
+}
+
+// Configure interface declares methods implemented
+// to apply configuration to BMCs.
+type Configure interface {
+	User([]*cfgresources.User) error
+	Syslog(*cfgresources.Syslog) error
+	Ntp(*cfgresources.Ntp) error
+	Ldap(*cfgresources.Ldap) error
+	LdapGroup([]*cfgresources.LdapGroup, *cfgresources.Ldap) error
+	Timezone(string) error
+	Network(*cfgresources.Network) error
 }

--- a/devices/interfaces.go
+++ b/devices/interfaces.go
@@ -38,6 +38,8 @@ type Bmc interface {
 // BmcChassis represents the requirement of items to be collected from a chassis
 type BmcChassis interface {
 	ApplyCfg(*cfgresources.ResourcesConfig) error
+	// embed Configure interface
+	Configure
 	Blades() ([]*Blade, error)
 	BmcType() string
 	ChassisSnapshot() (*Chassis, error)

--- a/devices/interfaces.go
+++ b/devices/interfaces.go
@@ -91,4 +91,5 @@ type Configure interface {
 	LdapGroup([]*cfgresources.LdapGroup, *cfgresources.Ldap) error
 	Network(*cfgresources.Network) error
 	SetLicense(*cfgresources.License) error
+	Bios(*cfgresources.Bios) error
 }

--- a/discover/discover.go
+++ b/discover/discover.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/bmc-toolbox/bmclib/errors"
@@ -30,7 +31,7 @@ func ScanAndConnect(host string, username string, password string) (bmcConnectio
 	log.WithFields(log.Fields{"step": "ScanAndConnect", "host": host}).Debug("detecting vendor")
 
 	// return a connection to our dummy device.
-	if host == "01.01.01.01" {
+	if os.Getenv("BMCLIB_TEST") == "1" {
 		log.WithFields(log.Fields{"step": "ScanAndConnect", "host": host}).Debug("returning connection to dummy ibmc device.")
 		return ibmc.New(host, username, password), nil
 	}

--- a/discover/discover.go
+++ b/discover/discover.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bmc-toolbox/bmclib/providers/dell/idrac8"
 	"github.com/bmc-toolbox/bmclib/providers/dell/idrac9"
 	"github.com/bmc-toolbox/bmclib/providers/dell/m1000e"
+	"github.com/bmc-toolbox/bmclib/providers/dummy/ibmc"
 	"github.com/bmc-toolbox/bmclib/providers/hp"
 	"github.com/bmc-toolbox/bmclib/providers/hp/c7000"
 
@@ -27,6 +28,12 @@ import (
 // ScanAndConnect will scan the bmc trying to learn the device type and return a working connection
 func ScanAndConnect(host string, username string, password string) (bmcConnection interface{}, err error) {
 	log.WithFields(log.Fields{"step": "ScanAndConnect", "host": host}).Debug("detecting vendor")
+
+	// return a connection to our dummy device.
+	if host == "01.01.01.01" {
+		log.WithFields(log.Fields{"step": "ScanAndConnect", "host": host}).Debug("returning connection to dummy ibmc device.")
+		return ibmc.New(host, username, password), nil
+	}
 
 	client, err := httpclient.Build()
 	if err != nil {

--- a/providers/dell/idrac8/idrac8.go
+++ b/providers/dell/idrac8/idrac8.go
@@ -244,8 +244,13 @@ func (i *IDrac8) Nics() (nics []*devices.Nic, err error) {
 
 	for _, component := range i.iDracInventory.Component {
 		if component.Classname == "DCIM_NICView" {
+			var speed string
+			var up bool
 			for _, property := range component.Properties {
-				if property.Name == "ProductName" && property.Type == "string" {
+				if property.Name == "LinkSpeed" && property.Type == "uint8" && property.DisplayValue != "Unknown" {
+					speed = property.DisplayValue
+					up = true
+				} else if property.Name == "ProductName" && property.Type == "string" {
 					data := strings.Split(property.Value, " - ")
 					if len(data) == 2 {
 						if nics == nil {
@@ -254,6 +259,8 @@ func (i *IDrac8) Nics() (nics []*devices.Nic, err error) {
 
 						n := &devices.Nic{
 							Name:       data[0],
+							Speed:      speed,
+							Up:         up,
 							MacAddress: strings.ToLower(data[1]),
 						}
 						nics = append(nics, n)

--- a/providers/dell/idrac8/idrac8_test.go
+++ b/providers/dell/idrac8/idrac8_test.go
@@ -2926,7 +2926,7 @@ var (
 				   </PROPERTY>
 				   <PROPERTY NAME="LinkSpeed" TYPE="uint8">
 					 <VALUE>9</VALUE>
-					 <DisplayValue>Unknown</DisplayValue>
+					 <DisplayValue>10 Gbps</DisplayValue>
 				   </PROPERTY>
 				   <PROPERTY NAME="LinkDuplex" TYPE="uint8">
 					 <VALUE>1</VALUE>
@@ -5485,14 +5485,20 @@ func TestIDracNics(t *testing.T) {
 		&devices.Nic{
 			MacAddress: "24:8a:07:5a:9e:8c",
 			Name:       "Mellanox ConnectX-4 LX 25GbE SFP Rack NDC",
+			Up:         true,
+			Speed:      "10 Gbps",
 		},
 		&devices.Nic{
 			MacAddress: "24:8a:07:5a:9e:8d",
 			Name:       "Mellanox ConnectX-4 LX 25GbE SFP Rack NDC",
+			Up:         false,
+			Speed:      "",
 		},
 		&devices.Nic{
 			MacAddress: "84:7b:eb:f7:82:5a",
 			Name:       "bmc",
+			Up:         false,
+			Speed:      "",
 		},
 	}
 
@@ -5511,7 +5517,7 @@ func TestIDracNics(t *testing.T) {
 	}
 
 	for pos, nic := range nics {
-		if nic.MacAddress != expectedAnswer[pos].MacAddress || nic.Name != expectedAnswer[pos].Name {
+		if nic.MacAddress != expectedAnswer[pos].MacAddress || nic.Name != expectedAnswer[pos].Name || nic.Speed != expectedAnswer[pos].Speed || nic.Up != expectedAnswer[pos].Up {
 			t.Errorf("Expected answer %v: found %v", expectedAnswer[pos], nic)
 		}
 	}

--- a/providers/dell/idrac9/configure.go
+++ b/providers/dell/idrac9/configure.go
@@ -26,7 +26,7 @@ func (i *IDrac9) Resources() []string {
 		"network",
 		"ntp",
 		"ldap",
-		"roup",
+		"ldap_group",
 		"bios",
 	}
 }

--- a/providers/dell/idrac9/configure.go
+++ b/providers/dell/idrac9/configure.go
@@ -3,146 +3,44 @@ package idrac9
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"strconv"
 
 	"github.com/bmc-toolbox/bmclib/cfgresources"
+	"github.com/bmc-toolbox/bmclib/devices"
 	"github.com/bmc-toolbox/bmclib/internal/helper"
 
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/go-playground/validator.v9"
 )
 
+// This ensures the compiler errors if this type is missing
+// a method that should be implmented to satisfy the Configure interface.
+var _ devices.Configure = (*IDrac9)(nil)
+
+// Resources returns a slice of supported resources and
+// the order they are to be applied in.
+func (i *IDrac9) Resources() []string {
+	return []string{
+		"user",
+		"syslog",
+		"network",
+		"ntp",
+		"ldap",
+		"roup",
+		"bios",
+	}
+}
+
+// ApplyCfg implements the Bmc interface
 func (i *IDrac9) ApplyCfg(config *cfgresources.ResourcesConfig) (err error) {
-
-	if config == nil {
-		msg := "No config to apply."
-		log.WithFields(log.Fields{
-			"step": "ApplyCfg",
-		}).Warn(msg)
-		return errors.New(msg)
-	}
-
-	cfg := reflect.ValueOf(config).Elem()
-
-	//Each Field in ResourcesConfig struct is a ptr to a resource,
-	//Here we figure the resources to be configured, i.e the ptr is not nil
-	for r := 0; r < cfg.NumField(); r++ {
-		resourceName := cfg.Type().Field(r).Name
-		if cfg.Field(r).Pointer() != 0 {
-			switch resourceName {
-			case "User":
-				//retrieve users resource values as an interface
-				userAccounts := cfg.Field(r).Interface()
-
-				//assert userAccounts interface to its actual type - A slice of ptrs to User
-				err := i.applyUserParams(userAccounts.([]*cfgresources.User))
-				if err != nil {
-					log.WithFields(log.Fields{
-						"step":     "ApplyCfg",
-						"resource": cfg.Field(r).Kind(),
-						"IP":       i.ip,
-						"Model":    i.BmcType(),
-						"Serial":   i.Serial,
-						"Error":    err,
-					}).Warn("Unable to apply User config.")
-				}
-			case "Syslog":
-				syslogCfg := cfg.Field(r).Interface().(*cfgresources.Syslog)
-				err := i.applySyslogParams(syslogCfg)
-				if err != nil {
-					log.WithFields(log.Fields{
-						"step":     "ApplyCfg",
-						"resource": cfg.Field(r).Kind(),
-						"IP":       i.ip,
-						"Model":    i.BmcType(),
-						"Serial":   i.Serial,
-						"Error":    err,
-					}).Warn("Unable to set Syslog config.")
-				}
-			case "Network":
-				networkCfg := cfg.Field(r).Interface().(*cfgresources.Network)
-				err := i.applyNetworkParams(networkCfg)
-				if err != nil {
-					log.WithFields(log.Fields{
-						"step":     "ApplyCfg",
-						"resource": cfg.Field(r).Kind(),
-						"IP":       i.ip,
-						"Model":    i.BmcType(),
-						"Serial":   i.Serial,
-						"Error":    err,
-					}).Warn("Unable to set Network config params.")
-				}
-			case "Ntp":
-				ntpCfg := cfg.Field(r).Interface().(*cfgresources.Ntp)
-				err := i.applyNtpParams(ntpCfg)
-				if err != nil {
-					log.WithFields(log.Fields{
-						"step":     "ApplyCfg",
-						"resource": cfg.Field(r).Kind(),
-						"IP":       i.ip,
-						"Model":    i.BmcType(),
-						"Serial":   i.Serial,
-					}).Warn("Unable to set NTP config.")
-				}
-			case "Ldap":
-				ldapCfg := cfg.Field(r).Interface().(*cfgresources.Ldap)
-				err := i.applyLdapServerParams(ldapCfg)
-				if err != nil {
-					log.WithFields(log.Fields{
-						"step":     "applyLdapParams",
-						"resource": "Ldap",
-						"IP":       i.ip,
-						"Model":    i.BmcType(),
-						"Serial":   i.Serial,
-						"Error":    err,
-					}).Warn("applyLdapServerParams returned error.")
-				}
-			case "LdapGroup":
-				ldapGroupCfg := cfg.Field(r).Interface().([]*cfgresources.LdapGroup)
-				err := i.applyLdapGroupParams(ldapGroupCfg)
-				if err != nil {
-					log.WithFields(log.Fields{
-						"step":     "applyLdapParams",
-						"resource": "Ldap",
-						"IP":       i.ip,
-						"Model":    i.BmcType(),
-						"Serial":   i.Serial,
-						"Error":    err,
-					}).Warn("applyLdapGroupParams returned error.")
-				}
-			case "Ssl":
-			case "Dell":
-				biosCfg := cfg.Field(r).Interface().(*cfgresources.Dell)
-				if biosCfg.Idrac9BiosSettings != nil {
-					err := i.applyBiosParams(biosCfg.Idrac9BiosSettings)
-					if err != nil {
-						log.WithFields(log.Fields{
-							"step":     "applyBiosCfg",
-							"resource": "Bios",
-							"IP":       i.ip,
-							"Model":    i.BmcType(),
-							"Serial":   i.Serial,
-							"Error":    err,
-						}).Warn("applyBiosParams returned error.")
-					}
-				}
-			default:
-				log.WithFields(log.Fields{
-					"step": "ApplyCfg",
-				}).Debug("Unknown resource.")
-			}
-		}
-	}
-
 	return err
 }
 
-// Applies Bios params
-func (i *IDrac9) applyBiosParams(newBiosSettings *cfgresources.Idrac9BiosSettings) (err error) {
+// Bios sets up Bios configuration
+// Bios implements the Configure interface
+func (i *IDrac9) Bios(cfg *cfgresources.Bios) (err error) {
 
-	//The bios settings that will be applied
-	toApplyBiosSettings := &BiosSettings{}
+	newBiosSettings := cfg.Dell.Idrac9BiosSettings
 
 	//validate config
 	validate := validator.New()
@@ -173,7 +71,7 @@ func (i *IDrac9) applyBiosParams(newBiosSettings *cfgresources.Idrac9BiosSetting
 	if *newBiosSettings != *currentBiosSettings {
 
 		//retrieve fields that is the config to be applied
-		toApplyBiosSettings, err = diffBiosSettings(newBiosSettings, currentBiosSettings)
+		toApplyBiosSettings, err := diffBiosSettings(newBiosSettings, currentBiosSettings)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"IP":     i.ip,
@@ -239,8 +137,11 @@ func (i *IDrac9) applyBiosParams(newBiosSettings *cfgresources.Idrac9BiosSetting
 	return err
 }
 
-// Iterates over iDrac users and adds/removes/modifies the user account
-func (i *IDrac9) applyUserParams(cfgUsers []*cfgresources.User) (err error) {
+// User applies the User configuration resource,
+// if the user exists, it updates the users password,
+// User implements the Configure interface.
+// Iterate over iDrac users and adds/removes/modifies user accounts
+func (i *IDrac9) User(cfgUsers []*cfgresources.User) (err error) {
 
 	err = i.validateCfg(cfgUsers)
 	if err != nil {
@@ -271,14 +172,14 @@ func (i *IDrac9) applyUserParams(cfgUsers []*cfgresources.User) (err error) {
 	//for each configuration user
 	for _, cfgUser := range cfgUsers {
 
-		userId, userInfo, uExists := userInIdrac(cfgUser.Name, idracUsers)
+		userID, userInfo, uExists := userInIdrac(cfgUser.Name, idracUsers)
 
 		//user to be added/updated
 		if cfgUser.Enable {
 
 			//new user to be added
 			if uExists == false {
-				userId, userInfo, err = getEmptyUserSlot(idracUsers)
+				userID, userInfo, err = getEmptyUserSlot(idracUsers)
 				if err != nil {
 					log.WithFields(log.Fields{
 						"IP":     i.ip,
@@ -306,7 +207,7 @@ func (i *IDrac9) applyUserParams(cfgUsers []*cfgresources.User) (err error) {
 				userInfo.IpmiLanPrivilege = "Operator"
 			}
 
-			err = i.putUser(userId, userInfo)
+			err = i.putUser(userID, userInfo)
 			if err != nil {
 				log.WithFields(log.Fields{
 					"IP":     i.ip,
@@ -323,7 +224,7 @@ func (i *IDrac9) applyUserParams(cfgUsers []*cfgresources.User) (err error) {
 
 		//if the user exists but is disabled in our config, remove the user
 		if cfgUser.Enable == false && uExists == true {
-			endpoint := fmt.Sprintf("sysmgmt/2017/server/user?userid=%d", userId)
+			endpoint := fmt.Sprintf("sysmgmt/2017/server/user?userid=%d", userID)
 			statusCode, response, err := i.delete_(endpoint)
 			if err != nil {
 				log.WithFields(log.Fields{
@@ -352,8 +253,9 @@ func (i *IDrac9) applyUserParams(cfgUsers []*cfgresources.User) (err error) {
 	return err
 }
 
-// Applies LDAP server params
-func (i *IDrac9) applyLdapServerParams(cfg *cfgresources.Ldap) (err error) {
+// Ldap applies LDAP configuration params.
+// Ldap implements the Configure interface.
+func (i *IDrac9) Ldap(cfg *cfgresources.Ldap) (err error) {
 	params := map[string]string{
 		"Enable":               "Disabled",
 		"Port":                 "636",
@@ -427,14 +329,15 @@ func (i *IDrac9) applyLdapServerParams(cfg *cfgresources.Ldap) (err error) {
 			"step":   helper.WhosCalling(),
 			"Error":  err,
 		}).Warn(msg)
-		return errors.New("Ldap params put request failed.")
+		return errors.New("Ldap params put request failed")
 	}
 
 	return err
 }
 
-// Iterates over iDrac Ldap role groups and adds/removes/modifies ldap role groups
-func (i *IDrac9) applyLdapGroupParams(cfg []*cfgresources.LdapGroup) (err error) {
+// LdapGroup applies LDAP Group/Role related configuration
+// LdapGroup implements the Configure interface.
+func (i *IDrac9) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.Ldap) (err error) {
 
 	idracLdapRoleGroups, err := i.queryLdapRoleGroups()
 	if err != nil {
@@ -451,14 +354,14 @@ func (i *IDrac9) applyLdapGroupParams(cfg []*cfgresources.LdapGroup) (err error)
 
 	//for each configuration ldap role group
 	for _, cfgRole := range cfg {
-		roleId, role, rExists := ldapRoleGroupInIdrac(cfgRole.Group, idracLdapRoleGroups)
+		roleID, role, rExists := ldapRoleGroupInIdrac(cfgRole.Group, idracLdapRoleGroups)
 
 		//role to be added/updated
 		if cfgRole.Enable {
 
 			//new role to be added
 			if rExists == false {
-				roleId, role, err = getEmptyLdapRoleGroupSlot(idracLdapRoleGroups)
+				roleID, role, err = getEmptyLdapRoleGroupSlot(idracLdapRoleGroups)
 				if err != nil {
 					log.WithFields(log.Fields{
 						"IP":              i.ip,
@@ -482,7 +385,7 @@ func (i *IDrac9) applyLdapGroupParams(cfg []*cfgresources.LdapGroup) (err error)
 				role.Privilege = "499"
 			}
 
-			err = i.putLdapRoleGroup(roleId, role)
+			err = i.putLdapRoleGroup(roleID, role)
 			if err != nil {
 				log.WithFields(log.Fields{
 					"IP":              i.ip,
@@ -503,7 +406,7 @@ func (i *IDrac9) applyLdapGroupParams(cfg []*cfgresources.LdapGroup) (err error)
 
 			role.DN = ""
 			role.Privilege = "0"
-			err = i.putLdapRoleGroup(roleId, role)
+			err = i.putLdapRoleGroup(roleID, role)
 			if err != nil {
 				log.WithFields(log.Fields{
 					"IP":              i.ip,
@@ -532,7 +435,9 @@ func (i *IDrac9) applyLdapGroupParams(cfg []*cfgresources.LdapGroup) (err error)
 	return err
 }
 
-func (i *IDrac9) applyNtpParams(cfg *cfgresources.Ntp) (err error) {
+// Ntp applies NTP configuration params
+// Ntp implements the Configure interface.
+func (i *IDrac9) Ntp(cfg *cfgresources.Ntp) (err error) {
 
 	var enable string
 
@@ -618,7 +523,9 @@ func (i *IDrac9) applyNtpParams(cfg *cfgresources.Ntp) (err error) {
 	return err
 }
 
-func (i *IDrac9) applySyslogParams(cfg *cfgresources.Syslog) (err error) {
+// Syslog applies the Syslog configuration resource
+// Syslog implements the Configure interface
+func (i *IDrac9) Syslog(cfg *cfgresources.Syslog) (err error) {
 
 	var port int
 	enable := "Enabled"
@@ -676,7 +583,9 @@ func (i *IDrac9) applySyslogParams(cfg *cfgresources.Syslog) (err error) {
 	return err
 }
 
-func (i *IDrac9) applyNetworkParams(cfg *cfgresources.Network) (err error) {
+// Network method implements the Configure interface
+// applies various network parameters.
+func (i *IDrac9) Network(cfg *cfgresources.Network) (err error) {
 
 	params := map[string]string{
 		"EnableIPv4":              "Enabled",
@@ -772,5 +681,10 @@ func (i *IDrac9) applyNetworkParams(cfg *cfgresources.Network) (err error) {
 		"Model":  i.BmcType(),
 		"Serial": i.Serial,
 	}).Debug("Network config parameters applied.")
+	return err
+}
+
+// SetLicense implements the Configure interface.
+func (i *IDrac9) SetLicense(cfg *cfgresources.License) (err error) {
 	return err
 }

--- a/providers/dell/idrac9/idrac9.go
+++ b/providers/dell/idrac9/idrac9.go
@@ -214,8 +214,13 @@ func (i *IDrac9) Nics() (nics []*devices.Nic, err error) {
 
 	for _, component := range i.iDracInventory.Component {
 		if component.Classname == "DCIM_NICView" {
+			var speed string
+			var up bool
 			for _, property := range component.Properties {
-				if property.Name == "ProductName" && property.Type == "string" {
+				if property.Name == "LinkSpeed" && property.Type == "uint8" && property.DisplayValue != "Unknown" {
+					speed = property.DisplayValue
+					up = true
+				} else if property.Name == "ProductName" && property.Type == "string" {
 					data := strings.Split(property.Value, " - ")
 					if len(data) == 2 {
 						if nics == nil {
@@ -224,6 +229,8 @@ func (i *IDrac9) Nics() (nics []*devices.Nic, err error) {
 
 						n := &devices.Nic{
 							Name:       data[0],
+							Speed:      speed,
+							Up:         up,
 							MacAddress: strings.ToLower(data[1]),
 						}
 						nics = append(nics, n)

--- a/providers/dell/idrac9/idrac9_test.go
+++ b/providers/dell/idrac9/idrac9_test.go
@@ -4160,14 +4160,20 @@ func TestIDracNics(t *testing.T) {
 		&devices.Nic{
 			MacAddress: "24:6e:96:78:33:0c",
 			Name:       "Intel(R) Ethernet 10G 2P X520-k bNDC",
+			Up:         true,
+			Speed:      "10 Gbps",
 		},
 		&devices.Nic{
 			MacAddress: "24:6e:96:78:33:0e",
 			Name:       "Intel(R) Ethernet 10G 2P X520-k bNDC",
+			Up:         false,
+			Speed:      "",
 		},
 		&devices.Nic{
 			MacAddress: "50:9a:4c:6e:d7:2c",
 			Name:       "bmc",
+			Up:         false,
+			Speed:      "",
 		},
 	}
 
@@ -4186,7 +4192,7 @@ func TestIDracNics(t *testing.T) {
 	}
 
 	for pos, nic := range nics {
-		if nic.MacAddress != expectedAnswer[pos].MacAddress || nic.Name != expectedAnswer[pos].Name {
+		if nic.MacAddress != expectedAnswer[pos].MacAddress || nic.Name != expectedAnswer[pos].Name || nic.Speed != expectedAnswer[pos].Speed || nic.Up != expectedAnswer[pos].Up {
 			t.Errorf("Expected answer %v: found %v", expectedAnswer[pos], nic)
 		}
 	}

--- a/providers/dell/idrac9/redfish_helpers.go
+++ b/providers/dell/idrac9/redfish_helpers.go
@@ -33,16 +33,14 @@ func diffBiosSettings(new *BiosSettings, current *BiosSettings) (diff *BiosSetti
 		//
 		struct1fieldValue, ok := struct1V.Field(i).Interface().(string)
 		if !ok {
-			return diff, errors.New(
-				fmt.Sprintf("BiosSettings struct field expected to be of type string: ",
-					typeOfStruct.Field(i).Name))
+			return diff, fmt.Errorf("BiosSettings struct field expected to be of type string: %v",
+				typeOfStruct.Field(i).Name)
 		}
 
 		struct2fieldValue := struct2V.Field(i).Interface().(string)
 		if !ok {
-			return diff, errors.New(
-				fmt.Sprintf("BiosSettings struct field expected to be of type string: ",
-					typeOfStruct.Field(i).Name))
+			return diff, fmt.Errorf("BiosSettings struct field expected to be of type string: %v",
+				typeOfStruct.Field(i).Name)
 		}
 
 		if struct1fieldValue != struct2fieldValue {
@@ -278,7 +276,7 @@ func isRequestMethodValid(method string) (valid bool) {
 func (i *IDrac9) queryRedfish(method string, endpoint string, payload []byte) (statusCode int, response []byte, err error) {
 
 	if !isRequestMethodValid(method) {
-		return statusCode, response, errors.New(fmt.Sprintf("Invalid request method: ", method))
+		return statusCode, response, fmt.Errorf("Invalid request method: %v", method)
 	}
 
 	bmcURL := fmt.Sprintf("https://%s", i.ip)

--- a/providers/dell/m1000e/actions.go
+++ b/providers/dell/m1000e/actions.go
@@ -401,6 +401,6 @@ func (m *M1000e) RemoveBladeBmcUser(username string) (err error) {
 }
 
 // ModBladeBmcUser modifies a BMC Admin user password through the chassis.
-func (m *M1000e) ModBladeBmcUser(username string) (err error) {
+func (m *M1000e) ModBladeBmcUser(username string, password string)) (err error) {
 	return errors.ErrNotImplemented
 }

--- a/providers/dell/m1000e/actions.go
+++ b/providers/dell/m1000e/actions.go
@@ -401,6 +401,6 @@ func (m *M1000e) RemoveBladeBmcUser(username string) (err error) {
 }
 
 // ModBladeBmcUser modifies a BMC Admin user password through the chassis.
-func (m *M1000e) ModBladeBmcUser(username string, password string)) (err error) {
+func (m *M1000e) ModBladeBmcUser(username string, password string) (err error) {
 	return errors.ErrNotImplemented
 }

--- a/providers/dummy/dummy.go
+++ b/providers/dummy/dummy.go
@@ -1,0 +1,6 @@
+package dummy
+
+const (
+	// VendorID represents the id of the vendor across all packages
+	VendorID = "dummy"
+)

--- a/providers/dummy/ibmc/configure.go
+++ b/providers/dummy/ibmc/configure.go
@@ -1,0 +1,40 @@
+package ibmc
+
+import (
+	"github.com/bmc-toolbox/bmclib/cfgresources"
+)
+
+// User method implements the Configure interface
+func (i *Ibmc) User(cfg []*cfgresources.User) error {
+	return nil
+}
+
+// Syslog method implements the Configure interface
+func (i *Ibmc) Syslog(cfg *cfgresources.Syslog) error {
+	return nil
+}
+
+// Ntp method implements the Configure interface
+func (i *Ibmc) Ntp(cfg *cfgresources.Ntp) error {
+	return nil
+}
+
+// Ldap method implements the Configure interface
+func (i *Ibmc) Ldap(cfg *cfgresources.Ldap) error {
+	return nil
+}
+
+// LdapGroup method implements the Configure interface
+func (i *Ibmc) LdapGroup(cfgGroup []*cfgresources.LdapGroup, cfgLdap *cfgresources.Ldap) error {
+	return nil
+}
+
+// Timezone method implements the Configure interface
+func (i *Ibmc) Timezone(timezone string) error {
+	return nil
+}
+
+// Network method implements the Configure interface
+func (i *Ibmc) Network(cfg *cfgresources.Network) error {
+	return nil
+}

--- a/providers/dummy/ibmc/configure.go
+++ b/providers/dummy/ibmc/configure.go
@@ -51,3 +51,8 @@ func (i *Ibmc) Network(cfg *cfgresources.Network) error {
 func (i *Ibmc) SetLicense(*cfgresources.License) error {
 	return nil
 }
+
+// Bios method implements the Configure interface
+func (i *Ibmc) Bios(cfg *cfgresources.Bios) error {
+	return nil
+}

--- a/providers/dummy/ibmc/configure.go
+++ b/providers/dummy/ibmc/configure.go
@@ -4,6 +4,19 @@ import (
 	"github.com/bmc-toolbox/bmclib/cfgresources"
 )
 
+// Resources returns a slice of supported resources and
+// the order they are to be applied in.
+func (i *Ibmc) Resources() []string {
+	return []string{
+		"user",
+		"syslog",
+		"ntp",
+		"ldap",
+		"ldap_group",
+		"network",
+	}
+}
+
 // User method implements the Configure interface
 func (i *Ibmc) User(cfg []*cfgresources.User) error {
 	return nil
@@ -29,12 +42,12 @@ func (i *Ibmc) LdapGroup(cfgGroup []*cfgresources.LdapGroup, cfgLdap *cfgresourc
 	return nil
 }
 
-// Timezone method implements the Configure interface
-func (i *Ibmc) Timezone(timezone string) error {
+// Network method implements the Configure interface
+func (i *Ibmc) Network(cfg *cfgresources.Network) error {
 	return nil
 }
 
-// Network method implements the Configure interface
-func (i *Ibmc) Network(cfg *cfgresources.Network) error {
+// SetLicense implements the Configure interface
+func (i *Ibmc) SetLicense(*cfgresources.License) error {
 	return nil
 }

--- a/providers/dummy/ibmc/ibmc.go
+++ b/providers/dummy/ibmc/ibmc.go
@@ -1,0 +1,152 @@
+package ibmc
+
+import (
+	"github.com/bmc-toolbox/bmclib/cfgresources"
+	"github.com/bmc-toolbox/bmclib/devices"
+)
+
+// The ibmc model is part of the dummy vendor,
+// for lack of a better name and since most annoying devices begin with "i"
+// ibmc only exists to make testing easier.
+
+const (
+	// BMCType defines the bmc model that is supported by this package
+	BMCType = "ibmc"
+)
+
+// Ibmc holds the status and properties of a connection to an iDrac device
+type Ibmc struct {
+	ip       string
+	username string
+	password string
+}
+
+// New returns a new ibmc ready to be used
+func New(ip string, username string, password string) *Ibmc {
+	return &Ibmc{ip: ip, username: username, password: password}
+}
+
+// ApplyCfg implements the Bmc interface
+func (i *Ibmc) ApplyCfg(config *cfgresources.ResourcesConfig) (err error) {
+	return nil
+}
+
+// BiosVersion implements the Bmc interface
+func (i *Ibmc) BiosVersion() (string, error) {
+	return "", nil
+}
+
+// BmcType implements the Bmc interface
+func (i *Ibmc) BmcType() string {
+	return ""
+}
+
+// BmcVersion implements the Bmc interface
+func (i *Ibmc) BmcVersion() (string, error) {
+	return "", nil
+}
+
+// CPU implements the Bmc interface
+func (i *Ibmc) CPU() (string, int, int, int, error) {
+	return "", 0, 0, 0, nil
+}
+
+// CheckCredentials implements the Bmc interface
+func (i *Ibmc) CheckCredentials() error {
+	return nil
+}
+
+// Disks implements the Bmc interface
+func (i *Ibmc) Disks() ([]*devices.Disk, error) {
+	return make([]*devices.Disk, 0), nil
+}
+
+// IsBlade implements the Bmc interface
+func (i *Ibmc) IsBlade() (bool, error) {
+	return false, nil
+}
+
+// License implements the Bmc interface
+func (i *Ibmc) License() (string, string, error) {
+	return "", "", nil
+}
+
+// Close implements the Bmc interface
+func (i *Ibmc) Close() error {
+	return nil
+}
+
+// Memory implements the Bmc interface
+func (i *Ibmc) Memory() (int, error) {
+	return 0, nil
+}
+
+// Model implements the Bmc interface
+func (i *Ibmc) Model() (string, error) {
+	return "", nil
+}
+
+// Name implements the Bmc interface
+func (i *Ibmc) Name() (string, error) {
+	return "", nil
+}
+
+// Nics implements the Bmc interface
+func (i *Ibmc) Nics() ([]*devices.Nic, error) {
+	return make([]*devices.Nic, 0), nil
+}
+
+// PowerKw implements the Bmc interface
+func (i *Ibmc) PowerKw() (float64, error) {
+	return 0.0, nil
+}
+
+// PowerState implements the Bmc interface
+func (i *Ibmc) PowerState() (string, error) {
+	return "", nil
+}
+
+// PowerCycleBmc implements the Bmc interface
+func (i *Ibmc) PowerCycleBmc() (status bool, err error) {
+	return false, nil
+}
+
+// PowerCycle implements the Bmc interface
+func (i *Ibmc) PowerCycle() (status bool, err error) {
+	return false, nil
+}
+
+// Serial implements the Bmc interface
+func (i *Ibmc) Serial() (string, error) {
+	return "", nil
+}
+
+// Status implements the Bmc interface
+func (i *Ibmc) Status() (string, error) {
+	return "", nil
+}
+
+// TempC implements the Bmc interface
+func (i *Ibmc) TempC() (int, error) {
+	return 0, nil
+}
+
+// Vendor implements the Bmc interface
+func (i *Ibmc) Vendor() string {
+	return ""
+}
+
+// Screenshot implements the Bmc interface
+func (i *Ibmc) Screenshot() ([]byte, string, error) {
+	return []byte{}, "", nil
+}
+
+// ServerSnapshot implements the Bmc interface
+func (i *Ibmc) ServerSnapshot() (interface{}, error) {
+	return nil, nil
+}
+
+// UpdateCredentials implements the Bmc interface
+func (i *Ibmc) UpdateCredentials(string, string) {
+	return
+}

--- a/providers/dummy/ibmc/ibmc.go
+++ b/providers/dummy/ibmc/ibmc.go
@@ -21,6 +21,10 @@ type Ibmc struct {
 	password string
 }
 
+// This ensures the compiler errors if this type is missing
+// a method that should be implmented to satisfy the configure interface.
+var _ devices.Configure = (*Ibmc)(nil)
+
 // New returns a new ibmc ready to be used
 func New(ip string, username string, password string) *Ibmc {
 	return &Ibmc{ip: ip, username: username, password: password}

--- a/providers/hp/c7000/configure.go
+++ b/providers/hp/c7000/configure.go
@@ -979,3 +979,8 @@ func (c *C7000) Network(cfg *cfgresources.Network) error {
 func (c *C7000) SetLicense(*cfgresources.License) error {
 	return nil
 }
+
+// Bios method implements the Configure interface
+func (c *C7000) Bios(cfg *cfgresources.Bios) error {
+	return nil
+}

--- a/providers/hp/c7000/configure.go
+++ b/providers/hp/c7000/configure.go
@@ -1,109 +1,26 @@
 package c7000
 
 import (
-	"reflect"
-
 	"github.com/bmc-toolbox/bmclib/cfgresources"
+	"github.com/bmc-toolbox/bmclib/devices"
 	log "github.com/sirupsen/logrus"
 )
 
-func (c *C7000) ApplyCfg(config *cfgresources.ResourcesConfig) (err error) {
-	cfg := reflect.ValueOf(config).Elem()
+// This ensures the compiler errors if this type is missing
+// a method that should be implmented to satisfy the Configure interface.
+var _ devices.Configure = (*C7000)(nil)
 
-	//Each Field in ResourcesConfig struct is a ptr to a resource,
-	//Here we figure the resources to be configured, i.e the ptr is not nil
-	for r := 0; r < cfg.NumField(); r++ {
-		resourceName := cfg.Type().Field(r).Name
-		if cfg.Field(r).Pointer() != 0 {
-			switch resourceName {
-			case "User":
-				//retrieve users resource values as an interface
-				userAccounts := cfg.Field(r).Interface()
-
-				//assert userAccounts interface to its actual type - A slice of ptrs to User
-				for _, user := range userAccounts.([]*cfgresources.User) {
-					err := c.applyUserParams(user)
-					if err != nil {
-						log.WithFields(log.Fields{
-							"step":     "ApplyCfg",
-							"Resource": cfg.Field(r).Kind(),
-							"IP":       c.ip,
-							"Model":    c.BmcType(),
-							"Serial":   c.serial,
-							"Error":    err,
-						}).Warn("Unable to set user config.")
-					}
-				}
-
-			case "Syslog":
-				syslogCfg := cfg.Field(r).Interface().(*cfgresources.Syslog)
-				err := c.applySyslogParams(syslogCfg)
-				if err != nil {
-					log.WithFields(log.Fields{
-						"step":     "ApplyCfg",
-						"resource": cfg.Field(r).Kind(),
-						"IP":       c.ip,
-						"Model":    c.BmcType(),
-						"Serial":   c.serial,
-						"Error":    err,
-					}).Warn("Unable to set Syslog config.")
-					return err
-				}
-			case "Network":
-			case "Ntp":
-				ntpCfg := cfg.Field(r).Interface().(*cfgresources.Ntp)
-				err := c.applyNtpParams(ntpCfg)
-				if err != nil {
-					log.WithFields(log.Fields{
-						"step":     "ApplyCfg",
-						"resource": cfg.Field(r).Kind(),
-						"IP":       c.ip,
-						"Model":    c.BmcType(),
-						"Serial":   c.serial,
-						"Error":    err,
-					}).Warn("Unable to set NTP config.")
-					return err
-				}
-			case "LdapGroup":
-				ldapGroups := cfg.Field(r).Interface()
-				err := c.applyLdapGroupParams(ldapGroups.([]*cfgresources.LdapGroup))
-				if err != nil {
-					log.WithFields(log.Fields{
-						"step":     "applyLdapParams",
-						"resource": "LdapGroup",
-						"IP":       c.ip,
-						"Model":    c.BmcType(),
-						"Serial":   c.serial,
-						"Error":    err,
-					}).Warn("applyLdapGroupParams returned error.")
-					return err
-				}
-			case "Ldap":
-				ldapCfg := cfg.Field(r).Interface().(*cfgresources.Ldap)
-				err := c.applyLdapParams(ldapCfg)
-				if err != nil {
-					log.WithFields(log.Fields{
-						"step":     "applyLdapParams",
-						"resource": "Ldap",
-						"IP":       c.ip,
-						"Model":    c.BmcType(),
-						"Serial":   c.serial,
-						"Error":    err,
-					}).Warn("applyLdapParams returned error.")
-					return err
-				}
-			case "License":
-			case "Ssl":
-			default:
-				log.WithFields(log.Fields{
-					"step":     "ApplyCfg",
-					"resource": resourceName,
-				}).Debug("Unknown resource.")
-			}
-		}
+// Resources returns a slice of supported resources and
+// the order they are to be applied in.
+func (c *C7000) Resources() []string {
+	return []string{
+		"user",
+		"syslog",
+		"license",
+		"ntp",
+		"ldap_group",
+		"ldap",
 	}
-
-	return err
 }
 
 // Return bool value if the role is valid.
@@ -119,12 +36,18 @@ func (c *C7000) isRoleValid(role string) bool {
 	return false
 }
 
+// ApplyCfg implements the BmcChassis interface
+func (c *C7000) ApplyCfg(config *cfgresources.ResourcesConfig) (err error) {
+	return nil
+}
+
+// Ldap applies LDAP configuration params.
+// Ldap implements the Configure interface.
 //1. apply ldap group params
 //2. enable ldap auth
 //3. apply ldap server params
-func (c *C7000) applyLdapParams(cfg *cfgresources.Ldap) error {
-
-	err := c.applysetLdapInfo4(cfg)
+func (c *C7000) Ldap(cfg *cfgresources.Ldap) (err error) {
+	err = c.applysetLdapInfo4(cfg)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"step":     "applyLdapParams",
@@ -260,11 +183,13 @@ func (c *C7000) applyEnableLdapAuth(enable bool) (err error) {
 	return err
 }
 
+// LdapGroup applies LDAP Group/Role related configuration
+// LdapGroup implements the Configure interface.
 // Actions carried out in order
 // 1.  addLdapGroup
 // 2.  setLdapGroupBayAcl
 // 3.  addLdapGroupBayAccess (done)
-func (c *C7000) applyLdapGroupParams(cfg []*cfgresources.LdapGroup) (err error) {
+func (c *C7000) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.Ldap) (err error) {
 
 	for _, group := range cfg {
 
@@ -321,7 +246,7 @@ func (c *C7000) applyLdapGroupParams(cfg []*cfgresources.LdapGroup) (err error) 
 		}
 
 		//2. setLdapGroupBayAcl
-		err = c.applyLdapGroupBayAcl(group.Role, group.Group)
+		err = c.applyLdapGroupBayACL(group.Role, group.Group)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"step":     "setLdapGroupBayAcl",
@@ -448,27 +373,27 @@ func (c *C7000) applyAddLdapGroup(group string) (err error) {
 //  <hpoa:ldapGroup>bmcAdmins</hpoa:ldapGroup>
 //  <hpoa:acl>ADMINISTRATOR</hpoa:acl>
 // </hpoa:setLdapGroupBayAcl>
-func (c *C7000) applyLdapGroupBayAcl(role string, group string) (err error) {
+func (c *C7000) applyLdapGroupBayACL(role string, group string) (err error) {
 
-	var userAcl string
+	var userACL string
 
 	if role == "admin" {
-		userAcl = "ADMINISTRATOR"
+		userACL = "ADMINISTRATOR"
 	} else {
-		userAcl = "USER"
+		userACL = "USER"
 	}
 
-	payload := setLdapGroupBayAcl{LdapGroup: ldapGroup{Text: group}, Acl: Acl{Text: userAcl}}
+	payload := setLdapGroupBayAcl{LdapGroup: ldapGroup{Text: group}, Acl: Acl{Text: userACL}}
 	statusCode, _, err := c.postXML(payload)
 	if statusCode != 200 || err != nil {
 		log.WithFields(log.Fields{
-			"step":       "applyLdapGroupBayAcl",
+			"step":       "applyLdapGroupBayACL",
 			"IP":         c.ip,
 			"Model":      c.BmcType(),
 			"Serial":     c.serial,
 			"statusCode": statusCode,
 			"Error":      err,
-		}).Warn("LDAP applyLdapGroupBayAcl request returned non 200.")
+		}).Warn("LDAP applyLdapGroupBayACL request returned non 200.")
 		return err
 	}
 
@@ -568,99 +493,103 @@ func (c *C7000) applyAddLdapGroupBayAccess(group string) (err error) {
 	return err
 }
 
-// attempts to add the user
-// if the user exists, update the users password.
-func (c *C7000) applyUserParams(cfg *cfgresources.User) (err error) {
+// User applies the User configuration resource,
+// if the user exists, it updates the users password,
+// User implements the Configure interface.
+func (c *C7000) User(users []*cfgresources.User) (err error) {
 
-	if cfg.Name == "" {
-		log.WithFields(log.Fields{
-			"step":  "applyUserParams",
-			"Model": c.BmcType(),
-		}).Fatal("User resource expects parameter: Name.")
-	}
+	for _, cfg := range users {
+		if cfg.Name == "" {
+			log.WithFields(log.Fields{
+				"step":  "applyUserParams",
+				"Model": c.BmcType(),
+			}).Fatal("User resource expects parameter: Name.")
+		}
 
-	if cfg.Password == "" {
-		log.WithFields(log.Fields{
-			"step":  "applyUserParams",
-			"Model": c.BmcType(),
-		}).Fatal("User resource expects parameter: Password.")
-	}
+		if cfg.Password == "" {
+			log.WithFields(log.Fields{
+				"step":  "applyUserParams",
+				"Model": c.BmcType(),
+			}).Fatal("User resource expects parameter: Password.")
+		}
 
-	if c.isRoleValid(cfg.Role) == false {
-		log.WithFields(log.Fields{
-			"step":  "applyUserParams",
-			"Model": c.BmcType(),
-			"Role":  cfg.Role,
-		}).Fatal("User resource Role must be declared and a valid role: admin.")
-	}
+		if c.isRoleValid(cfg.Role) == false {
+			log.WithFields(log.Fields{
+				"step":  "applyUserParams",
+				"Model": c.BmcType(),
+				"Role":  cfg.Role,
+			}).Fatal("User resource Role must be declared and a valid role: admin.")
+		}
 
-	username := Username{Text: cfg.Name}
-	password := Password{Text: cfg.Password}
+		username := Username{Text: cfg.Name}
+		password := Password{Text: cfg.Password}
 
-	//if user account is disabled, remove the user
-	if cfg.Enable == false {
-		payload := RemoveUser{Username: username}
-		statusCode, _, _ := c.postXML(payload)
+		//if user account is disabled, remove the user
+		if cfg.Enable == false {
+			payload := RemoveUser{Username: username}
+			statusCode, _, _ := c.postXML(payload)
 
-		//user doesn't exist
-		if statusCode != 400 {
+			//user doesn't exist
+			if statusCode != 400 {
+				return err
+			}
+
+			log.WithFields(log.Fields{
+				"IP":     c.ip,
+				"Model":  c.BmcType(),
+				"Serial": c.serial,
+				"User":   cfg.Name,
+			}).Debug("User removed.")
+
+			//user exists and was removed.
 			return err
+		}
+
+		payload := AddUser{Username: username, Password: password}
+		statusCode, _, err := c.postXML(payload)
+		if err != nil {
+			return err
+		}
+
+		//user exists
+		if statusCode == 400 {
+			log.WithFields(log.Fields{
+				"step":        "applyUserParams",
+				"user":        cfg.Name,
+				"IP":          c.ip,
+				"Model":       c.BmcType(),
+				"Serial":      c.serial,
+				"Return code": statusCode,
+			}).Debug("User already exists, setting password.")
+
+			//update user password
+			err := c.setUserPassword(cfg.Name, cfg.Password)
+			if err != nil {
+				return err
+			}
+
+			//update user acl
+			err = c.setUserACL(cfg.Name, cfg.Role)
+			if err != nil {
+				return err
+			}
+
+			//updates user blade bay access acls
+			err = c.applyAddUserBayAccess(cfg.Name)
+			if err != nil {
+				return err
+			}
+
 		}
 
 		log.WithFields(log.Fields{
 			"IP":     c.ip,
 			"Model":  c.BmcType(),
 			"Serial": c.serial,
-			"User":   cfg.Name,
-		}).Debug("User removed.")
-
-		//user exists and was removed.
-		return err
-	}
-
-	payload := AddUser{Username: username, Password: password}
-	statusCode, _, err := c.postXML(payload)
-	if err != nil {
-		return err
-	}
-
-	//user exists
-	if statusCode == 400 {
-		log.WithFields(log.Fields{
-			"step":        "applyUserParams",
-			"user":        cfg.Name,
-			"IP":          c.ip,
-			"Model":       c.BmcType(),
-			"Serial":      c.serial,
-			"Return code": statusCode,
-		}).Debug("User already exists, setting password.")
-
-		//update user password
-		err := c.setUserPassword(cfg.Name, cfg.Password)
-		if err != nil {
-			return err
-		}
-
-		//update user acl
-		err = c.setUserAcl(cfg.Name, cfg.Role)
-		if err != nil {
-			return err
-		}
-
-		//updates user blade bay access acls
-		err = c.applyAddUserBayAccess(cfg.Name)
-		if err != nil {
-			return err
-		}
+			"user":   cfg.Name,
+		}).Debug("User cfg applied.")
 
 	}
-
-	log.WithFields(log.Fields{
-		"IP":     c.ip,
-		"Model":  c.BmcType(),
-		"Serial": c.serial,
-		"user":   cfg.Name,
-	}).Debug("User cfg applied.")
 	return err
 }
 
@@ -693,7 +622,7 @@ func (c *C7000) setUserPassword(user string, password string) (err error) {
 	return err
 }
 
-func (c *C7000) setUserAcl(user string, role string) (err error) {
+func (c *C7000) setUserACL(user string, role string) (err error) {
 
 	var aclRole string
 	if role == "admin" {
@@ -710,7 +639,7 @@ func (c *C7000) setUserAcl(user string, role string) (err error) {
 	statusCode, _, err := c.postXML(payload)
 	if err != nil {
 		log.WithFields(log.Fields{
-			"step":        "setUserAcl",
+			"step":        "setUserACL",
 			"user":        user,
 			"Acl":         role,
 			"IP":          c.ip,
@@ -795,7 +724,9 @@ func (c *C7000) applyAddUserBayAccess(user string) (err error) {
 	return err
 }
 
-// Applies ntp parameters
+// Ntp applies NTP configuration params
+// Ntp implements the Configure interface.
+//
 // 1. SOAP call to set the NTP server params
 // 2. SOAP call to set TZ
 // 1.
@@ -808,7 +739,7 @@ func (c *C7000) applyAddUserBayAccess(user string) (err error) {
 // <hpoa:setEnclosureTimeZone>
 //  <hpoa:timeZone>CET</hpoa:timeZone>
 // </hpoa:setEnclosureTimeZone>
-func (c *C7000) applyNtpParams(cfg *cfgresources.Ntp) (err error) {
+func (c *C7000) Ntp(cfg *cfgresources.Ntp) (err error) {
 
 	if cfg.Server1 == "" {
 		log.WithFields(log.Fields{
@@ -902,12 +833,14 @@ func (c *C7000) applyNtpTimezoneParam(timezone string) (err error) {
 	return err
 }
 
+// Syslog applies the Syslog configuration resource
+// Syslog implements the Configure interface
 // Applies syslog parameters
 // 1. set syslog server
 // 2. set syslog port
 // 3. enable syslog
 // theres no option to set the port
-func (c *C7000) applySyslogParams(cfg *cfgresources.Syslog) (err error) {
+func (c *C7000) Syslog(cfg *cfgresources.Syslog) (err error) {
 
 	var port int
 	if cfg.Server == "" {
@@ -1035,4 +968,14 @@ func (c *C7000) applySyslogEnabled(enabled bool) {
 	}).Debug("Syslog enabled.")
 	return
 
+}
+
+// Network method implements the Configure interface
+func (c *C7000) Network(cfg *cfgresources.Network) error {
+	return nil
+}
+
+// SetLicense implements the Configure interface
+func (c *C7000) SetLicense(*cfgresources.License) error {
+	return nil
 }

--- a/providers/hp/ilo/configure.go
+++ b/providers/hp/ilo/configure.go
@@ -695,3 +695,8 @@ func (i *Ilo) Ldap(cfg *cfgresources.Ldap) (err error) {
 func (i *Ilo) Network(cfg *cfgresources.Network) error {
 	return nil
 }
+
+// Bios method implements the Configure interface
+func (i *Ilo) Bios(cfg *cfgresources.Bios) error {
+	return nil
+}

--- a/providers/hp/ilo/configure.go
+++ b/providers/hp/ilo/configure.go
@@ -10,6 +10,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// This ensures the compiler errors if this type is missing
+// a method that should be implmented to satisfy the Configure interface.
+var _ devices.Configure = (*Ilo)(nil)
+
 // Resources returns a slice of supported resources and
 // the order they are to be applied in.
 func (i *Ilo) Resources() []string {

--- a/providers/supermicro/supermicrox10/model.go
+++ b/providers/supermicro/supermicrox10/model.go
@@ -32,7 +32,7 @@ type ConfigDateTime struct {
 // /cgi/config_user.cgi
 type ConfigUser struct {
 	Username     string `url:"username"`
-	UserId       int    `url:"original_username"` //username integer
+	UserID       int    `url:"original_username"` //username integer
 	Password     string `url:"password,omitempty"`
 	NewPrivilege int    `url:"new_privilege,omitempty"` //4 == administrator, 3 == operator
 }


### PR DESCRIPTION
- Add a Configure interface for configuration methods.
- Split up the ugly ApplyCfg method https://github.com/bmc-toolbox/bmcbutler/issues/2
- Update all providers to implement the Configure interface.
- Add Resources method to each provider, which declares the order and configuration supported.
- Add the dummy provider, model with ibmc dummy device to enable testing.
- Declaring `BMCLIB_TEST=1` will cause bmclib to run on the dummy provider, to enable running bmclib without an actual bmc.
- Update .gitignore file.



