### PR TITLE
PSM-2320 Fix a race condition in tests

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -8,34 +8,45 @@ import (
 var (
 	// ErrLoginFailed is returned when we fail to login to a bmc
 	ErrLoginFailed = errors.New("failed to login")
+
 	// ErrBiosNotFound is returned when we are not able to find the server bios version
 	ErrBiosNotFound = errors.New("bios version not found")
+
 	// ErrVendorUnknown is returned when we are unable to identify the redfish vendor
 	ErrVendorUnknown = errors.New("unable to identify the vendor")
+
 	// ErrInvalidSerial is returned when the serial number for the device is invalid
 	ErrInvalidSerial = errors.New("unable to find the serial number")
+
 	// ErrPageNotFound is used to inform the http request that we couldn't find the expected page and/or endpoint
 	ErrPageNotFound = errors.New("requested page couldn't be found in the server")
+
 	// ErrRedFishNotSupported is returned when redfish isn't supported by the vendor
 	ErrRedFishNotSupported = errors.New("redfish not supported")
+
 	// ErrUnableToReadData is returned when we fail to read data from a chassis or bmc
 	ErrUnableToReadData = errors.New("unable to read data from this device")
+
 	// ErrVendorNotSupported is returned when we are able to identify a vendor but we won't support it
 	ErrVendorNotSupported = errors.New("vendor not supported")
+
 	// ErrUnableToGetSessionToken is returned when we are unable to retrieve ST2 which is required to set configuration parameters
 	ErrUnableToGetSessionToken = errors.New("unable to get ST2 session token")
+
 	// Err500 is returned when we receive a 500 response from an endpoint.
 	Err500 = errors.New("we've received 500 calling this endpoint")
+
 	// ErrNotImplemented is returned for not implemented methods called
 	ErrNotImplemented = errors.New("this feature hasn't been implemented yet")
+
 	// ErrFeatureUnavailable is returned for features not available/supported.
 	ErrFeatureUnavailable = errors.New("this feature isn't supported/available for this hardware")
 
 	// ErrIdracMaxSessionsReached indicates the bmc has reached the max number of login sessions.
-	ErrIdracMaxSessionsReached = errors.New("The maximum number of user sessions is reached")
+	ErrIdracMaxSessionsReached = errors.New("the maximum number of user sessions is reached")
 
 	// Err401Redfish indicates auth failure
-	Err401Redfish = errors.New("Redfish authorization failed")
+	Err401Redfish = errors.New("redfish authorization failed")
 
 	// ErrDeviceNotMatched is the error returned when the device was not a type it was probed for
 	ErrDeviceNotMatched = errors.New("the vendor device did not match the probe")

--- a/providers/dell/idrac8/actions_test.go
+++ b/providers/dell/idrac8/actions_test.go
@@ -6,8 +6,12 @@ import (
 	"github.com/bmc-toolbox/bmclib/sshmock"
 )
 
+const (
+	sshUsername = "super"
+	sshPassword = "test"
+)
+
 var (
-	sshServer  *sshmock.Server
 	sshAnswers = map[string][]byte{
 		"racadm serveraction hardreset": []byte(`Server power operation successful`),
 		"racadm racreset hard": []byte(`RAC reset operation initiated successfully. It may take a few
@@ -39,144 +43,87 @@ var (
 	}
 )
 
-func setupSSH() (bmc *IDrac8, err error) {
-	username := "super"
-	password := "test"
-
-	sshServer, err = sshmock.New(sshAnswers, true)
+func setupBMC() (func(), *IDrac8, error) {
+	ssh, err := sshmock.New(sshAnswers)
 	if err != nil {
-		return bmc, err
+		return nil, nil, err
 	}
-	address := sshServer.Address()
-
-	bmc, err = New(address, username, password)
+	tearDown, address, err := ssh.ListenAndServe()
 	if err != nil {
-		return bmc, err
+		return nil, nil, err
 	}
 
-	return bmc, err
+	bmc, err := New(address, sshUsername, sshPassword)
+	if err != nil {
+		tearDown()
+		return nil, nil, err
+	}
+
+	return tearDown, bmc, err
 }
 
-func tearDownSSH() {
-	sshServer.Close()
-}
-
-func TestIDracPowerCycle(t *testing.T) {
-	expectedAnswer := true
-
-	bmc, err := setupSSH()
+func Test_IDrac8(t *testing.T) {
+	tearDown, bmc, err := setupBMC()
 	if err != nil {
-		t.Fatalf("Found errors during the test setup %v", err)
+		t.Fatalf("failed to setup BMC: %v", err)
+	}
+	defer tearDown()
+
+	tests := []struct {
+		name      string
+		bmcMethod func() (bool, error)
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name:      "PowerCycle",
+			bmcMethod: bmc.PowerCycle,
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "PowerCycleBmc",
+			bmcMethod: bmc.PowerCycleBmc,
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "PowerOn",
+			bmcMethod: bmc.PowerOn,
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "PowerOff",
+			bmcMethod: bmc.PowerOff,
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "PxeOnce",
+			bmcMethod: bmc.PxeOnce,
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "IsOn",
+			bmcMethod: bmc.IsOn,
+			want:      true,
+			wantErr:   false,
+		},
 	}
 
-	answer, err := bmc.PowerCycle()
-	if err != nil {
-		t.Fatalf("Found errors calling bmc.PowerCycle %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.bmcMethod()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("got = %v, want %v", got, tt.want)
+			}
+		})
 	}
-
-	if answer != expectedAnswer {
-		t.Errorf("Expected answer %v: found %v", expectedAnswer, answer)
-	}
-
-	tearDownSSH()
-}
-
-func TestIDracPowerCycleBmc(t *testing.T) {
-	expectedAnswer := true
-
-	bmc, err := setupSSH()
-	if err != nil {
-		t.Fatalf("Found errors during the test setup %v", err)
-	}
-
-	answer, err := bmc.PowerCycleBmc()
-	if err != nil {
-		t.Fatalf("Found errors calling bmc.PowerCycleBmc %v", err)
-	}
-
-	if answer != expectedAnswer {
-		t.Errorf("Expected answer %v: found %v", expectedAnswer, answer)
-	}
-
-	tearDownSSH()
-}
-
-func TestIDracPowerOn(t *testing.T) {
-	expectedAnswer := true
-
-	bmc, err := setupSSH()
-	if err != nil {
-		t.Fatalf("Found errors during the test setup %v", err)
-	}
-
-	answer, err := bmc.PowerOn()
-	if err != nil {
-		t.Fatalf("Found errors calling bmc.PowerOn %v", err)
-	}
-
-	if answer != expectedAnswer {
-		t.Errorf("Expected answer %v: found %v", expectedAnswer, answer)
-	}
-
-	tearDownSSH()
-}
-
-func TestIDracPowerOff(t *testing.T) {
-	expectedAnswer := true
-
-	bmc, err := setupSSH()
-	if err != nil {
-		t.Fatalf("Found errors during the test setup %v", err)
-	}
-
-	answer, err := bmc.PowerOff()
-	if err != nil {
-		t.Fatalf("Found errors calling bmc.PowerOff %v", err)
-	}
-
-	if answer != expectedAnswer {
-		t.Errorf("Expected answer %v: found %v", expectedAnswer, answer)
-	}
-
-	tearDownSSH()
-}
-
-func TestIDracPxeOnce(t *testing.T) {
-	expectedAnswer := true
-
-	bmc, err := setupSSH()
-	if err != nil {
-		t.Fatalf("Found errors during the test setup %v", err)
-	}
-
-	answer, err := bmc.PxeOnce()
-	if err != nil {
-		t.Fatalf("Found errors calling bmc.PxeOnce %v", err)
-	}
-
-	if answer != expectedAnswer {
-		t.Errorf("Expected answer %v: found %v", expectedAnswer, answer)
-	}
-
-	tearDownSSH()
-}
-
-func TestIDracIsOn(t *testing.T) {
-	expectedAnswer := true
-
-	bmc, err := setupSSH()
-	if err != nil {
-		t.Fatalf("Found errors during the test setup %v", err)
-	}
-
-	answer, err := bmc.IsOn()
-	if err != nil {
-		t.Fatalf("Found errors calling bmc.IsOn %v", err)
-	}
-
-	if answer != expectedAnswer {
-		t.Errorf("Expected answer %v: found %v", expectedAnswer, answer)
-	}
-
-	tearDownSSH()
 }

--- a/providers/hp/c7000/actions.go
+++ b/providers/hp/c7000/actions.go
@@ -29,12 +29,12 @@ func (c *C7000) PowerCycle() (status bool, err error) {
 
 // PowerOn power on the chassis
 func (c *C7000) PowerOn() (status bool, err error) {
-	return status, fmt.Errorf("Unsupported action")
+	return status, errors.ErrFeatureUnavailable
 }
 
 // PowerOff power off the chassis
 func (c *C7000) PowerOff() (status bool, err error) {
-	return status, fmt.Errorf("Unsupported action")
+	return status, errors.ErrFeatureUnavailable
 }
 
 // IsOn tells if a machine is currently powered on
@@ -62,7 +62,7 @@ func (c *C7000) FindBladePosition(serial string) (position int, err error) {
 		return position, err
 	}
 
-	for _, line := range strings.Split(string(output), "\n") {
+	for _, line := range strings.Split(output, "\n") {
 		line = strings.Replace(line, "Server-", "", -1)
 		data := strings.FieldsFunc(line, sshclient.IsntLetterOrNumber)
 		for _, field := range data {
@@ -382,11 +382,11 @@ end_marker`
 
 // SetFlexAddressState Enable/Disable FlexAddress disables flex Addresses for blades
 // FlexAddress is a virtual addressing scheme
-func (c *C7000) SetFlexAddressState(position int, enable bool) (status bool, err error) {
+func (c *C7000) SetFlexAddressState(_ int, _ bool) (status bool, err error) {
 	return status, errors.ErrNotImplemented
 }
 
 // SetIpmiOverLan Enable/Disable IPMI over lan parameter per blade in chassis
-func (c *C7000) SetIpmiOverLan(position int, enable bool) (status bool, err error) {
+func (c *C7000) SetIpmiOverLan(_ int, _ bool) (status bool, err error) {
 	return status, errors.ErrNotImplemented
 }

--- a/sshmock/sshmock_test.go
+++ b/sshmock/sshmock_test.go
@@ -6,16 +6,20 @@ import (
 	"github.com/bmc-toolbox/bmclib/internal/sshclient"
 )
 
-func TestServer(t *testing.T) {
-	expectedAnswer := `world`
+func Test_Server(t *testing.T) {
+	expectedAnswer := "world"
 	command := "hello"
 	answers := map[string][]byte{command: []byte(expectedAnswer)}
 
-	s, err := New(answers, true)
+	s, err := New(answers)
 	if err != nil {
-		t.Fatalf("found errors during setup Server %s", err.Error())
+		t.Fatalf(err.Error())
 	}
-	address := s.Address()
+	shutdown, address, err := s.ListenAndServe()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer shutdown()
 
 	sshClient, err := sshclient.New(address, "super", "test")
 	if err != nil {
@@ -29,10 +33,5 @@ func TestServer(t *testing.T) {
 
 	if answer != expectedAnswer {
 		t.Errorf("Expected answer %v: found %v", expectedAnswer, answer)
-	}
-
-	err = s.Close()
-	if err != nil {
-		t.Fatalf("unable to close the ssh server %s", err.Error())
 	}
 }


### PR DESCRIPTION
This changes fixes a race condition in tests

Steps to reproduce
```
➜  bmclib git:(master) ✗ go test -count=1 -mod=vendor ./...
?       github.com/bmc-toolbox/bmclib   [no test files]
?       github.com/bmc-toolbox/bmclib/cfgresources      [no test files]
?       github.com/bmc-toolbox/bmclib/devices   [no test files]
ok      github.com/bmc-toolbox/bmclib/discover  0.648s
?       github.com/bmc-toolbox/bmclib/errors    [no test files]
ok      github.com/bmc-toolbox/bmclib/internal/helper   0.227s
?       github.com/bmc-toolbox/bmclib/internal/httpclient       [no test files]
?       github.com/bmc-toolbox/bmclib/internal/ipmi     [no test files]
?       github.com/bmc-toolbox/bmclib/internal/sshclient        [no test files]
?       github.com/bmc-toolbox/bmclib/logging   [no test files]
?       github.com/bmc-toolbox/bmclib/providers/dell    [no test files]
2020/04/17 15:39:06 Failed to listen on 127.0.0.1:15589 (listen tcp 127.0.0.1:15589: bind: address already in use)
FAIL    github.com/bmc-toolbox/bmclib/providers/dell/idrac8     1.190s
2020/04/17 15:39:05 Failed to listen on 127.0.0.1:15589 (listen tcp 127.0.0.1:15589: bind: address already in use)
FAIL    github.com/bmc-toolbox/bmclib/providers/dell/idrac9     0.937s
2020/04/17 15:39:06 Failed to listen on 127.0.0.1:4324 (listen tcp 127.0.0.1:4324: bind: address already in use)
FAIL    github.com/bmc-toolbox/bmclib/providers/dell/m1000e     1.561s
?       github.com/bmc-toolbox/bmclib/providers/dummy   [no test files]
ok      github.com/bmc-toolbox/bmclib/providers/dummy/ibmc      0.140s
?       github.com/bmc-toolbox/bmclib/providers/hp      [no test files]
ok      github.com/bmc-toolbox/bmclib/providers/hp/c7000        2.404s
ok      github.com/bmc-toolbox/bmclib/providers/hp/ilo  1.647s
?       github.com/bmc-toolbox/bmclib/providers/supermicro      [no test files]
ok      github.com/bmc-toolbox/bmclib/providers/supermicro/supermicrox  0.811s
ok      github.com/bmc-toolbox/bmclib/sshmock   0.330s
FAIL
➜  bmclib git:(master) ✗
```