### PR TITLE
replace single fmt.Println with logger

### DIFF
--- a/providers/supermicro/supermicrox/configure.go
+++ b/providers/supermicro/supermicrox/configure.go
@@ -83,7 +83,7 @@ func (s *SupermicroX) queryUserAccounts() (userAccounts map[string]int, err erro
 	userAccounts = make(map[string]int)
 	ipmi, err := s.query("CONFIG_INFO.XML=(0,0)")
 	if err != nil {
-		fmt.Println(err)
+		s.log.V(1).Info("error querying user accounts", "error", err.Error())
 		return userAccounts, err
 	}
 


### PR DESCRIPTION
There is a single fmt.Println in the supermicro implementation
that affects structured logs for clients. This PR replaces that with a logged line.