### PR TITLE
ipmitool: increase retransmission from 1 to 5s

### DIFF
--- a/internal/ipmi/ipmi.go
+++ b/internal/ipmi/ipmi.go
@@ -32,7 +32,7 @@ func New(username string, password string, host string) (ipmi *Ipmi, err error) 
 }
 
 func (i *Ipmi) run(command []string) (output string, err error) {
-	ipmiArgs := []string{"-I", "lanplus", "-U", i.Username, "-E", "-H", i.Host}
+	ipmiArgs := []string{"-I", "lanplus", "-U", i.Username, "-E", "-N", "5", "-H", i.Host}
 	ipmiArgs = append(ipmiArgs, command...)
 	cmd := exec.Command(i.ipmitool, ipmiArgs...)
 	cmd.Env = []string{fmt.Sprintf("IPMITOOL_PASSWORD=%s", i.Password)}


### PR DESCRIPTION
increase ipmitool retransmission to 5s as per Intel recommendation: https://www.intel.com/content/www/us/en/support/articles/000032584/server-products.html

it doesn't hurt