### PR TITLE
discover: optional hint for probing

### DIFF
--- a/discover/discover.go
+++ b/discover/discover.go
@@ -3,18 +3,45 @@ package discover
 import (
 	"os"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/bmc-toolbox/bmclib/errors"
 	"github.com/bmc-toolbox/bmclib/internal/httpclient"
+	_ "github.com/bmc-toolbox/bmclib/logging" // this make possible to setup logging and properties at any stage
 	"github.com/bmc-toolbox/bmclib/providers/dummy/ibmc"
-
-	// this make possible to setup logging and properties at any stage
-	_ "github.com/bmc-toolbox/bmclib/logging"
-	log "github.com/sirupsen/logrus"
 )
 
-// ScanAndConnect will scan the bmc trying to learn the device type and return a working connection
-func ScanAndConnect(host string, username string, password string) (bmcConnection interface{}, err error) {
+type Options struct {
+	// Hint is an opaque integer that hints which probe should be probed first.
+	Hint int
+
+	// HintCallBack is a function that is called back with an opaque hint that might be used
+	// for the next ScanAndConnect attempt.  The callback is called only on successful scan.
+	// If your code persists the hint as "best effort", always return a nil error.  Callback is
+	// synchronous.
+	HintCallback func(int) error
+}
+
+// Option is part of the functional options pattern, see the `With*` functions and
+// https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
+type Option func(*Options)
+
+// WithProbeHint sets the Options.Hint option.
+func WithProbeHint(hint int) Option { return func(args *Options) { args.Hint = hint } }
+
+// WithHintCallBack sets the Options.HintCallback option.
+func WithHintCallBack(fn func(int) error) Option {
+	return func(args *Options) { args.HintCallback = fn }
+}
+
+// ScanAndConnect will scan the bmc trying to learn the device type and return a working connection.
+func ScanAndConnect(host string, username string, password string, options ...Option) (bmcConnection interface{}, err error) {
 	log.WithFields(log.Fields{"step": "ScanAndConnect", "host": host}).Debug("detecting vendor")
+
+	opts := &Options{Hint: 0, HintCallback: func(_ int) error { return nil }}
+	for _, optFn := range options {
+		optFn(opts)
+	}
 
 	// return a connection to our dummy device.
 	if os.Getenv("BMCLIB_TEST") == "1" {
@@ -25,7 +52,7 @@ func ScanAndConnect(host string, username string, password string) (bmcConnectio
 
 	client, err := httpclient.Build()
 	if err != nil {
-		return bmcConnection, err
+		return nil, err
 	}
 
 	var probe = Probe{client: client, username: username, password: password, host: host}
@@ -40,8 +67,15 @@ func ScanAndConnect(host string, username string, password string) (bmcConnectio
 		probe.hpCl100,
 	}
 
-	for _, probeDevice := range devices {
+	// Check if probe hint is in bounds, revert to default if not.  Code below relies on this.
+	if opts.Hint < 0 || opts.Hint >= len(devices) {
+		opts.Hint = 0
+	}
 
+	// Swap the hinted probe with the first probe. Relies on bounds check above.
+	devices[0], devices[opts.Hint] = devices[opts.Hint], devices[0]
+
+	for i, probeDevice := range devices {
 		log.WithFields(log.Fields{"step": "ScanAndConnect", "host": host}).Debug("probing to identify device")
 
 		bmcConnection, err := probeDevice()
@@ -53,13 +87,28 @@ func ScanAndConnect(host string, username string, password string) (bmcConnectio
 
 		// at this point it could be a connection error or a errors.ErrUnsupportedHardware
 		if err != nil {
-			return bmcConnection, err
+			return nil, err
+		}
+
+		// Success.  Figure out which probe it was.  We need to do some reconstruction
+		// because of the swapping above.  Relies on bounds check above.
+		var hint int
+		switch i {
+		case 0:
+			hint = opts.Hint
+		case opts.Hint:
+			hint = 0
+		default:
+			hint = i
+		}
+
+		if err := opts.HintCallback(hint); err != nil {
+			return nil, err
 		}
 
 		// return a bmcConnection
-		return bmcConnection, err
-
+		return bmcConnection, nil
 	}
 
-	return bmcConnection, errors.ErrVendorUnknown
+	return nil, errors.ErrVendorUnknown
 }


### PR DESCRIPTION
Add an functional option that parametrizes and retrieves per callback an opaque hint for the most recent successful probe to use.  That hint is a simple `int` that indexes into the static slice of probe functions.  The probe indices are implementation detail and thus the `int` is opaque.  If the a persisted hint gets out of sync with the implementation or if the machine behind the coordinate that is probed changes to a different model, the hinting either just makes the probing sub-optimal (hint to a non-matching probe) or reverts to default behaviour (hint out of bounds).

The functional option pattern is used in order to keep the default behaviour (no hinting) simple and to keep the published function signature of `discover.ScanAndCoonect()` backwards compatible.