### PR TITLE
Handle ssh keyboard-interactive auth

### DIFF
--- a/internal/sshclient/sshclient.go
+++ b/internal/sshclient/sshclient.go
@@ -29,7 +29,13 @@ func New(addr string, username string, password string) (*SSHClient, error) {
 		Auth: []ssh.AuthMethod{
 			ssh.Password(password),
 			ssh.KeyboardInteractive(func(user, instruction string, questions []string, echos []bool) ([]string, error) {
-				return []string{}, nil
+				if len(questions) == 0 {
+					return []string{}, nil
+				}
+				if len(questions) == 1 {
+					return []string{password}, nil
+				}
+				return []string{}, fmt.Errorf("unsupported keyboard-interactive auth")
 			}),
 		},
 		HostKeyCallback: func(hostname string, remote net.Addr, key ssh.PublicKey) error {


### PR DESCRIPTION
On iDRAC9 4.22.00.53 ssh started to use keyboard-interactive method
instead of password method (on iDRAC9 4.10.10.10) and answering with
nothing causes the auth to fail.

There is a similar discussion on the forum in:
https://www.dell.com/community/Systems-Management-General/iDRAC8-2-70-70-70-SSH-keyboard-interactive-authentication/td-p/7427565