### PR TITLE
Streamline the IsOn() method

### DIFF
--- a/providers/dell/idrac8/actions.go
+++ b/providers/dell/idrac8/actions.go
@@ -115,8 +115,13 @@ func (i *IDrac8) IsOn() (status bool, err error) {
 	if err != nil {
 		return false, fmt.Errorf("%v: %v", err, output)
 	}
+
 	if strings.Contains(output, "Server power status: ON") {
-		return true, err
+		return true, nil
+	}
+
+	if strings.Contains(output, "Server power status: OFF") {
+		return false, nil
 	}
 
 	return status, fmt.Errorf(output)

--- a/providers/dell/idrac9/actions.go
+++ b/providers/dell/idrac9/actions.go
@@ -115,8 +115,13 @@ func (i *IDrac9) IsOn() (status bool, err error) {
 	if err != nil {
 		return false, fmt.Errorf("%v: %v", err, output)
 	}
+
 	if strings.Contains(output, "Server power status: ON") {
-		return true, err
+		return true, nil
+	}
+
+	if strings.Contains(output, "Server power status: OFF") {
+		return false, nil
 	}
 
 	return status, fmt.Errorf(output)

--- a/providers/hp/ilo/actions.go
+++ b/providers/hp/ilo/actions.go
@@ -117,9 +117,15 @@ func (i *Ilo) IsOn() (status bool, err error) {
 	if err != nil {
 		return false, fmt.Errorf("%v: %v", err, output)
 	}
+
 	if strings.Contains(output, "currently: On") {
-		return true, err
+		return true, nil
 	}
+
+	if strings.Contains(output, "currently: Off") {
+		return true, nil
+	}
+
 	return status, fmt.Errorf(output)
 }
 


### PR DESCRIPTION
This fixes the IsOn() method to return false if the host is powered off,
the previous implementation would return an error if the host is powered
off.