### PR TITLE
hpe: Add power regulator configuration support

### DIFF
--- a/cfgresources/cfgresources.go
+++ b/cfgresources/cfgresources.go
@@ -23,8 +23,14 @@ type ResourcesConfig struct {
 	HTTPSCert    *HTTPSCert    `yaml:"httpsCert"`
 	Ntp          *Ntp          `yaml:"ntp"`
 	Bios         *Bios         `yaml:"bios"`
+	Power        *Power        `yaml:"power"`
 	Supermicro   *Supermicro   `yaml:"supermicro"` //supermicro specific config, example of issue #34
 	SetupChassis *SetupChassis `yaml:"setupChassis"`
+}
+
+// Power struct holds Power settings configuration for each vendor.
+type Power struct {
+	HPE *HPE `yaml:"hpe"`
 }
 
 // Bios struct holds bios configuration for each vendor.

--- a/cfgresources/hp.go
+++ b/cfgresources/hp.go
@@ -1,0 +1,10 @@
+package cfgresources
+
+// HPE struct holds configuration parameters for HPE assets.
+type HPE struct {
+	// static_high
+	// static_low
+	// dynamic
+	// os_control - note this requires the machine to be rebooted
+	PowerRegulator string `yaml:"regulator"`
+}

--- a/devices/interfaces.go
+++ b/devices/interfaces.go
@@ -128,6 +128,7 @@ type Configure interface {
 	Network(*cfgresources.Network) (bool, error)
 	SetLicense(*cfgresources.License) error
 	Bios(*cfgresources.Bios) error
+	Power(*cfgresources.Power) error
 	CurrentHTTPSCert() ([]*x509.Certificate, bool, error)
 	GenerateCSR(*cfgresources.HTTPSCertAttributes) ([]byte, error)
 	UploadHTTPSCert([]byte, string, []byte, string) (bool, error)

--- a/providers/dell/idrac8/configure.go
+++ b/providers/dell/idrac8/configure.go
@@ -35,6 +35,11 @@ func (i *IDrac8) Resources() []string {
 	}
 }
 
