### PR TITLE
Bmc chassis setup interface

### DIFF
--- a/devices/interfaces.go
+++ b/devices/interfaces.go
@@ -44,6 +44,8 @@ type BmcChassis interface {
 	ApplyCfg(*cfgresources.ResourcesConfig) error
 	// embed Configure interface
 	Configure
+	// embed BmcChassisSetup interface
+	BmcChassisSetup
 	Blades() ([]*Blade, error)
 	BmcType() string
 	ChassisSnapshot() (*Chassis, error)
@@ -71,18 +73,24 @@ type BmcChassis interface {
 	PxeOnceBlade(int) (bool, error)
 	ReseatBlade(int) (bool, error)
 	Serial() (string, error)
-	RemoveBladeBmcUser(string) error
-	AddBladeBmcAdmin(string, string) error
-	ModBladeBmcUser(string, string) error
-	SetDynamicPower(bool) (bool, error)
-	SetIpmiOverLan(int, bool) (bool, error)
-	SetFlexAddressState(int, bool) (bool, error)
 	Status() (string, error)
 	StorageBlades() ([]*StorageBlade, error)
 	TempC() (int, error)
 	UpdateCredentials(string, string)
 	UpdateFirmware(string, string) (bool, error)
 	Vendor() string
+}
+
+// BmcChassisSetup interface declares methods
+// that are used to apply one time configuration to a Chassis.
+type BmcChassisSetup interface {
+	ResourcesSetup() []string
+	RemoveBladeBmcUser(string) error
+	AddBladeBmcAdmin(string, string) error
+	ModBladeBmcUser(string, string) error
+	SetDynamicPower(bool) (bool, error)
+	SetIpmiOverLan(int, bool) (bool, error)
+	SetFlexAddressState(int, bool) (bool, error)
 }
 
 // Configure interface declares methods implemented

--- a/providers/dell/m1000e/configure.go
+++ b/providers/dell/m1000e/configure.go
@@ -25,6 +25,7 @@ var _ devices.Configure = (*M1000e)(nil)
 
 // Resources returns a slice of supported resources and
 // the order they are to be applied in.
+// Resources implements the Configure interface
 func (m *M1000e) Resources() []string {
 	return []string{
 		"user",
@@ -33,6 +34,20 @@ func (m *M1000e) Resources() []string {
 		"ldap",
 		"ldap_group",
 		//"ssl",
+	}
+}
+
+// ResourcesSetup returns
+// - slice of supported one time setup resources,
+//   in the order they must be applied
+// ResourcesSetup implements the BmcChassisSetup interface
+// see cfgresources.SetupChassis for list of setup resources.
+func (m *M1000e) ResourcesSetup() []string {
+	return []string{
+		"setipmioverlan",
+		"flexaddress",
+		"dynamicpower",
+		"bladespower",
 	}
 }
 

--- a/providers/hp/c7000/actions.go
+++ b/providers/hp/c7000/actions.go
@@ -303,6 +303,11 @@ end_marker`
 	ribcl = strings.Replace(ribcl, "__USERNAME__", username, -1)
 	ribcl = strings.Replace(ribcl, "__PASSWORD__", password, -1)
 
+	err = c.sshLogin()
+	if err != nil {
+		return err
+	}
+
 	output, err := c.sshClient.Run(ribcl)
 	if err != nil {
 		return fmt.Errorf(output)
@@ -344,6 +349,11 @@ end_marker`
 	ribcl = strings.Replace(ribcl, "__USERNAME__", username, -1)
 	ribcl = strings.Replace(ribcl, "__PASSWORD__", password, -1)
 
+	err = c.sshLogin()
+	if err != nil {
+		return err
+	}
+
 	output, err := c.sshClient.Run(ribcl)
 	if err != nil {
 		return fmt.Errorf(output)
@@ -373,6 +383,11 @@ func (c *C7000) RemoveBladeBmcUser(username string) (err error) {
 end_marker`
 
 	ribcl = strings.Replace(ribcl, "__USERNAME__", username, -1)
+
+	err = c.sshLogin()
+	if err != nil {
+		return err
+	}
 
 	output, err := c.sshClient.Run(ribcl)
 	if err != nil {

--- a/providers/hp/c7000/configure.go
+++ b/providers/hp/c7000/configure.go
@@ -23,6 +23,20 @@ func (c *C7000) Resources() []string {
 	}
 }
 
+// ResourcesSetup returns
+// - slice of supported one time setup resources,
+//   in the order they must be applied
+// ResourcesSetup implements the BmcChassisSetup interface
+// see cfgresources.SetupChassis for list of setup resources.
+func (c *C7000) ResourcesSetup() []string {
+	return []string{
+		"add_blade_bmc_admins",
+		"remove_blade_bmc_users",
+		"dynamicpower",
+		"bladespower",
+	}
+}
+
 // Return bool value if the role is valid.
 func (c *C7000) isRoleValid(role string) bool {
 


### PR DESCRIPTION
- Splits out chassis setup configuration methods into its own interface
- Fix c7000 blade user add/mod methods.