### PR TITLE
m1000e: fix User resource not configuring all users (incorrect return)

### DIFF
--- a/providers/dell/m1000e/configure.go
+++ b/providers/dell/m1000e/configure.go
@@ -102,7 +102,6 @@ func (m *M1000e) User(cfgUsers []*cfgresources.User) (err error) {
 			"IP":    m.ip,
 			"Model": m.BmcType(),
 		}).Debug("User account config parameters applied.")
-		return err
 
 	}
 


### PR DESCRIPTION
We incorrectly returning after configuring just one user.