### PR TITLE
Idrac9 redfish fixes

### DIFF
--- a/providers/dell/idrac9/configure.go
+++ b/providers/dell/idrac9/configure.go
@@ -60,7 +60,7 @@ func (i *IDrac9) Bios(cfg *cfgresources.Bios) (err error) {
 
 	//GET current settings
 	currentBiosSettings, err := i.getBiosSettings()
-	if err != nil {
+	if err != nil || currentBiosSettings == nil {
 		msg := "Unable to get current bios settings through redfish."
 		log.WithFields(log.Fields{
 			"IP":    i.ip,


### PR DESCRIPTION
- Redfish on idrac9's require a valid Accept header
- Check for nil values when retrieving bios settings.