### PR TITLE
Fix a bug with managing the users on m1000e chassis

### DIFF
--- a/providers/dell/m1000e/configure.go
+++ b/providers/dell/m1000e/configure.go
@@ -83,8 +83,7 @@ func (m *M1000e) User(cfgUsers []*cfgresources.User) (err error) {
 		return err
 	}
 
-	id := 1
-	for _, cfgUser := range cfgUsers {
+	for id, cfgUser := range cfgUsers {
 
 		userID := id + 1
 		//setup params to post


### PR DESCRIPTION
We were writing all the users to id=2 and the last write wins.