### PR TITLE
Fix idrac9 session exhaustion:

### DIFF
--- a/providers/dell/idrac9/configure.go
+++ b/providers/dell/idrac9/configure.go
@@ -143,7 +143,10 @@ func (i *IDrac9) Bios(cfg *cfgresources.Bios) (err error) {
 // Iterate over iDrac users and adds/removes/modifies user accounts
 // nolint: gocyclo
 func (i *IDrac9) User(cfgUsers []*cfgresources.User) (err error) {
-
+	err = i.httpLogin()
+	if err != nil {
+		return err
+	}
 	err = i.validateCfg(cfgUsers)
 	if err != nil {
 		msg := "Config validation failed."

--- a/providers/dell/idrac9/idrac9.go
+++ b/providers/dell/idrac9/idrac9.go
@@ -48,11 +48,6 @@ func New(ctx context.Context, host string, httpHost string, username string, pas
 	}
 
 	idrac := &IDrac9{ip: httpHost, username: username, password: password, sshClient: sshClient, ctx: ctx, log: log}
-	err = idrac.httpLogin()
-	if err != nil {
-		return nil, err
-	}
-
 	return idrac, nil
 }
 


### PR DESCRIPTION
Running probe multiple times exhausts the login
sessions for idrac9 as the idrac.New would open a
session to the idrac but not close it. I moved the
login to Users as this was the original reason to
have the login in New.
