### PR TITLE
Fix all tests and linting errors

### DIFF
--- a/discover/discovery_test.go
+++ b/discover/discovery_test.go
@@ -34,7 +34,7 @@ func setup(answers map[string][]byte) (scanAndConnectCurry func(opts ...Option) 
 		url := url
 
 		mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
-			w.Write(answers[url])
+			_, _ = w.Write(answers[url])
 		})
 	}
 

--- a/discover/discovery_test.go
+++ b/discover/discovery_test.go
@@ -141,8 +141,11 @@ var (
 	}
 
 	_answers = map[string]map[string][]byte{
-		"IDrac8":      {"/session": []byte(`{"aimGetProp" : {"hostname" :"machine","gui_str_title_bar" :"","OEMHostName" :"machine.example.com","fwVersion" :"2.50.33","sysDesc" :"PowerEdge M630","status" : "OK"}}`)},
-		"IDrac9":      {"/sysmgmt/2015/bmc/info": []byte(`{"Attributes":{"ADEnabled":"Disabled","BuildVersion":"37","FwVer":"3.15.15.15","GUITitleBar":"spare-H16Z4M2","IsOEMBranded":"0","License":"Enterprise","SSOEnabled":"Disabled","SecurityPolicyMessage":"By accessing this computer, you confirm that such access complies with your organization's security policy.","ServerGen":"14G","SrvPrcName":"NULL","SystemLockdown":"Disabled","SystemModelName":"PowerEdge M640","TFAEnabled":"Disabled","iDRACName":"spare-H16Z4M2"}}`)},
+		"IDrac8": {"/session": []byte(`{"aimGetProp" : {"hostname" :"machine","gui_str_title_bar" :"","OEMHostName" :"machine.example.com","fwVersion" :"2.50.33","sysDesc" :"PowerEdge M630","status" : "OK"}}`)},
+		"IDrac9": {
+			"/sysmgmt/2015/bmc/info":    []byte(`{"Attributes":{"ADEnabled":"Disabled","BuildVersion":"37","FwVer":"3.15.15.15","GUITitleBar":"spare-H16Z4M2","IsOEMBranded":"0","License":"Enterprise","SSOEnabled":"Disabled","SecurityPolicyMessage":"By accessing this computer, you confirm that such access complies with your organization's security policy.","ServerGen":"14G","SrvPrcName":"NULL","SystemLockdown":"Disabled","SystemModelName":"PowerEdge M640","TFAEnabled":"Disabled","iDRACName":"spare-H16Z4M2"}}`),
+			"/sysmgmt/2015/bmc/session": []byte(`{"status": "good", "authResult": 7, "forwardUrl": "something", "errorMsg": "none"}`),
+		},
 		"SupermicroX": {"/cgi/login.cgi": []byte("ATEN International")},
 		"Quanta":      {"/page/login.html": []byte("Quanta")},
 		"C7000": {

--- a/discover/probe.go
+++ b/discover/probe.go
@@ -42,7 +42,7 @@ func (p *Probe) hpIlo(ctx context.Context, log logr.Logger) (bmcConnection inter
 		return bmcConnection, err
 	}
 	defer resp.Body.Close()
-	defer io.Copy(ioutil.Discard, resp.Body)
+	defer io.Copy(ioutil.Discard, resp.Body) // nolint
 
 	payload, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -88,7 +88,7 @@ func (p *Probe) hpC7000(ctx context.Context, log logr.Logger) (bmcConnection int
 	}
 
 	defer resp.Body.Close()
-	defer io.Copy(ioutil.Discard, resp.Body)
+	defer io.Copy(ioutil.Discard, resp.Body) // nolint
 
 	payload, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -126,7 +126,7 @@ func (p *Probe) hpCl100(ctx context.Context, log logr.Logger) (bmcConnection int
 	}
 
 	defer resp.Body.Close()
-	defer io.Copy(ioutil.Discard, resp.Body)
+	defer io.Copy(ioutil.Discard, resp.Body) // nolint
 
 	var firstBytes = make([]byte, 8)
 	_, err = io.ReadFull(resp.Body, firstBytes)
@@ -151,7 +151,7 @@ func (p *Probe) idrac8(ctx context.Context, log logr.Logger) (bmcConnection inte
 	}
 
 	defer resp.Body.Close()
-	defer io.Copy(ioutil.Discard, resp.Body)
+	defer io.Copy(ioutil.Discard, resp.Body) // nolint
 
 	payload, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -174,7 +174,7 @@ func (p *Probe) idrac9(ctx context.Context, log logr.Logger) (bmcConnection inte
 	}
 
 	defer resp.Body.Close()
-	defer io.Copy(ioutil.Discard, resp.Body)
+	defer io.Copy(ioutil.Discard, resp.Body) // nolint
 
 	payload, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -196,7 +196,7 @@ func (p *Probe) m1000e(ctx context.Context, log logr.Logger) (bmcConnection inte
 	}
 
 	defer resp.Body.Close()
-	defer io.Copy(ioutil.Discard, resp.Body)
+	defer io.Copy(ioutil.Discard, resp.Body) // nolint
 
 	payload, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -218,7 +218,7 @@ func (p *Probe) supermicrox(ctx context.Context, log logr.Logger) (bmcConnection
 	}
 
 	defer resp.Body.Close()
-	defer io.Copy(ioutil.Discard, resp.Body)
+	defer io.Copy(ioutil.Discard, resp.Body) // nolint
 
 	payload, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -241,7 +241,7 @@ func (p *Probe) quanta(ctx context.Context, log logr.Logger) (bmcConnection inte
 	}
 
 	defer resp.Body.Close()
-	defer io.Copy(ioutil.Discard, resp.Body)
+	defer io.Copy(ioutil.Discard, resp.Body) // nolint
 
 	payload, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/discover/probe.go
+++ b/discover/probe.go
@@ -183,7 +183,7 @@ func (p *Probe) idrac9(ctx context.Context, log logr.Logger) (bmcConnection inte
 
 	if resp.StatusCode == 200 && containsAnySubStr(payload, idrac9SysDesc) {
 		log.V(1).Info("step", "connection", "host", p.host, "vendor", string(devices.Dell), "msg", "it's a idrac9")
-		return idrac9.New(ctx, p.host, p.username, p.password, log)
+		return idrac9.New(ctx, p.host, p.host, p.username, p.password, log)
 	}
 
 	return bmcConnection, errors.ErrDeviceNotMatched

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/go-querystring v1.0.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/leodido/go-urn v1.1.0 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/viper v1.3.2
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 )
 
-var basename = regexp.MustCompile("^.+\\.(.*$)")
+var basename = regexp.MustCompile(`^.+\.(.*$)`)
 
 // WhosCalling returns the current caller of the functions
 func WhosCalling() string {

--- a/internal/ipmi/ipmi.go
+++ b/internal/ipmi/ipmi.go
@@ -92,7 +92,7 @@ func (i *Ipmi) PowerOn() (status bool, err error) {
 		return false, err
 	}
 
-	if s == true {
+	if s {
 		return false, fmt.Errorf("server is already on")
 	}
 
@@ -127,7 +127,7 @@ func (i *Ipmi) PowerOff() (status bool, err error) {
 		return false, err
 	}
 
-	if s == false {
+	if !s {
 		return false, fmt.Errorf("server is already off")
 	}
 

--- a/providers/dell/dell.go
+++ b/providers/dell/dell.go
@@ -406,7 +406,7 @@ type CMCSlotMacWwn struct {
 
 // UnmarshalJSON custom unmarshalling for this "special" data structure
 func (d *CMCSlotMacWwn) UnmarshalJSON(data []byte) error {
-	d.SlotMacWwnList = make(map[int]CMCWWNBlade, 0)
+	d.SlotMacWwnList = make(map[int]CMCWWNBlade)
 	var slotMacWwn map[string]json.RawMessage
 	if err := json.Unmarshal(data, &slotMacWwn); err != nil {
 		return err

--- a/providers/dell/idrac8/configure.go
+++ b/providers/dell/idrac8/configure.go
@@ -116,7 +116,7 @@ func (i *IDrac8) User(cfgUsers []*cfgresources.User) (err error) {
 		if cfgUser.Enable {
 
 			//new user to be added
-			if uExists == false {
+			if !uExists {
 				userID, userInfo, err = getEmptyUserSlot(idracUsers)
 				if err != nil {
 					i.log.V(1).Info("Unable to add new User.",
@@ -159,7 +159,7 @@ func (i *IDrac8) User(cfgUsers []*cfgresources.User) (err error) {
 		} // end if cfgUser.Enable
 
 		//if the user exists but is disabled in our config, remove the user
-		if cfgUser.Enable == false && uExists == true {
+		if !cfgUser.Enable && uExists {
 
 			userInfo.Enable = "Disabled"
 			userInfo.SolEnable = "Disabled"
@@ -209,7 +209,7 @@ func (i *IDrac8) Syslog(cfg *cfgresources.Syslog) (err error) {
 		port = cfg.Port
 	}
 
-	if cfg.Enable != true {
+	if !cfg.Enable {
 		enable = "Disabled"
 		i.log.V(1).Info("Syslog resource declared with enable: false.", "step", helper.WhosCalling())
 	}
@@ -293,7 +293,7 @@ func (i *IDrac8) Ntp(cfg *cfgresources.Ntp) (err error) {
 func (i *IDrac8) applyNtpServerParam(cfg *cfgresources.Ntp) {
 
 	var enable int
-	if cfg.Enable != true {
+	if !cfg.Enable {
 		i.log.V(1).Info("Ntp resource declared with enable: false.", "step", helper.WhosCalling())
 		enable = 0
 	} else {
@@ -618,10 +618,10 @@ func (i *IDrac8) Network(cfg *cfgresources.Network) (reset bool, err error) {
 	payload := fmt.Sprintf("dhcpForDNSDomain:%d,", params["DNSFromDHCP"])
 	payload += fmt.Sprintf("ipmiLAN:%d,", params["EnableIpmiOverLan"])
 	payload += fmt.Sprintf("serialOverLanEnabled:%d,", params["EnableSerialOverLan"])
-	payload += fmt.Sprintf("serialOverLanBaud:3,") //115.2 kbps
-	payload += fmt.Sprintf("serialOverLanPriv:0,") //Administrator
+	payload += "serialOverLanBaud:3," //115.2 kbps
+	payload += "serialOverLanPriv:0," //Administrator
 	payload += fmt.Sprintf("racRedirectEna:%d,", params["EnableSerialRedirection"])
-	payload += fmt.Sprintf("racEscKey:^\\\\")
+	payload += "racEscKey:^\\\\"
 
 	responseCode, responseBody, err := i.post(endpoint, []byte(payload), "")
 	if err != nil || responseCode != 200 {

--- a/providers/dell/idrac8/idrac8_test.go
+++ b/providers/dell/idrac8/idrac8_test.go
@@ -5242,7 +5242,7 @@ func setup() (bmc *IDrac8, err error) {
 	for url := range answers {
 		url := url
 		mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
-			w.Write(answers[url])
+			_, _ = w.Write(answers[url])
 		})
 	}
 

--- a/providers/dell/idrac8/setupConnections.go
+++ b/providers/dell/idrac8/setupConnections.go
@@ -111,7 +111,7 @@ func (i *IDrac8) Close() error {
 			multiErr = multierror.Append(multiErr, err)
 		} else {
 			defer resp.Body.Close()
-			defer io.Copy(ioutil.Discard, resp.Body)
+			defer io.Copy(ioutil.Discard, resp.Body) // nolint
 		}
 	}
 

--- a/providers/dell/idrac9/actions_test.go
+++ b/providers/dell/idrac9/actions_test.go
@@ -2,6 +2,9 @@ package idrac9
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/bmc-toolbox/bmclib/sshmock"
@@ -46,6 +49,11 @@ var (
 	}
 )
 
+var _answers = map[string][]byte{
+	"/sysmgmt/2015/bmc/info":    []byte(`{"Attributes":{"ADEnabled":"Disabled","BuildVersion":"37","FwVer":"3.15.15.15","GUITitleBar":"spare-H16Z4M2","IsOEMBranded":"0","License":"Enterprise","SSOEnabled":"Disabled","SecurityPolicyMessage":"By accessing this computer, you confirm that such access complies with your organization's security policy.","ServerGen":"14G","SrvPrcName":"NULL","SystemLockdown":"Disabled","SystemModelName":"PowerEdge M640","TFAEnabled":"Disabled","iDRACName":"spare-H16Z4M2"}}`),
+	"/sysmgmt/2015/bmc/session": []byte(`{"status": "good", "authResult": 7, "forwardUrl": "something", "errorMsg": "none"}`),
+}
+
 func setupBMC() (func(), *IDrac9, error) {
 	ssh, err := sshmock.New(sshAnswers)
 	if err != nil {
@@ -55,9 +63,20 @@ func setupBMC() (func(), *IDrac9, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	mux := http.NewServeMux()
+	server := httptest.NewTLSServer(mux)
+	ip := strings.TrimPrefix(server.URL, "https://")
+
+	for url := range _answers {
+		url := url
+
+		mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+			w.Write(_answers[url])
+		})
+	}
 
 	testLogger := logrus.New()
-	bmc, err := New(context.TODO(), address, sshUsername, sshPassword, logrusr.NewLogger(testLogger))
+	bmc, err := New(context.TODO(), address, ip, sshUsername, sshPassword, logrusr.NewLogger(testLogger))
 	if err != nil {
 		tearDown()
 		return nil, nil, err

--- a/providers/dell/idrac9/actions_test.go
+++ b/providers/dell/idrac9/actions_test.go
@@ -71,7 +71,7 @@ func setupBMC() (func(), *IDrac9, error) {
 		url := url
 
 		mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
-			w.Write(_answers[url])
+			_, _ = w.Write(_answers[url])
 		})
 	}
 

--- a/providers/dell/idrac9/configure.go
+++ b/providers/dell/idrac9/configure.go
@@ -177,7 +177,7 @@ func (i *IDrac9) User(cfgUsers []*cfgresources.User) (err error) {
 		if cfgUser.Enable {
 
 			//new user to be added
-			if uExists == false {
+			if !uExists {
 				userID, userInfo, err = getEmptyUserSlot(idracUsers)
 				if err != nil {
 					i.log.V(1).Error(err, "Unable to add new User.",
@@ -220,7 +220,7 @@ func (i *IDrac9) User(cfgUsers []*cfgresources.User) (err error) {
 		} // end if cfgUser.Enable
 
 		//if the user exists but is disabled in our config, remove the user
-		if cfgUser.Enable == false && uExists == true {
+		if !cfgUser.Enable && uExists {
 			endpoint := fmt.Sprintf("sysmgmt/2017/server/user?userid=%d", userID)
 			statusCode, response, err := i.delete(endpoint)
 			if err != nil {
@@ -363,7 +363,7 @@ func (i *IDrac9) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.
 		if cfgRole.Enable {
 
 			//new role to be added
-			if rExists == false {
+			if !rExists {
 				roleID, role, err = getEmptyLdapRoleGroupSlot(idracLdapRoleGroups)
 				if err != nil {
 					i.log.V(1).Error(err, "Unable to add new Ldap Role Group.",
@@ -403,7 +403,7 @@ func (i *IDrac9) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.
 		} // end if cfgUser.Enable
 
 		//if the role exists but is disabled in our config, remove the role
-		if cfgRole.Enable == false && rExists == true {
+		if !cfgRole.Enable && rExists {
 
 			role.DN = ""
 			role.Privilege = "0"
@@ -547,7 +547,7 @@ func (i *IDrac9) Syslog(cfg *cfgresources.Syslog) (err error) {
 		port = cfg.Port
 	}
 
-	if cfg.Enable != true {
+	if !cfg.Enable {
 		enable = "Disabled"
 		i.log.V(1).Info("Syslog resource declared with enable: false.", "step", helper.WhosCalling())
 	}
@@ -611,16 +611,16 @@ func (i *IDrac9) Network(cfg *cfgresources.Network) (reset bool, err error) {
 		"EnableIpmiOverLan":       "Enabled",
 	}
 
-	if cfg.DNSFromDHCP == false {
+	if !cfg.DNSFromDHCP {
 		params["DNSFromDHCP"] = "Disabled"
 	}
 
-	if cfg.SolEnable == false {
+	if !cfg.SolEnable {
 		params["EnableSerialOverLan"] = "Disabled"
 		params["EnableSerialRedirection"] = "Disabled"
 	}
 
-	if cfg.IpmiEnable == false {
+	if !cfg.IpmiEnable {
 		params["EnableIpmiOverLan"] = "Disabled"
 	}
 

--- a/providers/dell/idrac9/helpers.go
+++ b/providers/dell/idrac9/helpers.go
@@ -107,7 +107,7 @@ func (i *IDrac9) putLdap(ldap Ldap) (err error) {
 		return errors.New(msg)
 	}
 
-	endpoint := fmt.Sprintf("sysmgmt/2012/server/configgroup/iDRAC.LDAP")
+	endpoint := "sysmgmt/2012/server/configgroup/iDRAC.LDAP"
 	statusCode, _, err := i.put(endpoint, payload)
 	if err != nil || statusCode != 200 {
 		msg := fmt.Sprintf("PUT request to set User config returned error, return code: %d", statusCode)
@@ -176,7 +176,7 @@ func (i *IDrac9) putTimezone(timezone Timezone) (err error) {
 		return errors.New(msg)
 	}
 
-	endpoint := fmt.Sprintf("sysmgmt/2012/server/configgroup/iDRAC.Time")
+	endpoint := "sysmgmt/2012/server/configgroup/iDRAC.Time"
 	statusCode, _, err := i.put(endpoint, payload)
 	if err != nil || statusCode != 200 {
 		msg := fmt.Sprintf("PUT request to set Timezone config returned error, return code: %d", statusCode)
@@ -198,7 +198,7 @@ func (i *IDrac9) putNtpConfig(ntpConfig NtpConfig) (err error) {
 		return errors.New(msg)
 	}
 
-	endpoint := fmt.Sprintf("sysmgmt/2012/server/configgroup/iDRAC.NTPConfigGroup")
+	endpoint := "sysmgmt/2012/server/configgroup/iDRAC.NTPConfigGroup"
 	statusCode, _, err := i.put(endpoint, payload)
 	if err != nil || statusCode != 200 {
 		msg := fmt.Sprintf("PUT request to set Timezone config returned error, return code: %d", statusCode)
@@ -220,7 +220,7 @@ func (i *IDrac9) putSyslog(syslog Syslog) (err error) {
 		return errors.New(msg)
 	}
 
-	endpoint := fmt.Sprintf("sysmgmt/2012/server/configgroup/iDRAC.Syslog")
+	endpoint := "sysmgmt/2012/server/configgroup/iDRAC.Syslog"
 	statusCode, _, err := i.put(endpoint, payload)
 	if err != nil || statusCode != 200 {
 		msg := fmt.Sprintf("PUT request to set Syslog config returned error, return code: %d", statusCode)
@@ -242,7 +242,7 @@ func (i *IDrac9) putIPv4(ipv4 Ipv4) (err error) {
 		return errors.New(msg)
 	}
 
-	endpoint := fmt.Sprintf("sysmgmt/2012/server/configgroup/iDRAC.IPv4")
+	endpoint := "sysmgmt/2012/server/configgroup/iDRAC.IPv4"
 	statusCode, _, err := i.put(endpoint, payload)
 	if err != nil || statusCode != 200 {
 		msg := fmt.Sprintf("PUT request to set IPv4 config returned error, return code: %d", statusCode)
@@ -264,7 +264,7 @@ func (i *IDrac9) putSerialOverLan(serialOverLan SerialOverLan) (err error) {
 		return errors.New(msg)
 	}
 
-	endpoint := fmt.Sprintf("sysmgmt/2012/server/configgroup/iDRAC.IPMISOL")
+	endpoint := "sysmgmt/2012/server/configgroup/iDRAC.IPMISOL"
 	statusCode, _, err := i.put(endpoint, payload)
 	if err != nil || statusCode != 200 {
 		msg := fmt.Sprintf("PUT request to set SerialOverLan config returned error, return code: %d", statusCode)
@@ -286,7 +286,7 @@ func (i *IDrac9) putSerialRedirection(serialRedirection SerialRedirection) (err 
 		return errors.New(msg)
 	}
 
-	endpoint := fmt.Sprintf("sysmgmt/2012/server/configgroup/iDRAC.SerialRedirection")
+	endpoint := "sysmgmt/2012/server/configgroup/iDRAC.SerialRedirection"
 	statusCode, _, err := i.put(endpoint, payload)
 	if err != nil || statusCode != 200 {
 		msg := fmt.Sprintf("PUT request to set serialRedirection config returned error, return code: %d", statusCode)
@@ -308,7 +308,7 @@ func (i *IDrac9) putIpmiOverLan(ipmiOverLan IpmiOverLan) (err error) {
 		return errors.New(msg)
 	}
 
-	endpoint := fmt.Sprintf("sysmgmt/2012/server/configgroup/iDRAC.IPMILAN")
+	endpoint := "sysmgmt/2012/server/configgroup/iDRAC.IPMILAN"
 	statusCode, _, err := i.put(endpoint, payload)
 	if err != nil || statusCode != 200 {
 		msg := fmt.Sprintf("PUT request to set IpmiOverLan config returned error, return code: %d", statusCode)
@@ -328,7 +328,7 @@ func (i *IDrac9) putCSR(csrInfo CSRInfo) (err error) {
 		return errors.New(msg)
 	}
 
-	endpoint := fmt.Sprintf("sysmgmt/2012/server/configgroup/iDRAC.Security")
+	endpoint := "sysmgmt/2012/server/configgroup/iDRAC.Security"
 	statusCode, _, err := i.put(endpoint, payload)
 	if err != nil || statusCode != 200 {
 		msg := fmt.Sprintf("PUT request to set CSR attributes returned: %d", statusCode)
@@ -342,7 +342,7 @@ func (i *IDrac9) putCSR(csrInfo CSRInfo) (err error) {
 // see alertConfigPayload listed in model.go for payload.
 func (i *IDrac9) putAlertConfig() (err error) {
 
-	endpoint := fmt.Sprintf("sysmgmt/2012/server/eventpolicy")
+	endpoint := "sysmgmt/2012/server/eventpolicy"
 	statusCode, _, err := i.put(endpoint, alertConfigPayload)
 	if err != nil || statusCode != 200 {
 		msg := fmt.Sprintf("PUT request to set attributes returned: %d", statusCode)
@@ -362,7 +362,7 @@ func (i *IDrac9) putAlertEnable(alertEnable AlertEnable) (err error) {
 		return errors.New(msg)
 	}
 
-	endpoint := fmt.Sprintf("sysmgmt/2012/server/configgroup/iDRAC.IPMILAN")
+	endpoint := "sysmgmt/2012/server/configgroup/iDRAC.IPMILAN"
 	statusCode, _, err := i.put(endpoint, payload)
 	if err != nil || statusCode != 200 {
 		msg := fmt.Sprintf("PUT request to set attributes returned: %d", statusCode)

--- a/providers/dell/idrac9/idrac9.go
+++ b/providers/dell/idrac9/idrac9.go
@@ -41,13 +41,13 @@ type IDrac9 struct {
 }
 
 // New returns a new IDrac9 ready to be used
-func New(ctx context.Context, host string, username string, password string, log logr.Logger) (*IDrac9, error) {
+func New(ctx context.Context, host string, httpHost string, username string, password string, log logr.Logger) (*IDrac9, error) {
 	sshClient, err := sshclient.New(host, username, password)
 	if err != nil {
 		return nil, err
 	}
 
-	idrac := &IDrac9{ip: host, username: username, password: password, sshClient: sshClient, ctx: ctx, log: log}
+	idrac := &IDrac9{ip: httpHost, username: username, password: password, sshClient: sshClient, ctx: ctx, log: log}
 	err = idrac.httpLogin()
 	if err != nil {
 		return nil, err

--- a/providers/dell/idrac9/idrac9_c6420_test.go
+++ b/providers/dell/idrac9/idrac9_c6420_test.go
@@ -3907,7 +3907,7 @@ func setupC6420() (bmc *IDrac9, err error) {
 	}
 
 	testLogger := logrus.New()
-	bmc, err = New(context.TODO(), ip, username, password, logrusr.NewLogger(testLogger))
+	bmc, err = New(context.TODO(), ip, ip, username, password, logrusr.NewLogger(testLogger))
 	if err != nil {
 		return bmc, err
 	}

--- a/providers/dell/idrac9/idrac9_c6420_test.go
+++ b/providers/dell/idrac9/idrac9_c6420_test.go
@@ -3902,7 +3902,7 @@ func setupC6420() (bmc *IDrac9, err error) {
 	for url := range AnswersC6420 {
 		url := url
 		muxC6420.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
-			w.Write(AnswersC6420[url])
+			_, _ = w.Write(AnswersC6420[url])
 		})
 	}
 

--- a/providers/dell/idrac9/idrac9_test.go
+++ b/providers/dell/idrac9/idrac9_test.go
@@ -3288,7 +3288,7 @@ func setup() (bmc *IDrac9, err error) {
 	}
 
 	testLogger := logrus.New()
-	bmc, err = New(context.TODO(), ip, username, password, logrusr.NewLogger(testLogger))
+	bmc, err = New(context.TODO(), ip, ip, username, password, logrusr.NewLogger(testLogger))
 	if err != nil {
 		return bmc, err
 	}

--- a/providers/dell/idrac9/idrac9_test.go
+++ b/providers/dell/idrac9/idrac9_test.go
@@ -3283,7 +3283,7 @@ func setup() (bmc *IDrac9, err error) {
 	for url := range Answers {
 		url := url
 		mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
-			w.Write(Answers[url])
+			_, _ = w.Write(Answers[url])
 		})
 	}
 

--- a/providers/dell/idrac9/query.go
+++ b/providers/dell/idrac9/query.go
@@ -40,7 +40,7 @@ func (i *IDrac9) Screenshot() (response []byte, extension string, err error) {
 
 	extension = "png"
 	endpoint1 := "sysmgmt/2015/server/preview"
-	response, err = i.get(endpoint1, &map[string]string{})
+	_, err = i.get(endpoint1, &map[string]string{})
 	if err != nil {
 		return []byte{}, extension, err
 	}

--- a/providers/dell/idrac9/redfish_helpers.go
+++ b/providers/dell/idrac9/redfish_helpers.go
@@ -3,7 +3,6 @@ package idrac9
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -13,6 +12,7 @@ import (
 	"strings"
 
 	bmclibErrors "github.com/bmc-toolbox/bmclib/errors"
+	"github.com/pkg/errors"
 )
 
 //diffs two BiosSettings and returns a BiosSettings with the difference.
@@ -69,6 +69,7 @@ func (i *IDrac9) getBiosSettings() (biosSettings *BiosSettings, err error) {
 
 }
 
+/*
 //returns the bios settings pending reboot
 func (i *IDrac9) biosSettingsPendingReboot() (pendingBiosSettings *BiosSettings, err error) {
 
@@ -92,6 +93,7 @@ func (i *IDrac9) biosSettingsPendingReboot() (pendingBiosSettings *BiosSettings,
 	return oData.Attributes, err
 
 }
+*/
 
 // PATCHs Bios settings, queues setting to be applied at next boot.
 func (i *IDrac9) setBiosSettings(biosSettings *BiosSettings) (err error) {
@@ -185,7 +187,6 @@ func (i *IDrac9) purgeJobsForBiosSettings() (err error) {
 
 //Purges jobs of the given type - if they are in the "Scheduled" state
 func (i *IDrac9) purgeJobsByType(jobIDs []string, jobType string) (err error) {
-
 	for _, jobID := range jobIDs {
 		jState, jType, err := i.getJob(jobID)
 		if err != nil {
@@ -196,7 +197,7 @@ func (i *IDrac9) purgeJobsByType(jobIDs []string, jobType string) (err error) {
 			return i.purgeJob(jobID)
 		}
 
-		return fmt.Errorf(fmt.Sprintf("Job not in Scheduled state cannot be purged, state: %s, id: %s", jState, jobID))
+		return errors.Wrapf(err, "Job not in Scheduled state cannot be purged, state: %s, id: %s", jState, jobID) // nolint
 	}
 
 	return err

--- a/providers/dell/m1000e/actions.go
+++ b/providers/dell/m1000e/actions.go
@@ -77,7 +77,7 @@ func (m *M1000e) FindBladePosition(serial string) (int, error) {
 		line = strings.Replace(line, "Server-", "", -1)
 		data := strings.FieldsFunc(line, internal.IsntLetterOrNumber)
 		for _, field := range data {
-			if strings.ToLower(serial) == strings.ToLower(field) {
+			if strings.EqualFold(serial, field) {
 				return strconv.Atoi(data[0])
 			}
 		}

--- a/providers/dell/m1000e/configure.go
+++ b/providers/dell/m1000e/configure.go
@@ -135,7 +135,7 @@ func (m *M1000e) Ntp(cfg *cfgresources.Ntp) (err error) {
 	datetimeParams := m.newDatetimeCfg(cfg)
 
 	datetimeParams.SessionToken = m.SessionToken
-	path := fmt.Sprintf("datetime")
+	path := "datetime"
 	form, _ := query.Values(datetimeParams)
 	err = m.post(path, &form)
 	if err != nil {
@@ -153,7 +153,7 @@ func (m *M1000e) Ldap(cfg *cfgresources.Ldap) (err error) {
 	directoryServicesParams := m.newDirectoryServicesCfg(cfg)
 
 	directoryServicesParams.SessionToken = m.SessionToken
-	path := fmt.Sprintf("dirsvcs")
+	path := "dirsvcs"
 	form, _ := query.Values(directoryServicesParams)
 	err = m.post(path, &form)
 	if err != nil {

--- a/providers/dell/m1000e/constructors.go
+++ b/providers/dell/m1000e/constructors.go
@@ -279,7 +279,7 @@ func (m *M1000e) newUserCfg(user *cfgresources.User, userID int) UserParams {
 		m.log.V(0).Error(err, msg, "step", "apply-user-cfg")
 	}
 
-	if m.isRoleValid(user.Role) == false {
+	if !m.isRoleValid(user.Role) {
 		// TODO update method with error return and return err in this if, was doing logrus.Fatal here
 		msg := "user resource Role must be declared and a valid role: admin"
 		err := errors.New(msg)

--- a/providers/dell/m1000e/m1000e.go
+++ b/providers/dell/m1000e/m1000e.go
@@ -37,7 +37,6 @@ type M1000e struct {
 	httpClient   *http.Client
 	sshClient    *sshclient.SSHClient
 	cmcJSON      *dell.CMC
-	cmcTemp      *dell.CMCTemp
 	cmcWWN       *dell.CMCWWN
 	SessionToken string //required to set config
 	ctx          context.Context
@@ -409,8 +408,8 @@ func (m *M1000e) Blades() (blades []*devices.Blade, err error) {
 			blade.Vendor = dell.VendorID
 			blade.BiosVersion = dellBlade.BladeBIOSver
 			blade.Name = dellBlade.BladeName
-			idracURL := strings.TrimLeft(dellBlade.IdracURL, "https://")
-			idracURL = strings.TrimLeft(idracURL, "http://")
+			idracURL := strings.TrimPrefix(dellBlade.IdracURL, "https://")
+			idracURL = strings.TrimPrefix(idracURL, "http://")
 			idracURL = strings.Split(idracURL, ":")[0]
 			blade.BmcAddress = idracURL
 			blade.BmcVersion = dellBlade.BladeUSCVer

--- a/providers/dell/m1000e/m1000e_test.go
+++ b/providers/dell/m1000e/m1000e_test.go
@@ -1702,9 +1702,9 @@ func setup() (r *M1000e, err error) {
 			if url == "/cgi-bin/webcgi/json" {
 				urlQuery := r.URL.Query()
 				query := urlQuery.Get("method")
-				w.Write(dellChassisAnswers[url][query])
+				_, _ = w.Write(dellChassisAnswers[url][query])
 			} else {
-				w.Write(dellChassisAnswers[url]["default"])
+				_, _ = w.Write(dellChassisAnswers[url]["default"])
 			}
 		})
 	}

--- a/providers/dummy/ibmc/ibmc.go
+++ b/providers/dummy/ibmc/ibmc.go
@@ -168,7 +168,6 @@ func (i *Ibmc) ServerSnapshot() (interface{}, error) {
 
 // UpdateCredentials implements the Bmc interface
 func (i *Ibmc) UpdateCredentials(string, string) {
-	return
 }
 
 // Slot implements the Bmc interface

--- a/providers/hp/c7000/actions.go
+++ b/providers/hp/c7000/actions.go
@@ -52,7 +52,7 @@ func (c *C7000) FindBladePosition(serial string) (int, error) {
 		line = strings.Replace(line, "Server-", "", -1)
 		data := strings.FieldsFunc(line, internal.IsntLetterOrNumber)
 		for _, field := range data {
-			if strings.ToLower(serial) == strings.ToLower(field) {
+			if strings.EqualFold(serial, field) {
 				return strconv.Atoi(data[0])
 			}
 		}

--- a/providers/hp/c7000/c7000.go
+++ b/providers/hp/c7000/c7000.go
@@ -200,7 +200,7 @@ func (c *C7000) PassThru() (passthru string, err error) {
 		if strings.Contains(hpswitch.Spn, "10G") {
 			passthru = "10G"
 		}
-		break
+		break // nolint
 	}
 	return passthru, err
 }

--- a/providers/hp/c7000/c7000_test.go
+++ b/providers/hp/c7000/c7000_test.go
@@ -2425,7 +2425,7 @@ func setup() (r *C7000, err error) {
 		mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
 			cookie := http.Cookie{Name: "sessionKey", Value: "sessionKey_test"}
 			http.SetCookie(w, &cookie)
-			w.Write(answers[url])
+			_, _ = w.Write(answers[url])
 		})
 	}
 

--- a/providers/hp/c7000/configure.go
+++ b/providers/hp/c7000/configure.go
@@ -220,7 +220,7 @@ func (c *C7000) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.L
 
 		//0. removeLdapGroup
 		if !group.Enable {
-			c.applyRemoveLdapGroup(group.Group)
+			err = c.applyRemoveLdapGroup(group.Group)
 			if err != nil {
 				c.log.V(1).Info("Remove Ldap Group returned error.",
 					"step", "applyRemoveLdapGroup",
@@ -507,7 +507,7 @@ func (c *C7000) User(users []*cfgresources.User) (err error) {
 			return err
 		}
 
-		if c.isRoleValid(cfg.Role) == false {
+		if !c.isRoleValid(cfg.Role) {
 			err = errors.New("user resource Role must be declared and a valid role: admin")
 			c.log.V(1).Error(err, "user resource Role must be declared and a valid role: admin",
 				"step", "applyUserParams",
@@ -521,7 +521,7 @@ func (c *C7000) User(users []*cfgresources.User) (err error) {
 		password := Password{Text: cfg.Password}
 
 		//if user account is disabled, remove the user
-		if cfg.Enable == false {
+		if !cfg.Enable {
 			payload := RemoveUser{Username: username}
 			statusCode, _, _ := c.postXML(payload)
 
@@ -744,7 +744,7 @@ func (c *C7000) Ntp(cfg *cfgresources.Ntp) (err error) {
 		return
 	}
 
-	if cfg.Enable != true {
+	if !cfg.Enable {
 		c.log.V(1).Info("Ntp resource declared with enable: false.",
 			"step", "applyNtpParams",
 			"Model", c.HardwareType(),
@@ -845,7 +845,7 @@ func (c *C7000) Syslog(cfg *cfgresources.Syslog) (err error) {
 		port = cfg.Port
 	}
 
-	if cfg.Enable != true {
+	if !cfg.Enable {
 		c.log.V(1).Info("Syslog resource declared with enable: false.",
 			"step", "applySyslogParams",
 			"IP", c.ip,
@@ -887,7 +887,6 @@ func (c *C7000) applySyslogServer(server string) {
 		"IP", c.ip,
 		"Model", c.HardwareType(),
 	)
-	return
 }
 
 // Sets syslog port
@@ -912,7 +911,6 @@ func (c *C7000) applySyslogPort(port int) {
 		"IP", c.ip,
 		"Model", c.HardwareType(),
 	)
-	return
 }
 
 // Enables syslogging
@@ -938,8 +936,6 @@ func (c *C7000) applySyslogEnabled(enabled bool) {
 		"IP", c.ip,
 		"Model", c.HardwareType(),
 	)
-	return
-
 }
 
 // Network method implements the Configure interface

--- a/providers/hp/ilo/configure.go
+++ b/providers/hp/ilo/configure.go
@@ -164,7 +164,7 @@ func (i *Ilo) User(users []*cfgresources.User) (err error) {
 		}
 
 		//if the user is disabled remove it
-		if user.Enable == false && uexists {
+		if !user.Enable && uexists {
 			userinfo.Method = "del_user"
 			userinfo.UserID = userinfo.ID
 			msg := "User disabled in config, will be removed."
@@ -240,7 +240,7 @@ func (i *Ilo) Syslog(cfg *cfgresources.Syslog) (err error) {
 		port = cfg.Port
 	}
 
-	if cfg.Enable != true {
+	if !cfg.Enable {
 		enable = 0
 		i.log.V(1).Info("Syslog resource declared with disable.", "step", helper.WhosCalling())
 	}
@@ -369,7 +369,7 @@ func (i *Ilo) Ntp(cfg *cfgresources.Ntp) (err error) {
 		return errors.New(msg)
 	}
 
-	if cfg.Enable != true {
+	if !cfg.Enable {
 		enable = 0
 		i.log.V(1).Info("NTP resource declared with disable.", "step", helper.WhosCalling())
 	}
@@ -514,7 +514,7 @@ func (i *Ilo) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.Lda
 		}
 
 		//if the group is disabled remove it
-		if group.Enable == false && gexists {
+		if !group.Enable && gexists {
 			directoryGroup.Method = "del_group"
 			i.log.V(1).Info("Ldap role group disabled in config, will be removed.",
 				"IP", i.ip,
@@ -598,7 +598,7 @@ func (i *Ilo) Ldap(cfg *cfgresources.Ldap) (err error) {
 	}
 
 	var enable int
-	if cfg.Enable == false {
+	if !cfg.Enable {
 		enable = 0
 	} else {
 		enable = 1

--- a/providers/hp/ilo/helpers.go
+++ b/providers/hp/ilo/helpers.go
@@ -17,11 +17,7 @@ func (i *Ilo) cmpPowerSettings(regulatorMode string) (PowerRegulator, bool, erro
 	}
 
 	settingsMatch := func() bool {
-		if currentConfig.PowerMode != regulatorMode {
-			return false
-		}
-
-		return true
+		return currentConfig.PowerMode == regulatorMode
 	}
 
 	if settingsMatch() {
@@ -97,15 +93,15 @@ func (i *Ilo) cmpAccessSettings(cfg *cfgresources.Network) (AccessSettings, bool
 	// setup some params as int for comparison
 	var sshEnable, ipmiEnable, serialEnable int
 
-	if cfg.SSHEnable == true {
+	if cfg.SSHEnable {
 		sshEnable = 1
 	}
 
-	if cfg.IpmiEnable == true {
+	if cfg.IpmiEnable {
 		ipmiEnable = 1
 	}
 
-	if cfg.SolEnable == true {
+	if cfg.SolEnable {
 		// enable with Auth
 		serialEnable = 2
 	}

--- a/providers/hp/ilo/ilo_test.go
+++ b/providers/hp/ilo/ilo_test.go
@@ -165,7 +165,7 @@ func setup() (bmc *Ilo, err error) {
 		mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
 			cookie := http.Cookie{Name: "sessionKey", Value: "sessionKey_test"}
 			http.SetCookie(w, &cookie)
-			w.Write(Answers[url])
+			_, _ = w.Write(Answers[url])
 		})
 	}
 

--- a/providers/hp/ilo/model.go
+++ b/providers/hp/ilo/model.go
@@ -23,7 +23,7 @@ type LicenseInfo struct {
 // POST
 // https://10.193.251.48/json/user_info
 type UserInfo struct {
-	ID               int    `json:"id,int,omitempty"`
+	ID               int    `json:"id,omitempty"`
 	LoginName        string `json:"login_name,omitempty"`
 	UserName         string `json:"user_name,omitempty"`
 	Password         string `json:"password,omitempty"`
@@ -34,7 +34,7 @@ type UserInfo struct {
 	UserPriv         int    `json:"user_priv,omitempty"`
 	LoginPriv        int    `json:"login_priv,omitempty"`
 	Method           string `json:"method"` //mod_user, add_user, del_user
-	UserID           int    `json:"user_id,int,omitempty"`
+	UserID           int    `json:"user_id,omitempty"`
 	SessionKey       string `json:"session_key,omitempty"`
 }
 

--- a/providers/hp/ilo/setupConnection.go
+++ b/providers/hp/ilo/setupConnection.go
@@ -105,7 +105,7 @@ func (i *Ilo) Close() error {
 				multiErr = multierror.Append(multiErr, err)
 			} else {
 				defer resp.Body.Close()
-				defer io.Copy(ioutil.Discard, resp.Body)
+				defer io.Copy(ioutil.Discard, resp.Body) // nolint
 
 				respDump, _ := httputil.DumpResponse(resp, true)
 				i.log.V(2).Info("responseTrace", "responseDump", string(respDump))

--- a/providers/supermicro/supermicro.go
+++ b/providers/supermicro/supermicro.go
@@ -1,9 +1,5 @@
 package supermicro
 
-import (
-	"net/http"
-)
-
 const (
 	// VendorID represents the id of the vendor across all packages
 	VendorID = "Supermicro"
@@ -128,14 +124,6 @@ type PowerSupply struct {
 	Location  string `xml:"LOCATION,attr"`
 	Status    string `xml:"STATUS,attr"`
 	Unplugged string `xml:"UNPLUGGED,attr"`
-}
-
-// Reader holds the status and properties of a connection to a supermicro bmc
-type Reader struct {
-	ip       *string
-	username *string
-	password *string
-	client   *http.Client
 }
 
 // NodeInfo contains a lists of boards in the chassis

--- a/providers/supermicro/supermicrox/actions.go
+++ b/providers/supermicro/supermicrox/actions.go
@@ -52,7 +52,7 @@ func (s *SupermicroX) PxeOnce() (status bool, err error) {
 	if err != nil {
 		return status, err
 	}
-	status, err = i.PxeOnceEfi()
+	_, err = i.PxeOnceEfi()
 	if err != nil {
 		return false, err
 	}

--- a/providers/supermicro/supermicrox/configure.go
+++ b/providers/supermicro/supermicrox/configure.go
@@ -210,7 +210,7 @@ func (s *SupermicroX) Network(cfg *cfgresources.Network) (reset bool, err error)
 		SslRedirectEnable: true,
 	}
 
-	endpoint := fmt.Sprintf("op.cgi")
+	endpoint := "op.cgi"
 	form, _ := query.Values(configPort)
 	statusCode, err := s.post(endpoint, &form, []byte{}, "")
 	if err != nil || statusCode != 200 {
@@ -260,7 +260,7 @@ func (s *SupermicroX) Ntp(cfg *cfgresources.Ntp) (err error) {
 
 	tzUtcOffset := timezoneToUtcOffset(tzLocation)
 
-	if cfg.Enable != true {
+	if !cfg.Enable {
 		s.log.V(1).Info("Ntp resource declared with enable: false.",
 			"step", "applyNtpParams",
 			"model", s.HardwareType())
@@ -296,7 +296,7 @@ func (s *SupermicroX) Ntp(cfg *cfgresources.Ntp) (err error) {
 		TimeStamp:          ts,
 	}
 
-	endpoint := fmt.Sprintf("op.cgi")
+	endpoint := "op.cgi"
 	form, _ := query.Values(configDateTime)
 	statusCode, err := s.post(endpoint, &form, []byte{}, "")
 	if err != nil || statusCode != 200 {
@@ -348,7 +348,7 @@ func (s *SupermicroX) LdapGroup(cfgGroup []*cfgresources.LdapGroup, cfgLdap *cfg
 		return errors.New(msg)
 	}
 
-	if cfgLdap.Enable != true {
+	if !cfgLdap.Enable {
 		s.log.V(1).Info("Ldap resource declared with enable: false.",
 			"step", helper.WhosCalling(),
 			"model", s.HardwareType())
@@ -413,7 +413,7 @@ func (s *SupermicroX) LdapGroup(cfgGroup []*cfgresources.LdapGroup, cfgLdap *cfg
 			Op:           "config_ldap",
 			Enable:       enable,
 			EnableSsl:    true,
-			LdapIP:       fmt.Sprintf("%s", serverIP[0]),
+			LdapIP:       string(serverIP[0]),
 			BaseDn:       group.Group,
 			LdapPort:     cfgLdap.Port,
 			BindDn:       cfgLdap.BindDn,
@@ -461,7 +461,7 @@ func (s *SupermicroX) Syslog(cfg *cfgresources.Syslog) (err error) {
 		port = cfg.Port
 	}
 
-	if cfg.Enable != true {
+	if !cfg.Enable {
 		msg := "Syslog resource declared with disable."
 		s.log.V(1).Info(msg, "step", helper.WhosCalling(), "model", s.HardwareType())
 	}
@@ -475,7 +475,7 @@ func (s *SupermicroX) Syslog(cfg *cfgresources.Syslog) (err error) {
 
 	configSyslog := ConfigSyslog{
 		Op:          "config_syslog",
-		SyslogIP1:   fmt.Sprintf("%s", serverIP[0]),
+		SyslogIP1:   string(serverIP[0]),
 		SyslogPort1: port,
 		Enable:      cfg.Enable,
 	}

--- a/providers/supermicro/supermicrox/query.go
+++ b/providers/supermicro/supermicrox/query.go
@@ -49,7 +49,7 @@ func (s *SupermicroX) Screenshot() (response []byte, extension string, err error
 		return response, extension, errors.ErrFeatureUnavailable
 	}
 
-	tzLocation, err := time.LoadLocation("CET")
+	tzLocation, _ := time.LoadLocation("CET")
 	t := time.Now().In(tzLocation)
 
 	//Fri Jun 06 2018 14:28:25 GMT+0100 (CET)

--- a/providers/supermicro/supermicrox/setupConnection.go
+++ b/providers/supermicro/supermicrox/setupConnection.go
@@ -88,7 +88,7 @@ func (s *SupermicroX) Close() (err error) {
 		}
 
 		defer resp.Body.Close()
-		defer io.Copy(ioutil.Discard, resp.Body)
+		defer io.Copy(ioutil.Discard, resp.Body) // nolint
 
 		return err
 	}

--- a/providers/supermicro/supermicrox/supermicrox_test.go
+++ b/providers/supermicro/supermicrox/supermicrox_test.go
@@ -126,11 +126,11 @@ func setup() (r *SupermicroX, err error) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		w.Write(Answers[string(query)])
+		_, _ = w.Write(Answers[string(query)])
 	})
 
 	mux.HandleFunc("/cgi/login.cgi", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("../cgi/url_redirect.cgi?url_name=mainmenu"))
+		_, _ = w.Write([]byte("../cgi/url_redirect.cgi?url_name=mainmenu"))
 	})
 
 	testLog := logrus.New()

--- a/sshmock/sshmock.go
+++ b/sshmock/sshmock.go
@@ -103,7 +103,7 @@ func (s *Server) handleChannels(chans <-chan ssh.NewChannel) {
 
 func (s *Server) handleChannel(newChannel ssh.NewChannel) {
 	if t := newChannel.ChannelType(); t != "session" {
-		newChannel.Reject(ssh.UnknownChannelType, fmt.Sprintf("unknown channel type: %s", t))
+		_ = newChannel.Reject(ssh.UnknownChannelType, fmt.Sprintf("unknown channel type: %s", t))
 		return
 	}
 
@@ -125,21 +125,21 @@ func (s *Server) handleChannel(newChannel ssh.NewChannel) {
 		}
 		if answer, ok := s.answers[reqCmd.Text]; ok {
 			if len(answer) == 0 {
-				channel.Stderr().Write([]byte(fmt.Sprintf("answer empty for %s", reqCmd.Text)))
-				req.Reply(req.WantReply, nil)
+				_, _ = channel.Stderr().Write([]byte(fmt.Sprintf("answer empty for %s", reqCmd.Text)))
+				_ = req.Reply(req.WantReply, nil)
 				if _, err := channel.SendRequest("exit-status", false, []byte{0, 0, 0, 1}); err != nil {
 					log.Printf("failed: %v\n", err)
 				}
 			} else {
-				channel.Write(answer)
-				req.Reply(req.WantReply, nil)
+				_, _ = channel.Write(answer)
+				_ = req.Reply(req.WantReply, nil)
 				if _, err := channel.SendRequest("exit-status", false, []byte{0, 0, 0, 0}); err != nil {
 					log.Printf("failed: %v\n", err)
 				}
 			}
 		} else {
-			channel.Stderr().Write([]byte(fmt.Sprintf("answer not found for %s", reqCmd.Text)))
-			req.Reply(req.WantReply, nil)
+			_, _ = channel.Stderr().Write([]byte(fmt.Sprintf("answer not found for %s", reqCmd.Text)))
+			_ = req.Reply(req.WantReply, nil)
 			if _, err := channel.SendRequest("exit-status", false, []byte{0, 0, 0, 1}); err != nil {
 				log.Printf("failed: %v\n", err)
 			}


### PR DESCRIPTION
fixes all linting errors from `golangci-lint` and tests. Creates a clean baseline for us going forward as the github actions tests, goimports, and golangci-test all pass.