### PR TITLE
Add distinct http port to new iDrac9

### DIFF
--- a/discover/discovery_test.go
+++ b/discover/discovery_test.go
@@ -141,8 +141,11 @@ var (
 	}
 
 	_answers = map[string]map[string][]byte{
-		"IDrac8":      {"/session": []byte(`{"aimGetProp" : {"hostname" :"machine","gui_str_title_bar" :"","OEMHostName" :"machine.example.com","fwVersion" :"2.50.33","sysDesc" :"PowerEdge M630","status" : "OK"}}`)},
-		"IDrac9":      {"/sysmgmt/2015/bmc/info": []byte(`{"Attributes":{"ADEnabled":"Disabled","BuildVersion":"37","FwVer":"3.15.15.15","GUITitleBar":"spare-H16Z4M2","IsOEMBranded":"0","License":"Enterprise","SSOEnabled":"Disabled","SecurityPolicyMessage":"By accessing this computer, you confirm that such access complies with your organization's security policy.","ServerGen":"14G","SrvPrcName":"NULL","SystemLockdown":"Disabled","SystemModelName":"PowerEdge M640","TFAEnabled":"Disabled","iDRACName":"spare-H16Z4M2"}}`)},
+		"IDrac8": {"/session": []byte(`{"aimGetProp" : {"hostname" :"machine","gui_str_title_bar" :"","OEMHostName" :"machine.example.com","fwVersion" :"2.50.33","sysDesc" :"PowerEdge M630","status" : "OK"}}`)},
+		"IDrac9": {
+			"/sysmgmt/2015/bmc/info":    []byte(`{"Attributes":{"ADEnabled":"Disabled","BuildVersion":"37","FwVer":"3.15.15.15","GUITitleBar":"spare-H16Z4M2","IsOEMBranded":"0","License":"Enterprise","SSOEnabled":"Disabled","SecurityPolicyMessage":"By accessing this computer, you confirm that such access complies with your organization's security policy.","ServerGen":"14G","SrvPrcName":"NULL","SystemLockdown":"Disabled","SystemModelName":"PowerEdge M640","TFAEnabled":"Disabled","iDRACName":"spare-H16Z4M2"}}`),
+			"/sysmgmt/2015/bmc/session": []byte(`{"status": "good", "authResult": 7, "forwardUrl": "something", "errorMsg": "none"}`),
+		},
 		"SupermicroX": {"/cgi/login.cgi": []byte("ATEN International")},
 		"Quanta":      {"/page/login.html": []byte("Quanta")},
 		"C7000": {

--- a/discover/probe.go
+++ b/discover/probe.go
@@ -183,7 +183,7 @@ func (p *Probe) idrac9(ctx context.Context, log logr.Logger) (bmcConnection inte
 
 	if resp.StatusCode == 200 && containsAnySubStr(payload, idrac9SysDesc) {
 		log.V(1).Info("step", "connection", "host", p.host, "vendor", string(devices.Dell), "msg", "it's a idrac9")
-		return idrac9.New(ctx, p.host, p.username, p.password, log)
+		return idrac9.New(ctx, p.host, p.host, p.username, p.password, log)
 	}
 
 	return bmcConnection, errors.ErrDeviceNotMatched

--- a/providers/dell/idrac9/actions_test.go
+++ b/providers/dell/idrac9/actions_test.go
@@ -2,6 +2,9 @@ package idrac9
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/bmc-toolbox/bmclib/sshmock"
@@ -46,6 +49,11 @@ var (
 	}
 )
 
+var _answers = map[string][]byte{
+	"/sysmgmt/2015/bmc/info":    []byte(`{"Attributes":{"ADEnabled":"Disabled","BuildVersion":"37","FwVer":"3.15.15.15","GUITitleBar":"spare-H16Z4M2","IsOEMBranded":"0","License":"Enterprise","SSOEnabled":"Disabled","SecurityPolicyMessage":"By accessing this computer, you confirm that such access complies with your organization's security policy.","ServerGen":"14G","SrvPrcName":"NULL","SystemLockdown":"Disabled","SystemModelName":"PowerEdge M640","TFAEnabled":"Disabled","iDRACName":"spare-H16Z4M2"}}`),
+	"/sysmgmt/2015/bmc/session": []byte(`{"status": "good", "authResult": 7, "forwardUrl": "something", "errorMsg": "none"}`),
+}
+
 func setupBMC() (func(), *IDrac9, error) {
 	ssh, err := sshmock.New(sshAnswers)
 	if err != nil {
@@ -55,9 +63,20 @@ func setupBMC() (func(), *IDrac9, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	mux := http.NewServeMux()
+	server := httptest.NewTLSServer(mux)
+	ip := strings.TrimPrefix(server.URL, "https://")
+
+	for url := range _answers {
+		url := url
+
+		mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+			w.Write(_answers[url])
+		})
+	}
 
 	testLogger := logrus.New()
-	bmc, err := New(context.TODO(), address, sshUsername, sshPassword, logrusr.NewLogger(testLogger))
+	bmc, err := New(context.TODO(), address, ip, sshUsername, sshPassword, logrusr.NewLogger(testLogger))
 	if err != nil {
 		tearDown()
 		return nil, nil, err

--- a/providers/dell/idrac9/idrac9.go
+++ b/providers/dell/idrac9/idrac9.go
@@ -41,13 +41,13 @@ type IDrac9 struct {
 }
 
 // New returns a new IDrac9 ready to be used
-func New(ctx context.Context, host string, username string, password string, log logr.Logger) (*IDrac9, error) {
+func New(ctx context.Context, host string, httpHost string, username string, password string, log logr.Logger) (*IDrac9, error) {
 	sshClient, err := sshclient.New(host, username, password)
 	if err != nil {
 		return nil, err
 	}
 
-	idrac := &IDrac9{ip: host, username: username, password: password, sshClient: sshClient, ctx: ctx, log: log}
+	idrac := &IDrac9{ip: httpHost, username: username, password: password, sshClient: sshClient, ctx: ctx, log: log}
 	err = idrac.httpLogin()
 	if err != nil {
 		return nil, err

--- a/providers/dell/idrac9/idrac9_c6420_test.go
+++ b/providers/dell/idrac9/idrac9_c6420_test.go
@@ -3907,7 +3907,7 @@ func setupC6420() (bmc *IDrac9, err error) {
 	}
 
 	testLogger := logrus.New()
-	bmc, err = New(context.TODO(), ip, username, password, logrusr.NewLogger(testLogger))
+	bmc, err = New(context.TODO(), ip, ip, username, password, logrusr.NewLogger(testLogger))
 	if err != nil {
 		return bmc, err
 	}

--- a/providers/dell/idrac9/idrac9_test.go
+++ b/providers/dell/idrac9/idrac9_test.go
@@ -3288,7 +3288,7 @@ func setup() (bmc *IDrac9, err error) {
 	}
 
 	testLogger := logrus.New()
-	bmc, err = New(context.TODO(), ip, username, password, logrusr.NewLogger(testLogger))
+	bmc, err = New(context.TODO(), ip, ip, username, password, logrusr.NewLogger(testLogger))
 	if err != nil {
 		return bmc, err
 	}


### PR DESCRIPTION
Add distinct HTTP port to new iDrac9.
Adding a distinct http port makes testing easier.
mock ssh and http servers can be spun up and passed in.