### PR TITLE
hp: ilo5 - fix user account exists validation

### DIFF
--- a/providers/hp/ilo/configure.go
+++ b/providers/hp/ilo/configure.go
@@ -65,7 +65,7 @@ func (i *Ilo) isRoleValid(role string) bool {
 func userExists(user string, usersInfo []UserInfo) (userInfo UserInfo, exists bool) {
 
 	for _, userInfo := range usersInfo {
-		if userInfo.UserName == user {
+		if userInfo.UserName == user || userInfo.LoginName == user {
 			return userInfo, true
 		}
 	}


### PR DESCRIPTION
As part of configuring the user we check if the user_name exists in the BMC,
if it does we POST the action 'mod_user', else we POST with the action 'add_user',
in this fix we check both the user_name, login_name and attempt to configure the account if
either the user_name, login_name match.

We came across an issue where the Administrator username was messed up in the BMC,
this prevented us from being able to make any changes when logged in as the Administrator user,
the account looked like,

{"id":-1145261390,"login_name":"Administrator","user_name":"\u0089d\u0085\u008f\u00a2\u0010\u001e\u000arator"