### PR TITLE
Add Dell PowerEdge R740xd to probe

### DIFF
--- a/discover/probe.go
+++ b/discover/probe.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	idrac8SysDesc = []string{"PowerEdge M630", "PowerEdge R630"}
-	idrac9SysDesc = []string{"PowerEdge M640", "PowerEdge R640", "PowerEdge R6415", "PowerEdge R6515"}
+	idrac9SysDesc = []string{"PowerEdge M640", "PowerEdge R640", "PowerEdge R6415", "PowerEdge R6515", "PowerEdge R740xd"}
 	m1000eSysDesc = []string{"PowerEdge M1000e"}
 )
 


### PR DESCRIPTION
Enable discovery of Dell PowerEdge R740xd machines using idrac9 so we can interact with them.