### PR TITLE
Fix concurrent map writes error

### DIFF
--- a/discover/discovery_test.go
+++ b/discover/discovery_test.go
@@ -16,10 +16,14 @@ import (
 	"github.com/spf13/viper"
 )
 
+func init() {
+	if viper.GetBool("debug") != true {
+		viper.SetDefault("debug", true)
+	}
+}
+
 // setup creates a test server and returns a curried ScanAndConnect() function and a teardown func.
 func setup(answers map[string][]byte) (scanAndConnectCurry func(opts ...Option) (bmc interface{}, err error), cancel func()) {
-	viper.SetDefault("debug", true)
-
 	mux := http.NewServeMux()
 	server := httptest.NewTLSServer(mux)
 	ip := strings.TrimPrefix(server.URL, "https://")


### PR DESCRIPTION
I ran into this error while running `go test ./...` -> `fatal error: concurrent map writes`
Calling `viper.SetDefault` in multiple tests happening in parallel seems to be the root. Checking if the value is set before calling `SetDefault` fixes the problem. `go test ./...` will be successful now.

