### PR TITLE
We now identify properly if a machine is part of a chassis, by comparing

### DIFF
--- a/providers/dell/idrac9/idrac9.go
+++ b/providers/dell/idrac9/idrac9.go
@@ -662,13 +662,18 @@ func (i *IDrac9) IsBlade() (isBlade bool, err error) {
 		return isBlade, err
 	}
 
-	model, err := i.Model()
+	serial, err := i.Serial()
 	if err != nil {
 		return isBlade, err
 	}
 
-	if strings.HasPrefix(model, "PowerEdge M") {
-		isBlade = true
+	chassisSerial, err := i.ChassisSerial()
+	if err != nil {
+		return isBlade, err
+	}
+
+	if serial != chassisSerial {
+		return true, err
 	}
 
 	return isBlade, err


### PR DESCRIPTION
the serial number of the node with the chassis. For all discrete servers
from Dell I've tested it is a realistic statement