### PR TITLE
to make simpler to use methods from cmcs and bmcs we are using standard method signatures

### DIFF
--- a/devices/interfaces.go
+++ b/devices/interfaces.go
@@ -29,8 +29,8 @@ type Bmc interface {
 // BmcCollection represents the requirement of items to be collected a server
 type BmcCollection interface {
 	BiosVersion() (string, error)
-	BmcType() string
-	BmcVersion() (string, error)
+	HardwareType() string
+	Version() (string, error)
 	CPU() (string, int, int, int, error)
 	Disks() ([]*Disk, error)
 	IsBlade() (bool, error)
@@ -83,10 +83,9 @@ type Cmc interface {
 // CmcCollection represents the requirement of items to be collected from a chassis
 type CmcCollection interface {
 	Blades() ([]*Blade, error)
-	BmcType() string
+	HardwareType() string
 	FindBladePosition(string) (int, error)
-	FwVersion() (string, error)
-	GetFirmwareVersion() (string, error)
+	Version() (string, error)
 	Fans() ([]*Fan, error)
 	IsActive() bool
 	IsOn() (bool, error)

--- a/providers/dell/idrac8/configure.go
+++ b/providers/dell/idrac8/configure.go
@@ -90,7 +90,7 @@ func (i *IDrac8) User(cfgUsers []*cfgresources.User) (err error) {
 		log.WithFields(log.Fields{
 			"step":  "applyUserParams",
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Error": err,
 		}).Warn(msg)
 		return errors.New(msg)
@@ -102,7 +102,7 @@ func (i *IDrac8) User(cfgUsers []*cfgresources.User) (err error) {
 		log.WithFields(log.Fields{
 			"step":  "applyUserParams",
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Error": err,
 		}).Warn(msg)
 		return errors.New(msg)
@@ -121,7 +121,7 @@ func (i *IDrac8) User(cfgUsers []*cfgresources.User) (err error) {
 				if err != nil {
 					log.WithFields(log.Fields{
 						"IP":    i.ip,
-						"Model": i.BmcType(),
+						"Model": i.HardwareType(),
 						"step":  helper.WhosCalling(),
 						"User":  cfgUser.Name,
 						"Error": err,
@@ -148,7 +148,7 @@ func (i *IDrac8) User(cfgUsers []*cfgresources.User) (err error) {
 			if err != nil {
 				log.WithFields(log.Fields{
 					"IP":    i.ip,
-					"Model": i.BmcType(),
+					"Model": i.HardwareType(),
 					"step":  helper.WhosCalling(),
 					"User":  cfgUser.Name,
 					"Error": err,
@@ -171,7 +171,7 @@ func (i *IDrac8) User(cfgUsers []*cfgresources.User) (err error) {
 			if err != nil {
 				log.WithFields(log.Fields{
 					"IP":    i.ip,
-					"Model": i.BmcType(),
+					"Model": i.HardwareType(),
 					"step":  helper.WhosCalling(),
 					"User":  cfgUser.Name,
 					"Error": err,
@@ -181,7 +181,7 @@ func (i *IDrac8) User(cfgUsers []*cfgresources.User) (err error) {
 
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"User":  cfgUser.Name,
 		}).Debug("User parameters applied.")
 	}
@@ -250,7 +250,7 @@ func (i *IDrac8) Syslog(cfg *cfgresources.Syslog) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    i.ip,
-		"Model": i.BmcType(),
+		"Model": i.HardwareType(),
 	}).Debug("Syslog parameters applied.")
 
 	return err
@@ -309,7 +309,7 @@ func (i *IDrac8) applyNtpServerParam(cfg *cfgresources.Ntp) {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"endpoint": endpoint,
 			"step":     helper.WhosCalling(),
 			"response": string(response),
@@ -318,7 +318,7 @@ func (i *IDrac8) applyNtpServerParam(cfg *cfgresources.Ntp) {
 
 	log.WithFields(log.Fields{
 		"IP":    i.ip,
-		"Model": i.BmcType(),
+		"Model": i.HardwareType(),
 	}).Debug("NTP servers param applied.")
 
 }
@@ -341,7 +341,7 @@ func (i *IDrac8) Ldap(cfg *cfgresources.Ldap) error {
 		msg := "Request to set ldap server failed."
 		log.WithFields(log.Fields{
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"endpoint": endpoint,
 			"step":     helper.WhosCalling(),
 			"response": string(response),
@@ -356,7 +356,7 @@ func (i *IDrac8) Ldap(cfg *cfgresources.Ldap) error {
 
 	log.WithFields(log.Fields{
 		"IP":    i.ip,
-		"Model": i.BmcType(),
+		"Model": i.HardwareType(),
 	}).Debug("Ldap server param set.")
 	return nil
 }
@@ -379,7 +379,7 @@ func (i *IDrac8) applyLdapSearchFilterParam(cfg *cfgresources.Ldap) error {
 		msg := "request to set ldap search filter failed."
 		log.WithFields(log.Fields{
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"endpoint": endpoint,
 			"step":     helper.WhosCalling(),
 			"response": string(response),
@@ -389,7 +389,7 @@ func (i *IDrac8) applyLdapSearchFilterParam(cfg *cfgresources.Ldap) error {
 
 	log.WithFields(log.Fields{
 		"IP":    i.ip,
-		"Model": i.BmcType(),
+		"Model": i.HardwareType(),
 	}).Debug("Ldap search filter param applied.")
 	return nil
 }
@@ -495,7 +495,7 @@ func (i *IDrac8) LdapGroup(cfgGroup []*cfgresources.LdapGroup, cfgLdap *cfgresou
 		if err != nil {
 			log.WithFields(log.Fields{
 				"IP":       i.ip,
-				"Model":    i.BmcType(),
+				"Model":    i.HardwareType(),
 				"endpoint": endpoint,
 				"step":     "applyLdapGroupParams",
 				"response": string(response),
@@ -505,7 +505,7 @@ func (i *IDrac8) LdapGroup(cfgGroup []*cfgresources.LdapGroup, cfgLdap *cfgresou
 
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Role":  group.Role,
 		}).Debug("Ldap GroupDN config applied.")
 
@@ -530,7 +530,7 @@ func (i *IDrac8) LdapGroup(cfgGroup []*cfgresources.LdapGroup, cfgLdap *cfgresou
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  "applyLdapGroupParams",
 		}).Warn("Unable to set Ldap Role Group Privileges.")
 		return err
@@ -568,7 +568,7 @@ func (i *IDrac8) applyLdapRoleGroupPrivParam(cfg *cfgresources.Ldap, groupPrivil
 	if err != nil || responseCode != 200 {
 		log.WithFields(log.Fields{
 			"IP":           i.ip,
-			"Model":        i.BmcType(),
+			"Model":        i.HardwareType(),
 			"endpoint":     endpoint,
 			"step":         helper.WhosCalling(),
 			"responseCode": responseCode,
@@ -579,7 +579,7 @@ func (i *IDrac8) applyLdapRoleGroupPrivParam(cfg *cfgresources.Ldap, groupPrivil
 
 	log.WithFields(log.Fields{
 		"IP":    i.ip,
-		"Model": i.BmcType(),
+		"Model": i.HardwareType(),
 	}).Debug("Ldap Group role privileges applied.")
 
 	return err
@@ -595,7 +595,7 @@ func (i *IDrac8) applyTimezoneParam(timezone string) {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"endpoint": endpoint,
 			"step":     helper.WhosCalling(),
 			"response": string(response),
@@ -604,7 +604,7 @@ func (i *IDrac8) applyTimezoneParam(timezone string) {
 
 	log.WithFields(log.Fields{
 		"IP":    i.ip,
-		"Model": i.BmcType(),
+		"Model": i.HardwareType(),
 	}).Debug("Timezone param applied.")
 
 }
@@ -648,7 +648,7 @@ func (i *IDrac8) Network(cfg *cfgresources.Network) (reset bool, err error) {
 	if err != nil || responseCode != 200 {
 		log.WithFields(log.Fields{
 			"IP":           i.ip,
-			"Model":        i.BmcType(),
+			"Model":        i.HardwareType(),
 			"endpoint":     endpoint,
 			"step":         helper.WhosCalling(),
 			"responseCode": responseCode,
@@ -659,7 +659,7 @@ func (i *IDrac8) Network(cfg *cfgresources.Network) (reset bool, err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    i.ip,
-		"Model": i.BmcType(),
+		"Model": i.HardwareType(),
 	}).Debug("Network config parameters applied.")
 	return reset, err
 }
@@ -687,7 +687,7 @@ func (i *IDrac8) GenerateCSR(cert *cfgresources.HTTPSCertAttributes) ([]byte, er
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"endpoint": endpoint,
 			"step":     helper.WhosCalling(),
 			"Error":    err,
@@ -745,7 +745,7 @@ func (i *IDrac8) UploadHTTPSCert(cert []byte, certFileName string, key []byte, k
 	if err != nil || status != 201 {
 		log.WithFields(log.Fields{
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"endpoint": endpoint,
 			"step":     helper.WhosCalling(),
 			"status":   status,
@@ -760,7 +760,7 @@ func (i *IDrac8) UploadHTTPSCert(cert []byte, certFileName string, key []byte, k
 		log.WithFields(log.Fields{
 			"step":  helper.WhosCalling(),
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Error": err,
 		}).Warn("Unable to unmarshal cert store response payload.")
 		return false, err
@@ -771,7 +771,7 @@ func (i *IDrac8) UploadHTTPSCert(cert []byte, certFileName string, key []byte, k
 		log.WithFields(log.Fields{
 			"step":  helper.WhosCalling(),
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Error": err,
 		}).Warn("Unable to marshal cert store resource URI.")
 		return false, err
@@ -783,7 +783,7 @@ func (i *IDrac8) UploadHTTPSCert(cert []byte, certFileName string, key []byte, k
 	if err != nil || status != 201 {
 		log.WithFields(log.Fields{
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"endpoint": endpoint,
 			"step":     helper.WhosCalling(),
 			"status":   status,

--- a/providers/dell/idrac8/idrac8.go
+++ b/providers/dell/idrac8/idrac8.go
@@ -460,8 +460,8 @@ func (i *IDrac8) Name() (name string, err error) {
 	return name, err
 }
 
-// BmcVersion returns the version of the bmc we are running
-func (i *IDrac8) BmcVersion() (bmcVersion string, err error) {
+// Version returns the version of the bmc we are running
+func (i *IDrac8) Version() (bmcVersion string, err error) {
 	err = i.loadHwData()
 	if err != nil {
 		return bmcVersion, err
@@ -527,8 +527,8 @@ func (i *IDrac8) Model() (model string, err error) {
 	return model, err
 }
 
-// BmcType returns the type of bmc we are talking to
-func (i *IDrac8) BmcType() (bmcType string) {
+// HardwareType returns the type of bmc we are talking to
+func (i *IDrac8) HardwareType() (bmcType string) {
 	return BMCType
 }
 
@@ -776,13 +776,13 @@ func (i *IDrac8) ServerSnapshot() (server interface{}, err error) { // nolint: g
 		blade := &devices.Blade{}
 		blade.Vendor = i.Vendor()
 		blade.BmcAddress = i.ip
-		blade.BmcType = i.BmcType()
+		blade.BmcType = i.HardwareType()
 
 		blade.Serial, err = i.Serial()
 		if err != nil {
 			return nil, err
 		}
-		blade.BmcVersion, err = i.BmcVersion()
+		blade.BmcVersion, err = i.Version()
 		if err != nil {
 			return nil, err
 		}
@@ -847,13 +847,13 @@ func (i *IDrac8) ServerSnapshot() (server interface{}, err error) { // nolint: g
 		discrete := &devices.Discrete{}
 		discrete.Vendor = i.Vendor()
 		discrete.BmcAddress = i.ip
-		discrete.BmcType = i.BmcType()
+		discrete.BmcType = i.HardwareType()
 
 		discrete.Serial, err = i.Serial()
 		if err != nil {
 			return nil, err
 		}
-		discrete.BmcVersion, err = i.BmcVersion()
+		discrete.BmcVersion, err = i.Version()
 		if err != nil {
 			return nil, err
 		}

--- a/providers/dell/idrac8/idrac8_test.go
+++ b/providers/dell/idrac8/idrac8_test.go
@@ -5318,7 +5318,7 @@ func TestIDracBmcType(t *testing.T) {
 		t.Fatalf("Found errors during the test setup %v", err)
 	}
 
-	answer := bmc.BmcType()
+	answer := bmc.HardwareType()
 	if answer != expectedAnswer {
 		t.Errorf("Expected answer %v: found %v", expectedAnswer, answer)
 	}
@@ -5334,9 +5334,9 @@ func TestIDracBmcVersion(t *testing.T) {
 		t.Fatalf("Found errors during the test setup %v", err)
 	}
 
-	answer, err := bmc.BmcVersion()
+	answer, err := bmc.Version()
 	if err != nil {
-		t.Fatalf("Found errors calling bmc.BmcVersion %v", err)
+		t.Fatalf("Found errors calling bmc.Version %v", err)
 	}
 
 	if answer != expectedAnswer {

--- a/providers/dell/idrac8/query.go
+++ b/providers/dell/idrac8/query.go
@@ -79,7 +79,7 @@ func (i *IDrac8) queryUsers() (userInfo UserInfo, err error) {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"endpoint": endpoint,
 			"step":     helper.WhosCalling(),
 			"Error":    err,
@@ -94,7 +94,7 @@ func (i *IDrac8) queryUsers() (userInfo UserInfo, err error) {
 			"step":     "queryUserInfo",
 			"resource": "User",
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"Error":    err,
 		}).Warn("Unable to unmarshal payload.")
 		return userInfo, err

--- a/providers/dell/idrac9/configure.go
+++ b/providers/dell/idrac9/configure.go
@@ -64,7 +64,7 @@ func (i *IDrac9) Bios(cfg *cfgresources.Bios) (err error) {
 		msg := "Unable to get current bios settings through redfish."
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  helper.WhosCalling(),
 			"Error": err,
 		}).Warn(msg)
@@ -79,7 +79,7 @@ func (i *IDrac9) Bios(cfg *cfgresources.Bios) (err error) {
 		if err != nil {
 			log.WithFields(log.Fields{
 				"IP":    i.ip,
-				"Model": i.BmcType(),
+				"Model": i.HardwareType(),
 				"step":  helper.WhosCalling(),
 				"Error": err,
 			}).Fatal("diffBiosSettings returned error.")
@@ -87,7 +87,7 @@ func (i *IDrac9) Bios(cfg *cfgresources.Bios) (err error) {
 
 		log.WithFields(log.Fields{
 			"IP":                            i.ip,
-			"Model":                         i.BmcType(),
+			"Model":                         i.HardwareType(),
 			"step":                          helper.WhosCalling(),
 			"Changes (Ignore empty fields)": fmt.Sprintf("%+v", toApplyBiosSettings),
 		}).Info("Bios configuration to be applied.")
@@ -100,7 +100,7 @@ func (i *IDrac9) Bios(cfg *cfgresources.Bios) (err error) {
 				"step":                  "applyBiosParams",
 				"resource":              "Bios",
 				"IP":                    i.ip,
-				"Model":                 i.BmcType(),
+				"Model":                 i.HardwareType(),
 				"Bios settings pending": err,
 			}).Warn("Unable to purge pending bios setting jobs.")
 		}
@@ -110,7 +110,7 @@ func (i *IDrac9) Bios(cfg *cfgresources.Bios) (err error) {
 			msg := "setBiosAttributes returned error."
 			log.WithFields(log.Fields{
 				"IP":    i.ip,
-				"Model": i.BmcType(),
+				"Model": i.HardwareType(),
 				"step":  helper.WhosCalling(),
 				"Error": err,
 			}).Warn(msg)
@@ -119,7 +119,7 @@ func (i *IDrac9) Bios(cfg *cfgresources.Bios) (err error) {
 
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  helper.WhosCalling(),
 		}).Info("Bios configuration update job queued in iDrac.")
 
@@ -127,7 +127,7 @@ func (i *IDrac9) Bios(cfg *cfgresources.Bios) (err error) {
 
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  helper.WhosCalling(),
 		}).Info("Bios configuration is up to date.")
 	}
@@ -148,7 +148,7 @@ func (i *IDrac9) User(cfgUsers []*cfgresources.User) (err error) {
 		log.WithFields(log.Fields{
 			"step":  "applyUserParams",
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Error": err,
 		}).Warn(msg)
 		return errors.New(msg)
@@ -160,7 +160,7 @@ func (i *IDrac9) User(cfgUsers []*cfgresources.User) (err error) {
 		log.WithFields(log.Fields{
 			"step":  "applyUserParams",
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Error": err,
 		}).Warn(msg)
 		return errors.New(msg)
@@ -180,7 +180,7 @@ func (i *IDrac9) User(cfgUsers []*cfgresources.User) (err error) {
 				if err != nil {
 					log.WithFields(log.Fields{
 						"IP":    i.ip,
-						"Model": i.BmcType(),
+						"Model": i.HardwareType(),
 						"step":  helper.WhosCalling(),
 						"User":  cfgUser.Name,
 						"Error": err,
@@ -207,7 +207,7 @@ func (i *IDrac9) User(cfgUsers []*cfgresources.User) (err error) {
 			if err != nil {
 				log.WithFields(log.Fields{
 					"IP":    i.ip,
-					"Model": i.BmcType(),
+					"Model": i.HardwareType(),
 					"step":  helper.WhosCalling(),
 					"User":  cfgUser.Name,
 					"Error": err,
@@ -224,7 +224,7 @@ func (i *IDrac9) User(cfgUsers []*cfgresources.User) (err error) {
 			if err != nil {
 				log.WithFields(log.Fields{
 					"IP":         i.ip,
-					"Model":      i.BmcType(),
+					"Model":      i.HardwareType(),
 					"step":       helper.WhosCalling(),
 					"User":       cfgUser.Name,
 					"Error":      err,
@@ -237,7 +237,7 @@ func (i *IDrac9) User(cfgUsers []*cfgresources.User) (err error) {
 
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"User":  cfgUser.Name,
 		}).Debug("User parameters applied.")
 
@@ -263,7 +263,7 @@ func (i *IDrac9) Ldap(cfg *cfgresources.Ldap) (err error) {
 		msg := "Ldap resource parameter Server required but not declared."
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  helper.WhosCalling,
 		}).Warn(msg)
 		return errors.New(msg)
@@ -272,7 +272,7 @@ func (i *IDrac9) Ldap(cfg *cfgresources.Ldap) (err error) {
 	if cfg.BaseDn == "" {
 		msg := "Ldap resource parameter BaseDn required but not declared."
 		log.WithFields(log.Fields{
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  helper.WhosCalling,
 		}).Warn(msg)
 		return errors.New(msg)
@@ -316,7 +316,7 @@ func (i *IDrac9) Ldap(cfg *cfgresources.Ldap) (err error) {
 		msg := "Ldap params PUT request failed."
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  helper.WhosCalling(),
 			"Error": err,
 		}).Warn(msg)
@@ -337,7 +337,7 @@ func (i *IDrac9) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.
 		log.WithFields(log.Fields{
 			"step":  "applyUserParams",
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Error": err,
 		}).Warn(msg)
 		return errors.New(msg)
@@ -362,7 +362,7 @@ func (i *IDrac9) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.
 				if err != nil {
 					log.WithFields(log.Fields{
 						"IP":              i.ip,
-						"Model":           i.BmcType(),
+						"Model":           i.HardwareType(),
 						"step":            helper.WhosCalling(),
 						"Ldap Role Group": cfgRole.Group,
 						"Role Group DN":   cfgRole.Role,
@@ -385,7 +385,7 @@ func (i *IDrac9) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.
 			if err != nil {
 				log.WithFields(log.Fields{
 					"IP":              i.ip,
-					"Model":           i.BmcType(),
+					"Model":           i.HardwareType(),
 					"step":            helper.WhosCalling(),
 					"Ldap Role Group": cfgRole.Group,
 					"Role Group DN":   cfgRole.Role,
@@ -405,7 +405,7 @@ func (i *IDrac9) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.
 			if err != nil {
 				log.WithFields(log.Fields{
 					"IP":              i.ip,
-					"Model":           i.BmcType(),
+					"Model":           i.HardwareType(),
 					"step":            helper.WhosCalling(),
 					"Ldap Role Group": cfgRole.Group,
 					"Role Group DN":   cfgRole.Role,
@@ -417,7 +417,7 @@ func (i *IDrac9) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.
 
 		log.WithFields(log.Fields{
 			"IP":              i.ip,
-			"Model":           i.BmcType(),
+			"Model":           i.HardwareType(),
 			"Step":            helper.WhosCalling(),
 			"Ldap Role Group": cfgRole.Role,
 			"Role Group DN":   cfgRole.Role,
@@ -444,7 +444,7 @@ func (i *IDrac9) Ntp(cfg *cfgresources.Ntp) (err error) {
 		msg := "NTP resource expects parameter: server1."
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Step":  helper.WhosCalling(),
 		}).Warn(msg)
 		return errors.New(msg)
@@ -454,7 +454,7 @@ func (i *IDrac9) Ntp(cfg *cfgresources.Ntp) (err error) {
 		msg := "NTP resource expects parameter: timezone."
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Step":  helper.WhosCalling(),
 		}).Warn(msg)
 		return errors.New(msg)
@@ -465,7 +465,7 @@ func (i *IDrac9) Ntp(cfg *cfgresources.Ntp) (err error) {
 		msg := "NTP resource a valid timezone parameter, for valid timezones see dell/idrac9/model.go"
 		log.WithFields(log.Fields{
 			"IP":               i.ip,
-			"Model":            i.BmcType(),
+			"Model":            i.HardwareType(),
 			"step":             helper.WhosCalling(),
 			"Unknown Timezone": cfg.Timezone,
 		}).Warn(msg)
@@ -476,7 +476,7 @@ func (i *IDrac9) Ntp(cfg *cfgresources.Ntp) (err error) {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"step":     helper.WhosCalling(),
 			"Timezone": cfg.Timezone,
 			"Error":    err,
@@ -495,7 +495,7 @@ func (i *IDrac9) Ntp(cfg *cfgresources.Ntp) (err error) {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  helper.WhosCalling(),
 			"Error": err,
 		}).Warn("PUT Ntp  request failed.")
@@ -504,7 +504,7 @@ func (i *IDrac9) Ntp(cfg *cfgresources.Ntp) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    i.ip,
-		"Model": i.BmcType(),
+		"Model": i.HardwareType(),
 	}).Debug("NTP servers param applied.")
 
 	return err
@@ -520,7 +520,7 @@ func (i *IDrac9) Syslog(cfg *cfgresources.Syslog) (err error) {
 	if cfg.Server == "" {
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  helper.WhosCalling(),
 		}).Warn("Syslog resource expects parameter: Server.")
 		return
@@ -553,7 +553,7 @@ func (i *IDrac9) Syslog(cfg *cfgresources.Syslog) (err error) {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  helper.WhosCalling(),
 			"Error": err,
 		}).Warn("PUT Syslog request failed.")
@@ -562,7 +562,7 @@ func (i *IDrac9) Syslog(cfg *cfgresources.Syslog) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    i.ip,
-		"Model": i.BmcType(),
+		"Model": i.HardwareType(),
 	}).Debug("Syslog parameters applied.")
 	return err
 }
@@ -620,7 +620,7 @@ func (i *IDrac9) Network(cfg *cfgresources.Network) (reset bool, err error) {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  helper.WhosCalling(),
 			"Error": err,
 		}).Warn("PUT IPv4 request failed.")
@@ -630,7 +630,7 @@ func (i *IDrac9) Network(cfg *cfgresources.Network) (reset bool, err error) {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  helper.WhosCalling(),
 			"Error": err,
 		}).Warn("PUT SerialOverLan request failed.")
@@ -640,7 +640,7 @@ func (i *IDrac9) Network(cfg *cfgresources.Network) (reset bool, err error) {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  helper.WhosCalling(),
 			"Error": err,
 		}).Warn("PUT SerialRedirection request failed.")
@@ -650,7 +650,7 @@ func (i *IDrac9) Network(cfg *cfgresources.Network) (reset bool, err error) {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  helper.WhosCalling(),
 			"Error": err,
 		}).Warn("PUT IpmiOverLan request failed.")
@@ -658,7 +658,7 @@ func (i *IDrac9) Network(cfg *cfgresources.Network) (reset bool, err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    i.ip,
-		"Model": i.BmcType(),
+		"Model": i.HardwareType(),
 	}).Debug("Network config parameters applied.")
 	return reset, err
 }
@@ -732,7 +732,7 @@ func (i *IDrac9) UploadHTTPSCert(cert []byte, certFileName string, key []byte, k
 	if err != nil || status != 201 {
 		log.WithFields(log.Fields{
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"endpoint": endpoint,
 			"step":     helper.WhosCalling(),
 			"status":   status,
@@ -747,7 +747,7 @@ func (i *IDrac9) UploadHTTPSCert(cert []byte, certFileName string, key []byte, k
 		log.WithFields(log.Fields{
 			"step":  helper.WhosCalling(),
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Error": err,
 		}).Warn("Unable to unmarshal cert store response payload.")
 		return false, err
@@ -758,7 +758,7 @@ func (i *IDrac9) UploadHTTPSCert(cert []byte, certFileName string, key []byte, k
 		log.WithFields(log.Fields{
 			"step":  helper.WhosCalling(),
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Error": err,
 		}).Warn("Unable to marshal cert store resource URI.")
 		return false, err
@@ -770,7 +770,7 @@ func (i *IDrac9) UploadHTTPSCert(cert []byte, certFileName string, key []byte, k
 	if err != nil || status != 201 {
 		log.WithFields(log.Fields{
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"endpoint": endpoint,
 			"step":     helper.WhosCalling(),
 			"status":   status,

--- a/providers/dell/idrac9/idrac9.go
+++ b/providers/dell/idrac9/idrac9.go
@@ -468,8 +468,8 @@ func (i *IDrac9) Name() (name string, err error) {
 	return name, err
 }
 
-// BmcVersion returns the version of the bmc we are running
-func (i *IDrac9) BmcVersion() (bmcVersion string, err error) {
+// Version returns the version of the bmc we are running
+func (i *IDrac9) Version() (bmcVersion string, err error) {
 	err = i.loadHwData()
 	if err != nil {
 		return bmcVersion, err
@@ -535,8 +535,8 @@ func (i *IDrac9) Model() (model string, err error) {
 	return model, err
 }
 
-// BmcType returns the type of bmc we are talking to
-func (i *IDrac9) BmcType() (bmcType string) {
+// HardwareType returns the type of bmc we are talking to
+func (i *IDrac9) HardwareType() (bmcType string) {
 	return BMCType
 }
 
@@ -729,13 +729,13 @@ func (i *IDrac9) ServerSnapshot() (server interface{}, err error) { // nolint: g
 		blade := &devices.Blade{}
 		blade.Vendor = i.Vendor()
 		blade.BmcAddress = i.ip
-		blade.BmcType = i.BmcType()
+		blade.BmcType = i.HardwareType()
 
 		blade.Serial, err = i.Serial()
 		if err != nil {
 			return nil, err
 		}
-		blade.BmcVersion, err = i.BmcVersion()
+		blade.BmcVersion, err = i.Version()
 		if err != nil {
 			return nil, err
 		}
@@ -800,13 +800,13 @@ func (i *IDrac9) ServerSnapshot() (server interface{}, err error) { // nolint: g
 		discrete := &devices.Discrete{}
 		discrete.Vendor = i.Vendor()
 		discrete.BmcAddress = i.ip
-		discrete.BmcType = i.BmcType()
+		discrete.BmcType = i.HardwareType()
 
 		discrete.Serial, err = i.Serial()
 		if err != nil {
 			return nil, err
 		}
-		discrete.BmcVersion, err = i.BmcVersion()
+		discrete.BmcVersion, err = i.Version()
 		if err != nil {
 			return nil, err
 		}

--- a/providers/dell/idrac9/idrac9_test.go
+++ b/providers/dell/idrac9/idrac9_test.go
@@ -3992,7 +3992,7 @@ func TestIDracBmcType(t *testing.T) {
 		t.Fatalf("Found errors during the test setup %v", err)
 	}
 
-	answer := bmc.BmcType()
+	answer := bmc.HardwareType()
 	if answer != expectedAnswer {
 		t.Errorf("Expected answer %v: found %v", expectedAnswer, answer)
 	}
@@ -4008,9 +4008,9 @@ func TestIDracBmcVersion(t *testing.T) {
 		t.Fatalf("Found errors during the test setup %v", err)
 	}
 
-	answer, err := bmc.BmcVersion()
+	answer, err := bmc.Version()
 	if err != nil {
-		t.Fatalf("Found errors calling bmc.BmcVersion %v", err)
+		t.Fatalf("Found errors calling bmc.Version %v", err)
 	}
 
 	if answer != expectedAnswer {

--- a/providers/dell/idrac9/query.go
+++ b/providers/dell/idrac9/query.go
@@ -63,7 +63,7 @@ func (i *IDrac9) queryUsers() (users map[int]User, err error) {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"endpoint": endpoint,
 			"step":     helper.WhosCalling(),
 			"Error":    err,
@@ -78,7 +78,7 @@ func (i *IDrac9) queryUsers() (users map[int]User, err error) {
 			"step":     "queryUserInfo",
 			"resource": "User",
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"Error":    err,
 		}).Warn("Unable to unmarshal payload.")
 		return users, err
@@ -95,7 +95,7 @@ func (i *IDrac9) queryLdapRoleGroups() (ldapRoleGroups LdapRoleGroups, err error
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"endpoint": endpoint,
 			"step":     helper.WhosCalling(),
 			"Error":    err,
@@ -110,7 +110,7 @@ func (i *IDrac9) queryLdapRoleGroups() (ldapRoleGroups LdapRoleGroups, err error
 			"step":     "queryUserInfo",
 			"resource": "User",
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"Error":    err,
 		}).Warn("Unable to unmarshal payload.")
 		return ldapRoleGroups, err

--- a/providers/dell/m1000e/configure.go
+++ b/providers/dell/m1000e/configure.go
@@ -96,7 +96,7 @@ func (m *M1000e) User(cfgUsers []*cfgresources.User) (err error) {
 
 		log.WithFields(log.Fields{
 			"IP":    m.ip,
-			"Model": m.BmcType(),
+			"Model": m.HardwareType(),
 		}).Debug("User account config parameters applied.")
 
 	}
@@ -121,7 +121,7 @@ func (m *M1000e) Syslog(cfg *cfgresources.Syslog) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    m.ip,
-		"Model": m.BmcType(),
+		"Model": m.HardwareType(),
 	}).Debug("Interface config parameters applied.")
 	return err
 }
@@ -147,7 +147,7 @@ func (m *M1000e) Ntp(cfg *cfgresources.Ntp) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    m.ip,
-		"Model": m.BmcType(),
+		"Model": m.HardwareType(),
 	}).Debug("DateTime config parameters applied.")
 	return err
 }
@@ -168,7 +168,7 @@ func (m *M1000e) Ldap(cfg *cfgresources.Ldap) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    m.ip,
-		"Model": m.BmcType(),
+		"Model": m.HardwareType(),
 	}).Debug("Ldap config parameters applied.")
 	return err
 }
@@ -191,7 +191,7 @@ func (m *M1000e) applyLdapRoleCfg(cfg LdapArgParams, roleID int) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    m.ip,
-		"Model": m.BmcType(),
+		"Model": m.HardwareType(),
 	}).Debug("Ldap Role group config parameters applied.")
 	return err
 }
@@ -208,7 +208,7 @@ func (m *M1000e) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.
 				"step":      "applyLdapGroupParams",
 				"Ldap role": group.Role,
 				"IP":        m.ip,
-				"Model":     m.BmcType(),
+				"Model":     m.HardwareType(),
 				"Error":     err,
 			}).Warn("Unable to apply Ldap role group config.")
 			return err
@@ -220,7 +220,7 @@ func (m *M1000e) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.
 				"step":      "applyLdapGroupParams",
 				"Ldap role": group.Role,
 				"IP":        m.ip,
-				"Model":     m.BmcType(),
+				"Model":     m.HardwareType(),
 				"Error":     err,
 			}).Warn("Unable to apply Ldap role group config.")
 			return err
@@ -228,7 +228,7 @@ func (m *M1000e) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.
 
 		log.WithFields(log.Fields{
 			"IP":    m.ip,
-			"Model": m.BmcType(),
+			"Model": m.HardwareType(),
 			"Role":  group.Role,
 			"Group": group.Group,
 		}).Debug("Ldap group parameters applied.")
@@ -284,7 +284,7 @@ func (m *M1000e) CurrentHTTPSCert() (c []*x509.Certificate, b bool, e error) {
 //
 //	log.WithFields(log.Fields{
 //		"IP":    m.ip,
-//		"Model": m.BmcType(),
+//		"Model": m.HardwareType(),
 //	}).Debug("SSL certs uploaded.")
 //	return err
 //}
@@ -456,7 +456,7 @@ func (m *M1000e) ApplySecurityCfg(cfg LoginSecurityParams) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    m.ip,
-		"Model": m.BmcType(),
+		"Model": m.HardwareType(),
 	}).Debug("Security config parameters applied.")
 	return err
 

--- a/providers/dell/m1000e/m1000e.go
+++ b/providers/dell/m1000e/m1000e.go
@@ -93,8 +93,8 @@ func (m *M1000e) Name() (name string, err error) {
 	return m.cmcJSON.Chassis.ChassisGroupMemberHealthBlob.ChassisStatus.CHASSISName, err
 }
 
-// BmcType returns just Model id string - m1000e
-func (m *M1000e) BmcType() (model string) {
+// HardwareType returns just Model id string - m1000e
+func (m *M1000e) HardwareType() (model string) {
 	return BMCType
 }
 
@@ -205,8 +205,8 @@ func (m *M1000e) Status() (status string, err error) {
 	return status, err
 }
 
-// FwVersion returns the current firmware version of the bmc
-func (m *M1000e) FwVersion() (version string, err error) {
+// Version returns the current firmware version of the bmc
+func (m *M1000e) Version() (version string, err error) {
 	err = m.httpLogin()
 	if err != nil {
 		return version, err
@@ -466,7 +466,7 @@ func (m *M1000e) ChassisSnapshot() (chassis *devices.Chassis, err error) {
 	if err != nil {
 		return nil, err
 	}
-	chassis.FwVersion, err = m.FwVersion()
+	chassis.FwVersion, err = m.Version()
 	if err != nil {
 		return nil, err
 	}

--- a/providers/dell/m1000e/m1000e_test.go
+++ b/providers/dell/m1000e/m1000e_test.go
@@ -1721,9 +1721,9 @@ func TestChassisFwVersion(t *testing.T) {
 		t.Fatalf("Found errors during the test setup %v", err)
 	}
 
-	answer, err := chassis.FwVersion()
+	answer, err := chassis.Version()
 	if err != nil {
-		t.Fatalf("Found errors calling chassis.FwVersion %v", err)
+		t.Fatalf("Found errors calling chassis.Version %v", err)
 	}
 
 	if answer != expectedAnswer {
@@ -1976,7 +1976,7 @@ func TestChassisBmcType(t *testing.T) {
 		t.Fatalf("Found errors during the test setup %v", err)
 	}
 
-	answer := bmc.BmcType()
+	answer := bmc.HardwareType()
 	if answer != expectedAnswer {
 		t.Errorf("Expected answer %v: found %v", expectedAnswer, answer)
 	}

--- a/providers/dummy/ibmc/ibmc.go
+++ b/providers/dummy/ibmc/ibmc.go
@@ -36,13 +36,13 @@ func (i *Ibmc) BiosVersion() (string, error) {
 	return "", nil
 }
 
-// BmcType implements the Bmc interface
-func (i *Ibmc) BmcType() string {
+// HardwareType implements the Bmc interface
+func (i *Ibmc) HardwareType() string {
 	return ""
 }
 
-// BmcVersion implements the Bmc interface
-func (i *Ibmc) BmcVersion() (string, error) {
+// Version implements the Bmc interface
+func (i *Ibmc) Version() (string, error) {
 	return "", nil
 }
 

--- a/providers/hp/c7000/c7000.go
+++ b/providers/hp/c7000/c7000.go
@@ -78,8 +78,8 @@ func (c *C7000) Name() (name string, err error) {
 	return c.Rimp.Infra2.Encl, err
 }
 
-// BmcType returns the model id string - c7000
-func (c *C7000) BmcType() (model string) {
+// HardwareType returns the model id string - c7000
+func (c *C7000) HardwareType() (model string) {
 	return BMCType
 }
 
@@ -182,8 +182,8 @@ func (c *C7000) IsActive() bool {
 	return false
 }
 
-// FwVersion returns the current firmware version of the bmc
-func (c *C7000) FwVersion() (version string, err error) {
+// Version returns the current firmware version of the bmc
+func (c *C7000) Version() (version string, err error) {
 	return c.Rimp.MP.Fwri, err
 }
 
@@ -293,7 +293,7 @@ func (c *C7000) ChassisSnapshot() (chassis *devices.Chassis, err error) {
 	if err != nil {
 		return nil, err
 	}
-	chassis.FwVersion, err = c.FwVersion()
+	chassis.FwVersion, err = c.Version()
 	if err != nil {
 		return nil, err
 	}

--- a/providers/hp/c7000/c7000_test.go
+++ b/providers/hp/c7000/c7000_test.go
@@ -2441,9 +2441,9 @@ func TestHpChassisFwVersion(t *testing.T) {
 		t.Fatalf("Found errors during the test setup %v", err)
 	}
 
-	answer, err := chassis.FwVersion()
+	answer, err := chassis.Version()
 	if err != nil {
-		t.Fatalf("Found errors calling chassis.FwVersion %v", err)
+		t.Fatalf("Found errors calling chassis.Version %v", err)
 	}
 
 	if answer != expectedAnswer {
@@ -2830,7 +2830,7 @@ func TestHpChassisBmcType(t *testing.T) {
 		t.Fatalf("Found errors during the test setup %v", err)
 	}
 
-	answer := bmc.BmcType()
+	answer := bmc.HardwareType()
 	if answer != expectedAnswer {
 		t.Errorf("Expected answer %v: found %v", expectedAnswer, answer)
 	}

--- a/providers/hp/c7000/configure.go
+++ b/providers/hp/c7000/configure.go
@@ -69,7 +69,7 @@ func (c *C7000) Ldap(cfg *cfgresources.Ldap) (err error) {
 			"step":     "applyLdapParams",
 			"resource": "Ldap",
 			"IP":       c.ip,
-			"Model":    c.BmcType(),
+			"Model":    c.HardwareType(),
 			"Error":    err,
 		}).Warn("applyLdapParams returned error.")
 		return err
@@ -81,7 +81,7 @@ func (c *C7000) Ldap(cfg *cfgresources.Ldap) (err error) {
 			"step":     "applyLdapParams",
 			"resource": "Ldap",
 			"IP":       c.ip,
-			"Model":    c.BmcType(),
+			"Model":    c.HardwareType(),
 			"Error":    err,
 		}).Warn("applyLdapParams returned error.")
 		return err
@@ -112,7 +112,7 @@ func (c *C7000) applysetLdapInfo4(cfg *cfgresources.Ldap) (err error) {
 	if cfg.Server == "" {
 		log.WithFields(log.Fields{
 			"step":  "applysetLdapInfo4",
-			"Model": c.BmcType(),
+			"Model": c.HardwareType(),
 		}).Warn("Ldap resource parameter Server required but not declared.")
 		return err
 	}
@@ -120,7 +120,7 @@ func (c *C7000) applysetLdapInfo4(cfg *cfgresources.Ldap) (err error) {
 	if cfg.Port == 0 {
 		log.WithFields(log.Fields{
 			"step":  "applysetLdapInfo4",
-			"Model": c.BmcType(),
+			"Model": c.HardwareType(),
 		}).Warn("Ldap resource parameter Port required but not declared.")
 		return err
 	}
@@ -154,7 +154,7 @@ func (c *C7000) applysetLdapInfo4(cfg *cfgresources.Ldap) (err error) {
 		log.WithFields(log.Fields{
 			"step":       "applysetLdapInfo4",
 			"IP":         c.ip,
-			"Model":      c.BmcType(),
+			"Model":      c.HardwareType(),
 			"statusCode": statusCode,
 			"Error":      err,
 		}).Warn("Ldap applysetLdapInfo4 apply request returned non 200.")
@@ -163,7 +163,7 @@ func (c *C7000) applysetLdapInfo4(cfg *cfgresources.Ldap) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    c.ip,
-		"Model": c.BmcType(),
+		"Model": c.HardwareType(),
 	}).Debug("Ldap Server parameters applied.")
 	return err
 }
@@ -180,7 +180,7 @@ func (c *C7000) applyEnableLdapAuth(enable bool) (err error) {
 		log.WithFields(log.Fields{
 			"step":       "applyEnableLdapAuth",
 			"IP":         c.ip,
-			"Model":      c.BmcType(),
+			"Model":      c.HardwareType(),
 			"statusCode": statusCode,
 			"Error":      err,
 		}).Warn("Ldap applyEnableLdapAuth apply request returned non 200.")
@@ -189,7 +189,7 @@ func (c *C7000) applyEnableLdapAuth(enable bool) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    c.ip,
-		"Model": c.BmcType(),
+		"Model": c.HardwareType(),
 	}).Debug("Ldap Enabled.")
 	return err
 }
@@ -207,7 +207,7 @@ func (c *C7000) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.L
 		if group.Group == "" {
 			log.WithFields(log.Fields{
 				"step":      "applyLdapGroupParams",
-				"Model":     c.BmcType(),
+				"Model":     c.HardwareType(),
 				"Ldap role": group.Role,
 			}).Warn("Ldap resource parameter Group required but not declared.")
 			return
@@ -221,7 +221,7 @@ func (c *C7000) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.L
 					"step":     "applyRemoveLdapGroup",
 					"resource": "Ldap",
 					"IP":       c.ip,
-					"Model":    c.BmcType(),
+					"Model":    c.HardwareType(),
 					"Error":    err,
 				}).Warn("Remove Ldap Group returned error.")
 				return
@@ -234,7 +234,7 @@ func (c *C7000) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.L
 			log.WithFields(log.Fields{
 				"step":  "applyLdapGroupParams",
 				"role":  group.Role,
-				"Model": c.BmcType(),
+				"Model": c.HardwareType(),
 			}).Warn("Ldap resource Role must be a valid role: admin OR user.")
 			return
 		}
@@ -246,7 +246,7 @@ func (c *C7000) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.L
 				"step":     "applyAddLdapGroup",
 				"resource": "Ldap",
 				"IP":       c.ip,
-				"Model":    c.BmcType(),
+				"Model":    c.HardwareType(),
 				"Error":    err,
 			}).Warn("addLdapGroup returned error.")
 			return
@@ -259,7 +259,7 @@ func (c *C7000) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.L
 				"step":     "setLdapGroupBayACL",
 				"resource": "Ldap",
 				"IP":       c.ip,
-				"Model":    c.BmcType(),
+				"Model":    c.HardwareType(),
 				"Error":    err,
 			}).Warn("addLdapGroup returned error.")
 			return
@@ -272,7 +272,7 @@ func (c *C7000) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.L
 				"step":     "applyAddLdapGroupBayAccess",
 				"resource": "Ldap",
 				"IP":       c.ip,
-				"Model":    c.BmcType(),
+				"Model":    c.HardwareType(),
 				"Error":    err,
 			}).Warn("addLdapGroup returned error.")
 			return
@@ -281,7 +281,7 @@ func (c *C7000) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.L
 
 	log.WithFields(log.Fields{
 		"IP":    c.ip,
-		"Model": c.BmcType(),
+		"Model": c.HardwareType(),
 	}).Debug("Ldap config applied")
 	return
 }
@@ -298,7 +298,7 @@ func (c *C7000) applyRemoveLdapGroup(group string) (err error) {
 		log.WithFields(log.Fields{
 			"step":       "applyRemoveLdapGroup",
 			"IP":         c.ip,
-			"Model":      c.BmcType(),
+			"Model":      c.HardwareType(),
 			"statusCode": statusCode,
 		}).Debug("Ldap applyRemoveLdapGroup applied.")
 		return nil
@@ -308,7 +308,7 @@ func (c *C7000) applyRemoveLdapGroup(group string) (err error) {
 		log.WithFields(log.Fields{
 			"step":       "applyRemoveLdapGroup",
 			"IP":         c.ip,
-			"Model":      c.BmcType(),
+			"Model":      c.HardwareType(),
 			"statusCode": statusCode,
 		}).Warn("Ldap applyRemoveLdapGroup request returned non 200.")
 		return err
@@ -316,7 +316,7 @@ func (c *C7000) applyRemoveLdapGroup(group string) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    c.ip,
-		"Model": c.BmcType(),
+		"Model": c.HardwareType(),
 		"Group": group,
 	}).Debug("Ldap group removed.")
 	return nil
@@ -334,7 +334,7 @@ func (c *C7000) applyAddLdapGroup(group string) (err error) {
 		log.WithFields(log.Fields{
 			"step":       "applyAddLdapGroup",
 			"IP":         c.ip,
-			"Model":      c.BmcType(),
+			"Model":      c.HardwareType(),
 			"statusCode": statusCode,
 		}).Debug("Ldap applyAddLdapGroup applied.")
 		return nil
@@ -344,7 +344,7 @@ func (c *C7000) applyAddLdapGroup(group string) (err error) {
 		log.WithFields(log.Fields{
 			"step":       "applyAddLdapGroup",
 			"IP":         c.ip,
-			"Model":      c.BmcType(),
+			"Model":      c.HardwareType(),
 			"statusCode": statusCode,
 		}).Warn("Ldap applyAddLdapGroup request returned non 200.")
 		return err
@@ -352,7 +352,7 @@ func (c *C7000) applyAddLdapGroup(group string) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    c.ip,
-		"Model": c.BmcType(),
+		"Model": c.HardwareType(),
 	}).Debug("Ldap group added.")
 	return nil
 }
@@ -378,7 +378,7 @@ func (c *C7000) applyLdapGroupBayACL(role string, group string) (err error) {
 		log.WithFields(log.Fields{
 			"step":       "applyLdapGroupBayACL",
 			"IP":         c.ip,
-			"Model":      c.BmcType(),
+			"Model":      c.HardwareType(),
 			"statusCode": statusCode,
 			"Error":      err,
 		}).Warn("LDAP applyLdapGroupBayACL request returned non 200.")
@@ -387,7 +387,7 @@ func (c *C7000) applyLdapGroupBayACL(role string, group string) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    c.ip,
-		"Model": c.BmcType(),
+		"Model": c.HardwareType(),
 		"Role":  role,
 		"Group": group,
 	}).Debug("Ldap group ACL added.")
@@ -463,7 +463,7 @@ func (c *C7000) applyAddLdapGroupBayAccess(group string) (err error) {
 		log.WithFields(log.Fields{
 			"step":       "applyAddLdapGroupBayAccess",
 			"IP":         c.ip,
-			"Model":      c.BmcType(),
+			"Model":      c.HardwareType(),
 			"statusCode": statusCode,
 			"Error":      err,
 		}).Warn("LDAP applyAddLdapGroupBayAccess apply request returned non 200.")
@@ -472,7 +472,7 @@ func (c *C7000) applyAddLdapGroupBayAccess(group string) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    c.ip,
-		"Model": c.BmcType(),
+		"Model": c.HardwareType(),
 		"Group": group,
 	}).Debug("Ldap interconnect and bay ACLs added.")
 	return err
@@ -487,21 +487,21 @@ func (c *C7000) User(users []*cfgresources.User) (err error) {
 		if cfg.Name == "" {
 			log.WithFields(log.Fields{
 				"step":  "applyUserParams",
-				"Model": c.BmcType(),
+				"Model": c.HardwareType(),
 			}).Fatal("User resource expects parameter: Name.")
 		}
 
 		if cfg.Password == "" {
 			log.WithFields(log.Fields{
 				"step":  "applyUserParams",
-				"Model": c.BmcType(),
+				"Model": c.HardwareType(),
 			}).Fatal("User resource expects parameter: Password.")
 		}
 
 		if c.isRoleValid(cfg.Role) == false {
 			log.WithFields(log.Fields{
 				"step":  "applyUserParams",
-				"Model": c.BmcType(),
+				"Model": c.HardwareType(),
 				"Role":  cfg.Role,
 			}).Fatal("User resource Role must be declared and a valid role: admin.")
 		}
@@ -521,7 +521,7 @@ func (c *C7000) User(users []*cfgresources.User) (err error) {
 
 			log.WithFields(log.Fields{
 				"IP":    c.ip,
-				"Model": c.BmcType(),
+				"Model": c.HardwareType(),
 				"User":  cfg.Name,
 			}).Debug("User removed.")
 
@@ -541,7 +541,7 @@ func (c *C7000) User(users []*cfgresources.User) (err error) {
 				"step":        "applyUserParams",
 				"user":        cfg.Name,
 				"IP":          c.ip,
-				"Model":       c.BmcType(),
+				"Model":       c.HardwareType(),
 				"Return code": statusCode,
 			}).Debug("User already exists, setting password.")
 
@@ -567,7 +567,7 @@ func (c *C7000) User(users []*cfgresources.User) (err error) {
 
 		log.WithFields(log.Fields{
 			"IP":    c.ip,
-			"Model": c.BmcType(),
+			"Model": c.HardwareType(),
 			"user":  cfg.Name,
 		}).Debug("User cfg applied.")
 
@@ -587,7 +587,7 @@ func (c *C7000) setUserPassword(user string, password string) (err error) {
 			"step":        "setUserPassword",
 			"user":        user,
 			"IP":          c.ip,
-			"Model":       c.BmcType(),
+			"Model":       c.HardwareType(),
 			"return code": statusCode,
 			"Error":       err,
 		}).Warn("Unable to set user password.")
@@ -596,7 +596,7 @@ func (c *C7000) setUserPassword(user string, password string) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    c.ip,
-		"Model": c.BmcType(),
+		"Model": c.HardwareType(),
 		"user":  user,
 	}).Debug("User password set.")
 	return err
@@ -623,7 +623,7 @@ func (c *C7000) setUserACL(user string, role string) (err error) {
 			"user":        user,
 			"ACL":         role,
 			"IP":          c.ip,
-			"Model":       c.BmcType(),
+			"Model":       c.HardwareType(),
 			"return code": statusCode,
 			"Error":       err,
 		}).Warn("Unable to set user ACL.")
@@ -632,7 +632,7 @@ func (c *C7000) setUserACL(user string, role string) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    c.ip,
-		"Model": c.BmcType(),
+		"Model": c.HardwareType(),
 		"User":  user,
 		"ACL":   role,
 	}).Debug("User ACL set.")
@@ -684,7 +684,7 @@ func (c *C7000) applyAddUserBayAccess(user string) (err error) {
 		log.WithFields(log.Fields{
 			"step":       "applyAddUserBayAccess",
 			"IP":         c.ip,
-			"Model":      c.BmcType(),
+			"Model":      c.HardwareType(),
 			"statusCode": statusCode,
 			"Error":      err,
 		}).Warn("LDAP applyAddUserBayAccess apply request returned non 200.")
@@ -694,7 +694,7 @@ func (c *C7000) applyAddUserBayAccess(user string) (err error) {
 	log.WithFields(log.Fields{
 		"step":  "applyAddUserBayAccess",
 		"IP":    c.ip,
-		"Model": c.BmcType(),
+		"Model": c.HardwareType(),
 		"user":  user,
 	}).Debug("User account related interconnect and bay ACLs added.")
 	return err
@@ -720,7 +720,7 @@ func (c *C7000) Ntp(cfg *cfgresources.Ntp) (err error) {
 	if cfg.Server1 == "" {
 		log.WithFields(log.Fields{
 			"step":  "applyNtpParams",
-			"Model": c.BmcType(),
+			"Model": c.HardwareType(),
 		}).Warn("NTP resource expects parameter: server1.")
 		return
 	}
@@ -728,7 +728,7 @@ func (c *C7000) Ntp(cfg *cfgresources.Ntp) (err error) {
 	if cfg.Timezone == "" {
 		log.WithFields(log.Fields{
 			"step":  "applyNtpParams",
-			"Model": c.BmcType(),
+			"Model": c.HardwareType(),
 		}).Warn("NTP resource expects parameter: timezone.")
 		return
 	}
@@ -736,7 +736,7 @@ func (c *C7000) Ntp(cfg *cfgresources.Ntp) (err error) {
 	if cfg.Enable != true {
 		log.WithFields(log.Fields{
 			"step":  "applyNtpParams",
-			"Model": c.BmcType(),
+			"Model": c.HardwareType(),
 		}).Debug("Ntp resource declared with enable: false.")
 		return
 	}
@@ -753,7 +753,7 @@ func (c *C7000) Ntp(cfg *cfgresources.Ntp) (err error) {
 		log.WithFields(log.Fields{
 			"step":       "applyNtpParams",
 			"IP":         c.ip,
-			"Model":      c.BmcType(),
+			"Model":      c.HardwareType(),
 			"StatusCode": statusCode,
 			"Error":      err,
 		}).Warn("NTP apply request returned non 200.")
@@ -765,7 +765,7 @@ func (c *C7000) Ntp(cfg *cfgresources.Ntp) (err error) {
 		log.WithFields(log.Fields{
 			"step":  "applyNtpParams",
 			"IP":    c.ip,
-			"Model": c.BmcType(),
+			"Model": c.HardwareType(),
 			"Error": err,
 		}).Warn("Unable to apply NTP timezone config.")
 		return err
@@ -773,7 +773,7 @@ func (c *C7000) Ntp(cfg *cfgresources.Ntp) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    c.ip,
-		"Model": c.BmcType(),
+		"Model": c.HardwareType(),
 	}).Debug("Date and time config applied.")
 	return err
 }
@@ -790,7 +790,7 @@ func (c *C7000) applyNtpTimezoneParam(timezone string) (err error) {
 		log.WithFields(log.Fields{
 			"step":       "applyNtpTimezoneParam",
 			"IP":         c.ip,
-			"Model":      c.BmcType(),
+			"Model":      c.HardwareType(),
 			"Error":      err,
 			"StatusCode": statusCode,
 		}).Warn("NTP applyNtpTimezoneParam request returned non 200.")
@@ -799,7 +799,7 @@ func (c *C7000) applyNtpTimezoneParam(timezone string) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    c.ip,
-		"Model": c.BmcType(),
+		"Model": c.HardwareType(),
 	}).Debug("Timezone config applied.")
 	return err
 }
@@ -818,7 +818,7 @@ func (c *C7000) Syslog(cfg *cfgresources.Syslog) (err error) {
 		log.WithFields(log.Fields{
 			"step":  "applySyslogParams",
 			"IP":    c.ip,
-			"Model": c.BmcType(),
+			"Model": c.HardwareType(),
 		}).Warn("Syslog resource expects parameter: Server.")
 		return
 	}
@@ -827,7 +827,7 @@ func (c *C7000) Syslog(cfg *cfgresources.Syslog) (err error) {
 		log.WithFields(log.Fields{
 			"step":  "applySyslogParams",
 			"IP":    c.ip,
-			"Model": c.BmcType(),
+			"Model": c.HardwareType(),
 		}).Debug("Syslog resource port set to default: 514.")
 		port = 514
 	} else {
@@ -838,7 +838,7 @@ func (c *C7000) Syslog(cfg *cfgresources.Syslog) (err error) {
 		log.WithFields(log.Fields{
 			"step":  "applySyslogParams",
 			"IP":    c.ip,
-			"Model": c.BmcType(),
+			"Model": c.HardwareType(),
 		}).Debug("Syslog resource declared with enable: false.")
 	}
 
@@ -848,7 +848,7 @@ func (c *C7000) Syslog(cfg *cfgresources.Syslog) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    c.ip,
-		"Model": c.BmcType(),
+		"Model": c.HardwareType(),
 	}).Debug("Syslog config applied.")
 	return err
 }
@@ -865,7 +865,7 @@ func (c *C7000) applySyslogServer(server string) {
 		log.WithFields(log.Fields{
 			"step":       "applySyslogServer",
 			"IP":         c.ip,
-			"Model":      c.BmcType(),
+			"Model":      c.HardwareType(),
 			"Error":      err,
 			"StatusCode": statusCode,
 		}).Warn("Syslog set server request returned non 200.")
@@ -874,7 +874,7 @@ func (c *C7000) applySyslogServer(server string) {
 
 	log.WithFields(log.Fields{
 		"IP":    c.ip,
-		"Model": c.BmcType(),
+		"Model": c.HardwareType(),
 	}).Debug("Syslog server set.")
 	return
 }
@@ -890,7 +890,7 @@ func (c *C7000) applySyslogPort(port int) {
 		log.WithFields(log.Fields{
 			"step":       "applySyslogPort",
 			"IP":         c.ip,
-			"Model":      c.BmcType(),
+			"Model":      c.HardwareType(),
 			"Error":      err,
 			"StatusCode": statusCode,
 		}).Warn("Syslog set port request returned non 200.")
@@ -899,7 +899,7 @@ func (c *C7000) applySyslogPort(port int) {
 
 	log.WithFields(log.Fields{
 		"IP":    c.ip,
-		"Model": c.BmcType(),
+		"Model": c.HardwareType(),
 	}).Debug("Syslog port set.")
 	return
 }
@@ -916,7 +916,7 @@ func (c *C7000) applySyslogEnabled(enabled bool) {
 		log.WithFields(log.Fields{
 			"step":       "SetRemoteSyslogEnabled",
 			"IP":         c.ip,
-			"Model":      c.BmcType(),
+			"Model":      c.HardwareType(),
 			"Error":      err,
 			"StatusCode": statusCode,
 		}).Warn("Syslog enable request returned non 200.")
@@ -925,7 +925,7 @@ func (c *C7000) applySyslogEnabled(enabled bool) {
 
 	log.WithFields(log.Fields{
 		"IP":    c.ip,
-		"Model": c.BmcType(),
+		"Model": c.HardwareType(),
 	}).Debug("Syslog enabled.")
 	return
 

--- a/providers/hp/ilo/configure.go
+++ b/providers/hp/ilo/configure.go
@@ -40,7 +40,7 @@ func (i *Ilo) ApplyCfg(config *cfgresources.ResourcesConfig) (err error) {
 		log.WithFields(log.Fields{
 			"step":  "Login()",
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 		}).Warn(msg)
 		return errors.New(msg)
 	}
@@ -97,7 +97,7 @@ func (i *Ilo) User(users []*cfgresources.User) (err error) {
 		log.WithFields(log.Fields{
 			"step":  "applyUserParams",
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Error": err,
 		}).Warn(msg)
 		return errors.New(msg)
@@ -177,7 +177,7 @@ func (i *Ilo) User(users []*cfgresources.User) (err error) {
 			userinfo.UserID = userinfo.ID
 			log.WithFields(log.Fields{
 				"IP":    i.ip,
-				"Model": i.BmcType(),
+				"Model": i.HardwareType(),
 				"User":  user.Name,
 			}).Debug("User disabled in config, will be removed.")
 			postPayload = true
@@ -188,7 +188,7 @@ func (i *Ilo) User(users []*cfgresources.User) (err error) {
 			if err != nil {
 				log.WithFields(log.Fields{
 					"IP":    i.ip,
-					"Model": i.BmcType(),
+					"Model": i.HardwareType(),
 					"step":  helper.WhosCalling(),
 					"User":  user.Name,
 					"Error": err,
@@ -201,7 +201,7 @@ func (i *Ilo) User(users []*cfgresources.User) (err error) {
 			if err != nil || statusCode != 200 {
 				log.WithFields(log.Fields{
 					"IP":         i.ip,
-					"Model":      i.BmcType(),
+					"Model":      i.HardwareType(),
 					"endpoint":   endpoint,
 					"step":       helper.WhosCalling(),
 					"User":       user.Name,
@@ -214,7 +214,7 @@ func (i *Ilo) User(users []*cfgresources.User) (err error) {
 
 			log.WithFields(log.Fields{
 				"IP":    i.ip,
-				"Model": i.BmcType(),
+				"Model": i.HardwareType(),
 				"User":  user.Name,
 			}).Debug("User parameters applied.")
 
@@ -268,7 +268,7 @@ func (i *Ilo) Syslog(cfg *cfgresources.Syslog) (err error) {
 		msg := "Unable to marshal RemoteSyslog payload to set Syslog config."
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  helper.WhosCalling(),
 			"Error": err,
 		}).Warn(msg)
@@ -281,7 +281,7 @@ func (i *Ilo) Syslog(cfg *cfgresources.Syslog) (err error) {
 		msg := "POST request to set User config returned error."
 		log.WithFields(log.Fields{
 			"IP":         i.ip,
-			"Model":      i.BmcType(),
+			"Model":      i.HardwareType(),
 			"endpoint":   endpoint,
 			"step":       helper.WhosCalling(),
 			"StatusCode": statusCode,
@@ -293,7 +293,7 @@ func (i *Ilo) Syslog(cfg *cfgresources.Syslog) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    i.ip,
-		"Model": i.BmcType(),
+		"Model": i.HardwareType(),
 	}).Debug("Syslog parameters applied.")
 
 	return err
@@ -322,7 +322,7 @@ func (i *Ilo) SetLicense(cfg *cfgresources.License) (err error) {
 		msg := "Unable to marshal License payload to activate License."
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  helper.WhosCalling(),
 			"Error": err,
 		}).Warn(msg)
@@ -335,7 +335,7 @@ func (i *Ilo) SetLicense(cfg *cfgresources.License) (err error) {
 		msg := "POST request to set User config returned error."
 		log.WithFields(log.Fields{
 			"IP":         i.ip,
-			"Model":      i.BmcType(),
+			"Model":      i.HardwareType(),
 			"endpoint":   endpoint,
 			"step":       helper.WhosCalling(),
 			"StatusCode": statusCode,
@@ -347,7 +347,7 @@ func (i *Ilo) SetLicense(cfg *cfgresources.License) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    i.ip,
-		"Model": i.BmcType(),
+		"Model": i.HardwareType(),
 	}).Debug("License activated.")
 
 	return err
@@ -378,8 +378,8 @@ func (i *Ilo) Ntp(cfg *cfgresources.Ntp) (err error) {
 	var timezones map[string]int
 
 	// ideally ilo5 ilo4 should be split up into its own device
-	// instead of depending on BmcType.
-	if i.BmcType() == "ilo5" {
+	// instead of depending on HardwareType.
+	if i.HardwareType() == "ilo5" {
 		timezones = TimezonesIlo5
 	} else {
 		timezones = TimezonesIlo4
@@ -407,7 +407,7 @@ func (i *Ilo) Ntp(cfg *cfgresources.Ntp) (err error) {
 		log.WithFields(log.Fields{
 			"step":  helper.WhosCalling(),
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Error": err,
 		}).Warn(msg)
 		return errors.New(msg)
@@ -439,7 +439,7 @@ func (i *Ilo) Ntp(cfg *cfgresources.Ntp) (err error) {
 		msg := "Unable to marshal NetworkSntp payload to set NTP config."
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  helper.WhosCalling(),
 			"Error": err,
 		}).Warn(msg)
@@ -452,7 +452,7 @@ func (i *Ilo) Ntp(cfg *cfgresources.Ntp) (err error) {
 		msg := "POST request to set NTP config returned error."
 		log.WithFields(log.Fields{
 			"IP":         i.ip,
-			"Model":      i.BmcType(),
+			"Model":      i.HardwareType(),
 			"endpoint":   endpoint,
 			"step":       helper.WhosCalling(),
 			"StatusCode": statusCode,
@@ -464,7 +464,7 @@ func (i *Ilo) Ntp(cfg *cfgresources.Ntp) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    i.ip,
-		"Model": i.BmcType(),
+		"Model": i.HardwareType(),
 	}).Debug("NTP parameters applied.")
 
 	return err
@@ -480,7 +480,7 @@ func (i *Ilo) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.Lda
 		msg := "Unable to query existing Ldap groups"
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Step":  helper.WhosCalling(),
 			"Error": err,
 		}).Warn(msg)
@@ -493,7 +493,7 @@ func (i *Ilo) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.Lda
 		if group.Group == "" {
 			msg := "Ldap resource parameter Group required but not declared."
 			log.WithFields(log.Fields{
-				"Model":     i.BmcType(),
+				"Model":     i.HardwareType(),
 				"step":      helper.WhosCalling,
 				"Ldap role": group.Role,
 			}).Warn(msg)
@@ -503,7 +503,7 @@ func (i *Ilo) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.Lda
 		if !i.isRoleValid(group.Role) {
 			msg := "Ldap resource Role must be a valid role: admin OR user."
 			log.WithFields(log.Fields{
-				"Model":     i.BmcType(),
+				"Model":     i.HardwareType(),
 				"step":      helper.WhosCalling(),
 				"Ldap role": group.Role,
 			}).Warn(msg)
@@ -548,7 +548,7 @@ func (i *Ilo) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.Lda
 			directoryGroup.Method = "del_group"
 			log.WithFields(log.Fields{
 				"IP":    i.ip,
-				"Model": i.BmcType(),
+				"Model": i.HardwareType(),
 				"User":  group.Group,
 			}).Debug("Ldap role group disabled in config, will be removed.")
 			postPayload = true
@@ -559,7 +559,7 @@ func (i *Ilo) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.Lda
 			if err != nil {
 				log.WithFields(log.Fields{
 					"IP":    i.ip,
-					"Model": i.BmcType(),
+					"Model": i.HardwareType(),
 					"Step":  helper.WhosCalling(),
 					"Group": group.Group,
 					"Error": err,
@@ -572,7 +572,7 @@ func (i *Ilo) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.Lda
 			if err != nil || statusCode != 200 {
 				log.WithFields(log.Fields{
 					"IP":         i.ip,
-					"Model":      i.BmcType(),
+					"Model":      i.HardwareType(),
 					"endpoint":   endpoint,
 					"step":       helper.WhosCalling(),
 					"Group":      group.Group,
@@ -585,7 +585,7 @@ func (i *Ilo) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.Lda
 
 			log.WithFields(log.Fields{
 				"IP":    i.ip,
-				"Model": i.BmcType(),
+				"Model": i.HardwareType(),
 				"User":  group.Group,
 			}).Debug("LdapGroup parameters applied.")
 
@@ -603,7 +603,7 @@ func (i *Ilo) Ldap(cfg *cfgresources.Ldap) (err error) {
 	if cfg.Server == "" {
 		msg := "Ldap resource parameter Server required but not declared."
 		log.WithFields(log.Fields{
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  helper.WhosCalling,
 		}).Warn(msg)
 		return errors.New(msg)
@@ -612,7 +612,7 @@ func (i *Ilo) Ldap(cfg *cfgresources.Ldap) (err error) {
 	if cfg.Port == 0 {
 		msg := "Ldap resource parameter Port required but not declared."
 		log.WithFields(log.Fields{
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  helper.WhosCalling,
 		}).Warn(msg)
 		return errors.New(msg)
@@ -621,7 +621,7 @@ func (i *Ilo) Ldap(cfg *cfgresources.Ldap) (err error) {
 	if cfg.BaseDn == "" {
 		msg := "Ldap resource parameter BaseDn required but not declared."
 		log.WithFields(log.Fields{
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"step":  helper.WhosCalling,
 		}).Warn(msg)
 		return errors.New(msg)
@@ -651,7 +651,7 @@ func (i *Ilo) Ldap(cfg *cfgresources.Ldap) (err error) {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Step":  helper.WhosCalling(),
 			"Error": err,
 		}).Warn("Unable to marshal directory payload to set Ldap config.")
@@ -664,7 +664,7 @@ func (i *Ilo) Ldap(cfg *cfgresources.Ldap) (err error) {
 		msg := "POST request to set Ldap config returned error."
 		log.WithFields(log.Fields{
 			"IP":         i.ip,
-			"Model":      i.BmcType(),
+			"Model":      i.HardwareType(),
 			"endpoint":   endpoint,
 			"step":       helper.WhosCalling(),
 			"StatusCode": statusCode,
@@ -676,7 +676,7 @@ func (i *Ilo) Ldap(cfg *cfgresources.Ldap) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    i.ip,
-		"Model": i.BmcType(),
+		"Model": i.HardwareType(),
 	}).Debug("Ldap parameters applied.")
 
 	return err

--- a/providers/hp/ilo/ilo.go
+++ b/providers/hp/ilo/ilo.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	// BmcType defines the bmc model that is supported by this package
+	// HardwareType defines the bmc model that is supported by this package
 	BmcType = "ilo"
 
 	// Ilo2 is the constant for iLO2
@@ -248,8 +248,8 @@ func (i *Ilo) Model() (model string, err error) {
 	return i.rimpBlade.HSI.Spn, err
 }
 
-// BmcType returns the type of bmc we are talking to
-func (i *Ilo) BmcType() (bmcType string) {
+// HardwareType returns the type of bmc we are talking to
+func (i *Ilo) HardwareType() (bmcType string) {
 	switch i.rimpBlade.MP.Pn {
 	case "Integrated Lights-Out 2 (iLO 2)":
 		return Ilo2
@@ -264,8 +264,8 @@ func (i *Ilo) BmcType() (bmcType string) {
 	}
 }
 
-// BmcVersion returns the version of the bmc we are running
-func (i *Ilo) BmcVersion() (bmcVersion string, err error) {
+// Version returns the version of the bmc we are running
+func (i *Ilo) Version() (bmcVersion string, err error) {
 	return i.rimpBlade.MP.Fwri, err
 }
 
@@ -672,13 +672,13 @@ func (i *Ilo) ServerSnapshot() (server interface{}, err error) { // nolint: gocy
 		blade := &devices.Blade{}
 		blade.Vendor = i.Vendor()
 		blade.BmcAddress = i.ip
-		blade.BmcType = i.BmcType()
+		blade.BmcType = i.HardwareType()
 
 		blade.Serial, err = i.Serial()
 		if err != nil {
 			return nil, err
 		}
-		blade.BmcVersion, err = i.BmcVersion()
+		blade.BmcVersion, err = i.Version()
 		if err != nil {
 			return nil, err
 		}
@@ -743,13 +743,13 @@ func (i *Ilo) ServerSnapshot() (server interface{}, err error) { // nolint: gocy
 		discrete := &devices.Discrete{}
 		discrete.Vendor = i.Vendor()
 		discrete.BmcAddress = i.ip
-		discrete.BmcType = i.BmcType()
+		discrete.BmcType = i.HardwareType()
 
 		discrete.Serial, err = i.Serial()
 		if err != nil {
 			return nil, err
 		}
-		discrete.BmcVersion, err = i.BmcVersion()
+		discrete.BmcVersion, err = i.Version()
 		if err != nil {
 			return nil, err
 		}

--- a/providers/hp/ilo/ilo_test.go
+++ b/providers/hp/ilo/ilo_test.go
@@ -241,7 +241,7 @@ func TestIloBmcType(t *testing.T) {
 		t.Fatalf("Found errors during the test setup %v", err)
 	}
 
-	answer := bmc.BmcType()
+	answer := bmc.HardwareType()
 	if answer != expectedAnswer {
 		t.Errorf("Expected answer %v: found %v", expectedAnswer, answer)
 	}
@@ -257,9 +257,9 @@ func TestIloBmcVersion(t *testing.T) {
 		t.Fatalf("Found errors during the test setup %v", err)
 	}
 
-	answer, err := bmc.BmcVersion()
+	answer, err := bmc.Version()
 	if err != nil {
-		t.Fatalf("Found errors calling bmc.BmcVersion %v", err)
+		t.Fatalf("Found errors calling bmc.Version %v", err)
 	}
 
 	if answer != expectedAnswer {

--- a/providers/hp/ilo/query.go
+++ b/providers/hp/ilo/query.go
@@ -45,7 +45,7 @@ func (i *Ilo) Screenshot() (response []byte, extension string, err error) {
 	extension = "bmp"
 
 	// screen thumbnails are only available in ilo5.
-	if i.BmcType() != "ilo5" {
+	if i.HardwareType() != "ilo5" {
 		return response, extension, errors.ErrFeatureUnavailable
 	}
 
@@ -65,7 +65,7 @@ func (i *Ilo) queryDirectoryGroups() (directoryGroups []DirectoryGroups, err err
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"endpoint": endpoint,
 			"step":     helper.WhosCalling(),
 			"Error":    err,
@@ -80,7 +80,7 @@ func (i *Ilo) queryDirectoryGroups() (directoryGroups []DirectoryGroups, err err
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
 			"step":  helper.WhosCalling(),
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Error": err,
 		}).Warn("Unable to unmarshal payload.")
 		return directoryGroups, err
@@ -97,7 +97,7 @@ func (i *Ilo) queryUsers() (usersInfo []UserInfo, err error) {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"endpoint": endpoint,
 			"step":     helper.WhosCalling(),
 			"Error":    err,
@@ -113,7 +113,7 @@ func (i *Ilo) queryUsers() (usersInfo []UserInfo, err error) {
 			"step":     "queryUserInfo",
 			"resource": "User",
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"Error":    err,
 		}).Warn("Unable to unmarshal payload.")
 		return usersInfo, err
@@ -130,7 +130,7 @@ func (i *Ilo) queryNetworkSntp() (networkSntp NetworkSntp, err error) {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"endpoint": endpoint,
 			"step":     helper.WhosCalling(),
 			"Error":    err,
@@ -143,7 +143,7 @@ func (i *Ilo) queryNetworkSntp() (networkSntp NetworkSntp, err error) {
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
 			"step":  helper.WhosCalling(),
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Error": err,
 		}).Warn("Unable to unmarshal payload.")
 		return networkSntp, err
@@ -162,7 +162,7 @@ func (i *Ilo) queryAccessSettings() (AccessSettings, error) {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"endpoint": endpoint,
 			"step":     helper.WhosCalling(),
 			"Error":    err,
@@ -175,7 +175,7 @@ func (i *Ilo) queryAccessSettings() (AccessSettings, error) {
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
 			"step":  helper.WhosCalling(),
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Error": err,
 		}).Warn("Unable to unmarshal payload.")
 		return accessSettings, err
@@ -194,7 +194,7 @@ func (i *Ilo) queryNetworkIPv4() (NetworkIPv4, error) {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"IP":       i.ip,
-			"Model":    i.BmcType(),
+			"Model":    i.HardwareType(),
 			"endpoint": endpoint,
 			"step":     helper.WhosCalling(),
 			"Error":    err,
@@ -207,7 +207,7 @@ func (i *Ilo) queryNetworkIPv4() (NetworkIPv4, error) {
 		log.WithFields(log.Fields{
 			"IP":    i.ip,
 			"step":  helper.WhosCalling(),
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 			"Error": err,
 		}).Warn("Unable to unmarshal payload.")
 		return networkIPv4, err

--- a/providers/hp/ilo/setupConnection.go
+++ b/providers/hp/ilo/setupConnection.go
@@ -70,7 +70,7 @@ func (i *Ilo) httpLogin() (err error) {
 		log.WithFields(log.Fields{
 			"step":  "Login()",
 			"IP":    i.ip,
-			"Model": i.BmcType(),
+			"Model": i.HardwareType(),
 		}).Warn("Expected sessionKey cookie value not found.")
 	}
 

--- a/providers/supermicro/supermicrox10/configure.go
+++ b/providers/supermicro/supermicrox10/configure.go
@@ -105,7 +105,7 @@ func (s *SupermicroX10) User(users []*cfgresources.User) (err error) {
 		msg := "Unable to query current user accounts."
 		log.WithFields(log.Fields{
 			"IP":    s.ip,
-			"Model": s.BmcType(),
+			"Model": s.HardwareType(),
 			"Step":  helper.WhosCalling(),
 			"Error": err,
 		}).Warn(msg)
@@ -175,7 +175,7 @@ func (s *SupermicroX10) User(users []*cfgresources.User) (err error) {
 			msg := "POST request to set User config returned error."
 			log.WithFields(log.Fields{
 				"IP":         s.ip,
-				"Model":      s.BmcType(),
+				"Model":      s.HardwareType(),
 				"Endpoint":   endpoint,
 				"StatusCode": statusCode,
 				"Step":       helper.WhosCalling(),
@@ -186,7 +186,7 @@ func (s *SupermicroX10) User(users []*cfgresources.User) (err error) {
 
 		log.WithFields(log.Fields{
 			"IP":    s.ip,
-			"Model": s.BmcType(),
+			"Model": s.HardwareType(),
 			"User":  user.Name,
 		}).Debug("User parameters applied.")
 
@@ -232,7 +232,7 @@ func (s *SupermicroX10) Network(cfg *cfgresources.Network) (reset bool, err erro
 		msg := "POST request to set Port config returned error."
 		log.WithFields(log.Fields{
 			"IP":         s.ip,
-			"Model":      s.BmcType(),
+			"Model":      s.HardwareType(),
 			"Endpoint":   endpoint,
 			"StatusCode": statusCode,
 			"Step":       helper.WhosCalling(),
@@ -243,7 +243,7 @@ func (s *SupermicroX10) Network(cfg *cfgresources.Network) (reset bool, err erro
 
 	log.WithFields(log.Fields{
 		"IP":    s.ip,
-		"Model": s.BmcType(),
+		"Model": s.HardwareType(),
 	}).Debug("Network config parameters applied.")
 	return reset, err
 }
@@ -256,7 +256,7 @@ func (s *SupermicroX10) Ntp(cfg *cfgresources.Ntp) (err error) {
 	if cfg.Server1 == "" {
 		log.WithFields(log.Fields{
 			"step":  "applyNtpParams",
-			"Model": s.BmcType(),
+			"Model": s.HardwareType(),
 		}).Warn("NTP resource expects parameter: server1.")
 		return
 	}
@@ -264,7 +264,7 @@ func (s *SupermicroX10) Ntp(cfg *cfgresources.Ntp) (err error) {
 	if cfg.Timezone == "" {
 		log.WithFields(log.Fields{
 			"step":  "applyNtpParams",
-			"Model": s.BmcType(),
+			"Model": s.HardwareType(),
 		}).Warn("NTP resource expects parameter: timezone.")
 		return
 	}
@@ -273,7 +273,7 @@ func (s *SupermicroX10) Ntp(cfg *cfgresources.Ntp) (err error) {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"step":              "applyNtpParams",
-			"Model":             s.BmcType(),
+			"Model":             s.HardwareType(),
 			"Declared timezone": cfg.Timezone,
 			"Error":             err,
 		}).Warn("NTP resource declared parameter timezone invalid.")
@@ -285,7 +285,7 @@ func (s *SupermicroX10) Ntp(cfg *cfgresources.Ntp) (err error) {
 	if cfg.Enable != true {
 		log.WithFields(log.Fields{
 			"step":  "applyNtpParams",
-			"Model": s.BmcType(),
+			"Model": s.HardwareType(),
 		}).Debug("Ntp resource declared with enable: false.")
 		return
 	}
@@ -326,7 +326,7 @@ func (s *SupermicroX10) Ntp(cfg *cfgresources.Ntp) (err error) {
 		msg := "POST request to set Syslog config returned error."
 		log.WithFields(log.Fields{
 			"IP":         s.ip,
-			"Model":      s.BmcType(),
+			"Model":      s.HardwareType(),
 			"Endpoint":   endpoint,
 			"StatusCode": statusCode,
 			"Step":       helper.WhosCalling(),
@@ -338,7 +338,7 @@ func (s *SupermicroX10) Ntp(cfg *cfgresources.Ntp) (err error) {
 	//
 	log.WithFields(log.Fields{
 		"IP":    s.ip,
-		"Model": s.BmcType(),
+		"Model": s.HardwareType(),
 	}).Debug("NTP config parameters applied.")
 	return err
 }
@@ -363,7 +363,7 @@ func (s *SupermicroX10) LdapGroup(cfgGroup []*cfgresources.LdapGroup, cfgLdap *c
 		msg := "Ldap resource parameter Server required but not declared."
 		log.WithFields(log.Fields{
 			"step":  helper.WhosCalling(),
-			"Model": s.BmcType(),
+			"Model": s.HardwareType(),
 		}).Warn(msg)
 		return errors.New(msg)
 	}
@@ -373,7 +373,7 @@ func (s *SupermicroX10) LdapGroup(cfgGroup []*cfgresources.LdapGroup, cfgLdap *c
 		msg := "Ldap resource parameter Port required but not declared"
 		log.WithFields(log.Fields{
 			"step":  helper.WhosCalling(),
-			"Model": s.BmcType(),
+			"Model": s.HardwareType(),
 		}).Warn(msg)
 		return errors.New(msg)
 	}
@@ -381,7 +381,7 @@ func (s *SupermicroX10) LdapGroup(cfgGroup []*cfgresources.LdapGroup, cfgLdap *c
 	if cfgLdap.Enable != true {
 		log.WithFields(log.Fields{
 			"step":  helper.WhosCalling(),
-			"Model": s.BmcType(),
+			"Model": s.HardwareType(),
 		}).Debug("Ldap resource declared with enable: false.")
 		return
 	}
@@ -392,7 +392,7 @@ func (s *SupermicroX10) LdapGroup(cfgGroup []*cfgresources.LdapGroup, cfgLdap *c
 		msg := "Ldap resource parameter BaseDn required but not declared."
 		log.WithFields(log.Fields{
 			"step":  helper.WhosCalling(),
-			"Model": s.BmcType(),
+			"Model": s.HardwareType(),
 		}).Warn(msg)
 		return errors.New(msg)
 	}
@@ -402,7 +402,7 @@ func (s *SupermicroX10) LdapGroup(cfgGroup []*cfgresources.LdapGroup, cfgLdap *c
 		msg := "Unable to lookup the IP for ldap server hostname."
 		log.WithFields(log.Fields{
 			"step":  helper.WhosCalling(),
-			"Model": s.BmcType(),
+			"Model": s.HardwareType(),
 		}).Warn(msg)
 		return errors.New(msg)
 	}
@@ -474,7 +474,7 @@ func (s *SupermicroX10) LdapGroup(cfgGroup []*cfgresources.LdapGroup, cfgLdap *c
 			msg := "POST request to set Ldap config returned error."
 			log.WithFields(log.Fields{
 				"IP":         s.ip,
-				"Model":      s.BmcType(),
+				"Model":      s.HardwareType(),
 				"Endpoint":   endpoint,
 				"StatusCode": statusCode,
 				"Step":       helper.WhosCalling(),
@@ -486,7 +486,7 @@ func (s *SupermicroX10) LdapGroup(cfgGroup []*cfgresources.LdapGroup, cfgLdap *c
 
 	log.WithFields(log.Fields{
 		"IP":    s.ip,
-		"Model": s.BmcType(),
+		"Model": s.HardwareType(),
 	}).Debug("Ldap config parameters applied.")
 	return err
 }
@@ -501,7 +501,7 @@ func (s *SupermicroX10) Syslog(cfg *cfgresources.Syslog) (err error) {
 		msg := "Syslog resource expects parameter: Server."
 		log.WithFields(log.Fields{
 			"step":  helper.WhosCalling(),
-			"Model": s.BmcType(),
+			"Model": s.HardwareType(),
 		}).Warn(msg)
 		return errors.New(msg)
 	}
@@ -509,7 +509,7 @@ func (s *SupermicroX10) Syslog(cfg *cfgresources.Syslog) (err error) {
 	if cfg.Port == 0 {
 		log.WithFields(log.Fields{
 			"step":  helper.WhosCalling(),
-			"Model": s.BmcType(),
+			"Model": s.HardwareType(),
 		}).Debug("Syslog resource port set to default: 514.")
 		port = 514
 	} else {
@@ -519,7 +519,7 @@ func (s *SupermicroX10) Syslog(cfg *cfgresources.Syslog) (err error) {
 	if cfg.Enable != true {
 		log.WithFields(log.Fields{
 			"step":  helper.WhosCalling(),
-			"Model": s.BmcType(),
+			"Model": s.HardwareType(),
 		}).Debug("Syslog resource declared with disable.")
 	}
 
@@ -528,7 +528,7 @@ func (s *SupermicroX10) Syslog(cfg *cfgresources.Syslog) (err error) {
 		msg := "Unable to lookup IP for syslog server hostname, yes supermicros requires the Syslog server IP :|."
 		log.WithFields(log.Fields{
 			"step":  helper.WhosCalling(),
-			"Model": s.BmcType(),
+			"Model": s.HardwareType(),
 		}).Warn(msg)
 		return errors.New(msg)
 	}
@@ -547,7 +547,7 @@ func (s *SupermicroX10) Syslog(cfg *cfgresources.Syslog) (err error) {
 		msg := "POST request to set Syslog config returned error."
 		log.WithFields(log.Fields{
 			"IP":         s.ip,
-			"Model":      s.BmcType(),
+			"Model":      s.HardwareType(),
 			"Endpoint":   endpoint,
 			"StatusCode": statusCode,
 			"step":       helper.WhosCalling(),
@@ -559,7 +559,7 @@ func (s *SupermicroX10) Syslog(cfg *cfgresources.Syslog) (err error) {
 
 	log.WithFields(log.Fields{
 		"IP":    s.ip,
-		"Model": s.BmcType(),
+		"Model": s.HardwareType(),
 	}).Debug("Syslog config parameters applied.")
 	return err
 }
@@ -614,7 +614,7 @@ func (s *SupermicroX10) UploadHTTPSCert(cert []byte, certFileName string, key []
 	if err != nil || status != 200 {
 		log.WithFields(log.Fields{
 			"IP":         s.ip,
-			"Model":      s.BmcType(),
+			"Model":      s.HardwareType(),
 			"Endpoint":   endpoint,
 			"StatusCode": status,
 			"Step":       helper.WhosCalling(),
@@ -656,7 +656,7 @@ func (s *SupermicroX10) validateSSL() error {
 	if err != nil || status != 200 {
 		log.WithFields(log.Fields{
 			"IP":         s.ip,
-			"Model":      s.BmcType(),
+			"Model":      s.HardwareType(),
 			"Endpoint":   endpoint,
 			"StatusCode": status,
 			"Step":       helper.WhosCalling(),
@@ -681,7 +681,7 @@ func (s *SupermicroX10) statusSSL() error {
 	if err != nil || status != 200 {
 		log.WithFields(log.Fields{
 			"IP":         s.ip,
-			"Model":      s.BmcType(),
+			"Model":      s.HardwareType(),
 			"Endpoint":   endpoint,
 			"StatusCode": status,
 			"Step":       helper.WhosCalling(),

--- a/providers/supermicro/supermicrox10/query.go
+++ b/providers/supermicro/supermicrox10/query.go
@@ -45,7 +45,7 @@ func (s *SupermicroX10) Screenshot() (response []byte, extension string, err err
 	extension = "bmp"
 
 	// allow thumbnails only for supermicro x10s.
-	if s.BmcType() != "supermicrox10" {
+	if s.HardwareType() != "supermicrox10" {
 		return response, extension, errors.ErrFeatureUnavailable
 	}
 

--- a/providers/supermicro/supermicrox10/supermicrox10.go
+++ b/providers/supermicro/supermicrox10/supermicrox10.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	// BmcType defines the bmc model that is supported by this package
+	// HardwareType defines the bmc model that is supported by this package
 	BmcType = "supermicrox10"
 )
 
@@ -277,8 +277,8 @@ func (s *SupermicroX10) ChassisSerial() (serial string, err error) {
 	return strings.ToLower(strings.TrimSpace(ipmi.FruInfo.Chassis.SerialNum)), err
 }
 
-// BmcType returns just Model id string - supermicrox10
-func (s *SupermicroX10) BmcType() (model string) {
+// HardwareType returns just Model id string - supermicrox10
+func (s *SupermicroX10) HardwareType() (model string) {
 	return BmcType
 }
 
@@ -296,8 +296,8 @@ func (s *SupermicroX10) Model() (model string, err error) {
 	return model, err
 }
 
-// BmcVersion returns the version of the bmc we are running
-func (s *SupermicroX10) BmcVersion() (bmcVersion string, err error) {
+// Version returns the version of the bmc we are running
+func (s *SupermicroX10) Version() (bmcVersion string, err error) {
 	ipmi, err := s.query("GENERIC_INFO.XML=(0,0)")
 	if err != nil {
 		return bmcVersion, err
@@ -593,13 +593,13 @@ func (s *SupermicroX10) ServerSnapshot() (server interface{}, err error) {
 		blade := &devices.Blade{}
 		blade.Vendor = s.Vendor()
 		blade.BmcAddress = s.ip
-		blade.BmcType = s.BmcType()
+		blade.BmcType = s.HardwareType()
 
 		blade.Serial, err = s.Serial()
 		if err != nil {
 			return nil, err
 		}
-		blade.BmcVersion, err = s.BmcVersion()
+		blade.BmcVersion, err = s.Version()
 		if err != nil {
 			return nil, err
 		}
@@ -664,13 +664,13 @@ func (s *SupermicroX10) ServerSnapshot() (server interface{}, err error) {
 		discrete := &devices.Discrete{}
 		discrete.Vendor = s.Vendor()
 		discrete.BmcAddress = s.ip
-		discrete.BmcType = s.BmcType()
+		discrete.BmcType = s.HardwareType()
 
 		discrete.Serial, err = s.Serial()
 		if err != nil {
 			return nil, err
 		}
-		discrete.BmcVersion, err = s.BmcVersion()
+		discrete.BmcVersion, err = s.Version()
 		if err != nil {
 			return nil, err
 		}

--- a/providers/supermicro/supermicrox10/supermicrox10_test.go
+++ b/providers/supermicro/supermicrox10/supermicrox10_test.go
@@ -205,7 +205,7 @@ func TestBmcType(t *testing.T) {
 		t.Fatalf("Found errors during the test setup %v", err)
 	}
 
-	answer := bmc.BmcType()
+	answer := bmc.HardwareType()
 	if answer != expectedAnswer {
 		t.Errorf("Expected answer %v: found %v", expectedAnswer, answer)
 	}
@@ -221,9 +221,9 @@ func TestBmcVersion(t *testing.T) {
 		t.Fatalf("Found errors during the test setup %v", err)
 	}
 
-	answer, err := bmc.BmcVersion()
+	answer, err := bmc.Version()
 	if err != nil {
-		t.Fatalf("Found errors calling bmc.BmcVersion %v", err)
+		t.Fatalf("Found errors calling bmc.Version %v", err)
 	}
 
 	if answer != expectedAnswer {


### PR DESCRIPTION
We have the same set of functions for bmcs and cmcs, but they have different names. I'm making these names standard, so It becomes easy for tool to have generic interfaces for both.  