+// Power implemented the Configure interface
+func (i *IDrac8) Power(cfg *cfgresources.Power) error {
+	return nil
+}
+
 // SetLicense implements the Configure interface.
 func (i *IDrac8) SetLicense(cfg *cfgresources.License) (err error) {
 	return err

--- a/providers/dell/idrac9/configure.go
+++ b/providers/dell/idrac9/configure.go
@@ -41,6 +41,11 @@ func (i *IDrac9) ApplyCfg(config *cfgresources.ResourcesConfig) (err error) {
 	return err
 }
 
+// Power implemented the Configure interface
+func (i *IDrac9) Power(cfg *cfgresources.Power) (err error) {
+	return err
+}
+
 // Bios sets up Bios configuration
 // Bios implements the Configure interface
 func (i *IDrac9) Bios(cfg *cfgresources.Bios) (err error) {

--- a/providers/dell/m1000e/configure.go
+++ b/providers/dell/m1000e/configure.go
@@ -53,6 +53,11 @@ func (m *M1000e) ApplyCfg(config *cfgresources.ResourcesConfig) (err error) {
 	return err
 }
 
+// Power implemented the Configure interface
+func (m *M1000e) Power(cfg *cfgresources.Power) (err error) {
+	return err
+}
+
 // SetLicense implements the Configure interface.
 func (m *M1000e) SetLicense(cfg *cfgresources.License) (err error) {
 	return err

--- a/providers/dummy/ibmc/configure.go
+++ b/providers/dummy/ibmc/configure.go
@@ -19,6 +19,11 @@ func (i *Ibmc) Resources() []string {
 	}
 }
 
+// Power implemented the Configure interface
+func (i *Ibmc) Power(cfg *cfgresources.Power) (err error) {
+	return err
+}
+
 // User method implements the Configure interface
 func (i *Ibmc) User(cfg []*cfgresources.User) error {
 	return nil

--- a/providers/hp/c7000/configure.go
+++ b/providers/hp/c7000/configure.go
@@ -57,6 +57,11 @@ func (c *C7000) ApplyCfg(config *cfgresources.ResourcesConfig) (err error) {
 	return nil
 }
 
+// Power implemented the Configure interface
+func (c *C7000) Power(cfg *cfgresources.Power) (err error) {
+	return err
+}
+
 // Ldap applies LDAP configuration params.
 // Ldap implements the Configure interface.
 //1. apply ldap group params

--- a/providers/hp/ilo/helpers.go
+++ b/providers/hp/ilo/helpers.go
@@ -6,8 +6,35 @@ import (
 	"github.com/bmc-toolbox/bmclib/cfgresources"
 )
 
+// cmdPowerSettings
+func (i *Ilo) cmpPowerSettings(regulatorMode string) (PowerRegulator, bool, error) {
+
+	// get current config
+	currentConfig, err := i.queryPowerRegulator()
+	if err != nil {
+		return PowerRegulator{}, false, fmt.Errorf("Unable to query existing Power regulator config")
+
+	}
+
+	settingsMatch := func() bool {
+		if currentConfig.PowerMode != regulatorMode {
+			return false
+		}
+
+		return true
+	}
+
+	if settingsMatch() {
+		return PowerRegulator{}, false, nil
+	}
+
+	// configuration update required.
+	return currentConfig, true, nil
+
+}
+
 // compares the current Network IPv4 config with the given Network configuration
-func (i Ilo) cmpNetworkIPv4Settings(cfg *cfgresources.Network) (NetworkIPv4, bool, error) {
+func (i *Ilo) cmpNetworkIPv4Settings(cfg *cfgresources.Network) (NetworkIPv4, bool, error) {
 
 	// setup some params as int for comparison
 	var dnsFromDHCP, dhcpEnable, ddnsEnable int

--- a/providers/hp/ilo/model.go
+++ b/providers/hp/ilo/model.go
@@ -208,6 +208,13 @@ type ipv4 struct {
 	Ipv4IP string `json:"ipv4_ip"`
 }
 
+// PowerRegulator declares json payload to set power regulator mode
+type PowerRegulator struct {
+	PowerMode  string `json:"prmode"`
+	SessionKey string `json:"session_key"`
+	Method     string `json:"method"`
+}
+
 // TimezonesIlo5 declares valid timezone for ilo5 devices.
 var TimezonesIlo5 = map[string]int{
 	"Etc/GMT+12":                     0,

--- a/providers/hp/ilo/query.go
+++ b/providers/hp/ilo/query.go
@@ -215,3 +215,35 @@ func (i *Ilo) queryNetworkIPv4() (NetworkIPv4, error) {
 
 	return networkIPv4, err
 }
+
+func (i *Ilo) queryPowerRegulator() (PowerRegulator, error) {
+
+	endpoint := "json/power_regulator"
+
+	var powerRegulator PowerRegulator
+
+	payload, err := i.get(endpoint)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"IP":       i.ip,
+			"Model":    i.HardwareType(),
+			"endpoint": endpoint,
+			"step":     helper.WhosCalling(),
+			"Error":    err,
+		}).Warn("GET request failed.")
+		return PowerRegulator{}, err
+	}
+
+	err = json.Unmarshal(payload, &powerRegulator)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"IP":    i.ip,
+			"step":  helper.WhosCalling(),
+			"Model": i.HardwareType(),
+			"Error": err,
+		}).Warn("Unable to unmarshal payload.")
+		return PowerRegulator{}, err
+	}
+
+	return powerRegulator, err
+}

--- a/providers/supermicro/supermicrox/configure.go
+++ b/providers/supermicro/supermicrox/configure.go
@@ -44,6 +44,11 @@ func (s *SupermicroX) ApplyCfg(config *cfgresources.ResourcesConfig) (err error)
 	return err
 }
 
+// Power implemented the Configure interface
+func (s *SupermicroX) Power(cfg *cfgresources.Power) (err error) {
+	return err
+}
+
 // SetLicense implements the Configure interface.
 func (s *SupermicroX) SetLicense(cfg *cfgresources.License) (err error) {
 	return err


### PR DESCRIPTION
Implement a method of apply power regulator configuration for HPE Gen 8,9,10 - iLO4, iLO5
    
The configuration that can be used here is,
```
    power:
      hpe:
        regulator: static_high
```    
Where the valid parameters to regulator is one of,
``` 
- static_high
- dynamic
- static_low
- os_control
```
