### PR TITLE
internal/sshclient: Include keyboard-interactive as an auth method

### DIFF
--- a/internal/sshclient/sshclient.go
+++ b/internal/sshclient/sshclient.go
@@ -77,7 +77,12 @@ func New(host string, username string, password string) (connection *SSHClient, 
 		host,
 		&ssh.ClientConfig{
 			User: username,
-			Auth: []ssh.AuthMethod{ssh.Password(password)},
+			Auth: []ssh.AuthMethod{
+				ssh.Password(password),
+				ssh.KeyboardInteractive(func(user, instruction string, questions []string, echos []bool) ([]string, error) {
+					return []string{}, nil
+				}),
+			},
 			HostKeyCallback: func(hostname string, remote net.Addr, key ssh.PublicKey) error {
 				return nil
 			},


### PR DESCRIPTION
The dell m640s since the new 4.00.00.00 idrac9 release send an empty
challenge once the password has been sent, with change we support the
newer release.