### PR TITLE
Log err instead of err.Error

### DIFF
--- a/providers/dell/idrac8/configure.go
+++ b/providers/dell/idrac8/configure.go
@@ -90,7 +90,7 @@ func (i *IDrac8) User(cfgUsers []*cfgresources.User) (err error) {
 			"step", "applyUserParams",
 			"IP", i.ip,
 			"Model", i.HardwareType(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -103,7 +103,7 @@ func (i *IDrac8) User(cfgUsers []*cfgresources.User) (err error) {
 			"step", "applyUserParams",
 			"IP", i.ip,
 			"Model", i.HardwareType(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -124,7 +124,7 @@ func (i *IDrac8) User(cfgUsers []*cfgresources.User) (err error) {
 						"Model", i.HardwareType(),
 						"step", helper.WhosCalling(),
 						"User", cfgUser.Name,
-						"Error", err.Error(),
+						"Error", err,
 					)
 					continue
 				}
@@ -151,7 +151,7 @@ func (i *IDrac8) User(cfgUsers []*cfgresources.User) (err error) {
 					"Model", i.HardwareType(),
 					"step", helper.WhosCalling(),
 					"User", cfgUser.Name,
-					"Error", err.Error(),
+					"Error", err,
 				)
 				continue
 			}
@@ -174,7 +174,7 @@ func (i *IDrac8) User(cfgUsers []*cfgresources.User) (err error) {
 					"Model", i.HardwareType(),
 					"step", helper.WhosCalling(),
 					"User", cfgUser.Name,
-					"Error", err.Error(),
+					"Error", err,
 				)
 			}
 		}
@@ -666,7 +666,7 @@ func (i *IDrac8) GenerateCSR(cert *cfgresources.HTTPSCertAttributes) ([]byte, er
 			"Model", i.HardwareType(),
 			"endpoint", endpoint,
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return []byte{}, err
 	}
@@ -737,7 +737,7 @@ func (i *IDrac8) UploadHTTPSCert(cert []byte, certFileName string, key []byte, k
 			"step", helper.WhosCalling(),
 			"IP", i.ip,
 			"Model", i.HardwareType(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return false, err
 	}
@@ -748,7 +748,7 @@ func (i *IDrac8) UploadHTTPSCert(cert []byte, certFileName string, key []byte, k
 			"step", helper.WhosCalling(),
 			"IP", i.ip,
 			"Model", i.HardwareType(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return false, err
 	}

--- a/providers/dell/idrac8/query.go
+++ b/providers/dell/idrac8/query.go
@@ -81,7 +81,7 @@ func (i *IDrac8) queryUsers() (userInfo UserInfo, err error) {
 			"Model", i.HardwareType(),
 			"endpoint", endpoint,
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return userInfo, err
 	}
@@ -94,7 +94,7 @@ func (i *IDrac8) queryUsers() (userInfo UserInfo, err error) {
 			"resource", "User",
 			"IP", i.ip,
 			"Model", i.HardwareType(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return userInfo, err
 	}

--- a/providers/dell/idrac9/configure.go
+++ b/providers/dell/idrac9/configure.go
@@ -55,7 +55,7 @@ func (i *IDrac9) Bios(cfg *cfgresources.Bios) (err error) {
 	validate := validator.New()
 	err = validate.Struct(newBiosSettings)
 	if err != nil {
-		i.log.V(1).Error(err, "Config validation failed.", "step", "applyBiosParams", "Error", err.Error())
+		i.log.V(1).Error(err, "Config validation failed.", "step", "applyBiosParams", "Error", err)
 		return err
 	}
 
@@ -67,7 +67,7 @@ func (i *IDrac9) Bios(cfg *cfgresources.Bios) (err error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return errors.New(msg)
 	}
@@ -82,7 +82,7 @@ func (i *IDrac9) Bios(cfg *cfgresources.Bios) (err error) {
 				"IP", i.ip,
 				"Model", i.HardwareType(),
 				"step", helper.WhosCalling(),
-				"Error", err.Error(),
+				"Error", err,
 			)
 			return err
 		}
@@ -103,7 +103,7 @@ func (i *IDrac9) Bios(cfg *cfgresources.Bios) (err error) {
 				"resource", "Bios",
 				"IP", i.ip,
 				"Model", i.HardwareType(),
-				"Bios settings pending", err.Error(),
+				"Bios settings pending", err,
 			)
 		}
 
@@ -114,7 +114,7 @@ func (i *IDrac9) Bios(cfg *cfgresources.Bios) (err error) {
 				"IP", i.ip,
 				"Model", i.HardwareType(),
 				"step", helper.WhosCalling(),
-				"Error", err.Error(),
+				"Error", err,
 			)
 			return errors.New(msg)
 		}
@@ -151,7 +151,7 @@ func (i *IDrac9) User(cfgUsers []*cfgresources.User) (err error) {
 			"step", "applyUserParams",
 			"IP", i.ip,
 			"Model", i.HardwareType(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return errors.New(msg)
 	}
@@ -163,7 +163,7 @@ func (i *IDrac9) User(cfgUsers []*cfgresources.User) (err error) {
 			"step", "applyUserParams",
 			"IP", i.ip,
 			"Model", i.HardwareType(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return errors.New(msg)
 	}
@@ -185,7 +185,7 @@ func (i *IDrac9) User(cfgUsers []*cfgresources.User) (err error) {
 						"Model", i.HardwareType(),
 						"step", helper.WhosCalling(),
 						"User", cfgUser.Name,
-						"Error", err.Error(),
+						"Error", err,
 					)
 					continue
 				}
@@ -212,7 +212,7 @@ func (i *IDrac9) User(cfgUsers []*cfgresources.User) (err error) {
 					"Model", i.HardwareType(),
 					"step", helper.WhosCalling(),
 					"User", cfgUser.Name,
-					"Error", err.Error(),
+					"Error", err,
 				)
 				continue
 			}
@@ -229,7 +229,7 @@ func (i *IDrac9) User(cfgUsers []*cfgresources.User) (err error) {
 					"Model", i.HardwareType(),
 					"step", helper.WhosCalling(),
 					"User", cfgUser.Name,
-					"Error", err.Error(),
+					"Error", err,
 					"StatusCode", statusCode,
 					"Response", response,
 				)
@@ -323,7 +323,7 @@ func (i *IDrac9) Ldap(cfg *cfgresources.Ldap) (err error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -344,7 +344,7 @@ func (i *IDrac9) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.
 			"step", "applyUserParams",
 			"IP", i.ip,
 			"Model", i.HardwareType(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -372,7 +372,7 @@ func (i *IDrac9) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.
 						"step", helper.WhosCalling(),
 						"Ldap Role Group", cfgRole.Group,
 						"Role Group DN", cfgRole.Role,
-						"Error", err.Error(),
+						"Error", err,
 					)
 					continue
 				}
@@ -395,7 +395,7 @@ func (i *IDrac9) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.
 					"step", helper.WhosCalling(),
 					"Ldap Role Group", cfgRole.Group,
 					"Role Group DN", cfgRole.Role,
-					"Error", err.Error(),
+					"Error", err,
 				)
 				continue
 			}
@@ -415,7 +415,7 @@ func (i *IDrac9) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.
 					"step", helper.WhosCalling(),
 					"Ldap Role Group", cfgRole.Group,
 					"Role Group DN", cfgRole.Role,
-					"Error", err.Error(),
+					"Error", err,
 				)
 				continue
 			}
@@ -488,7 +488,7 @@ func (i *IDrac9) Ntp(cfg *cfgresources.Ntp) (err error) {
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
 			"Timezone", cfg.Timezone,
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -506,7 +506,7 @@ func (i *IDrac9) Ntp(cfg *cfgresources.Ntp) (err error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -565,7 +565,7 @@ func (i *IDrac9) Syslog(cfg *cfgresources.Syslog) (err error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -577,7 +577,7 @@ func (i *IDrac9) Syslog(cfg *cfgresources.Syslog) (err error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -589,7 +589,7 @@ func (i *IDrac9) Syslog(cfg *cfgresources.Syslog) (err error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -653,7 +653,7 @@ func (i *IDrac9) Network(cfg *cfgresources.Network) (reset bool, err error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 	}
 
@@ -663,7 +663,7 @@ func (i *IDrac9) Network(cfg *cfgresources.Network) (reset bool, err error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 	}
 
@@ -673,7 +673,7 @@ func (i *IDrac9) Network(cfg *cfgresources.Network) (reset bool, err error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 	}
 
@@ -683,7 +683,7 @@ func (i *IDrac9) Network(cfg *cfgresources.Network) (reset bool, err error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 	}
 
@@ -776,7 +776,7 @@ func (i *IDrac9) UploadHTTPSCert(cert []byte, certFileName string, key []byte, k
 			"step", helper.WhosCalling(),
 			"IP", i.ip,
 			"Model", i.HardwareType(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return false, err
 	}
@@ -787,7 +787,7 @@ func (i *IDrac9) UploadHTTPSCert(cert []byte, certFileName string, key []byte, k
 			"step", helper.WhosCalling(),
 			"IP", i.ip,
 			"Model", i.HardwareType(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return false, err
 	}

--- a/providers/dell/idrac9/query.go
+++ b/providers/dell/idrac9/query.go
@@ -65,7 +65,7 @@ func (i *IDrac9) queryUsers() (users map[int]User, err error) {
 			"Model", i.HardwareType(),
 			"endpoint", endpoint,
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return users, err
 	}
@@ -78,7 +78,7 @@ func (i *IDrac9) queryUsers() (users map[int]User, err error) {
 			"Model", i.HardwareType(),
 			"resource", "User",
 			"step", "queryUserInfo",
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return users, err
 	}
@@ -97,7 +97,7 @@ func (i *IDrac9) queryLdapRoleGroups() (ldapRoleGroups LdapRoleGroups, err error
 			"Model", i.HardwareType(),
 			"endpoint", endpoint,
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return ldapRoleGroups, err
 	}
@@ -110,7 +110,7 @@ func (i *IDrac9) queryLdapRoleGroups() (ldapRoleGroups LdapRoleGroups, err error
 			"Model", i.HardwareType(),
 			"resource", "User",
 			"step", "queryUserInfo",
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return ldapRoleGroups, err
 	}

--- a/providers/dell/m1000e/configure.go
+++ b/providers/dell/m1000e/configure.go
@@ -197,7 +197,7 @@ func (m *M1000e) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.
 				"Ldap role", group.Role,
 				"IP", m.ip,
 				"Model", m.HardwareType(),
-				"Error", err.Error(),
+				"Error", err,
 			)
 			return err
 		}

--- a/providers/dell/m1000e/m1000e.go
+++ b/providers/dell/m1000e/m1000e.go
@@ -349,7 +349,7 @@ func (m *M1000e) StorageBlades() (storageBlades []*devices.StorageBlade, err err
 					"ip", m.ip,
 					"position", storageBlade.BladePosition,
 					"type", "chassis",
-					"error", err.Error(),
+					"error", err,
 				)
 				continue
 			}

--- a/providers/hp/c7000/configure.go
+++ b/providers/hp/c7000/configure.go
@@ -75,7 +75,7 @@ func (c *C7000) Ldap(cfg *cfgresources.Ldap) (err error) {
 			"resource", "Ldap",
 			"IP", c.ip,
 			"Model", c.HardwareType(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -87,7 +87,7 @@ func (c *C7000) Ldap(cfg *cfgresources.Ldap) (err error) {
 			"resource", "Ldap",
 			"IP", c.ip,
 			"Model", c.HardwareType(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -161,7 +161,7 @@ func (c *C7000) applysetLdapInfo4(cfg *cfgresources.Ldap) (err error) {
 			"IP", c.ip,
 			"Model", c.HardwareType(),
 			"statusCode", statusCode,
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -187,7 +187,7 @@ func (c *C7000) applyEnableLdapAuth(enable bool) (err error) {
 			"IP", c.ip,
 			"Model", c.HardwareType(),
 			"statusCode", statusCode,
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -227,7 +227,7 @@ func (c *C7000) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.L
 					"resource", "Ldap",
 					"IP", c.ip,
 					"Model", c.HardwareType(),
-					"Error", err.Error(),
+					"Error", err,
 				)
 				return
 			}
@@ -252,7 +252,7 @@ func (c *C7000) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.L
 				"resource", "Ldap",
 				"IP", c.ip,
 				"Model", c.HardwareType(),
-				"Error", err.Error(),
+				"Error", err,
 			)
 			return
 		}
@@ -265,7 +265,7 @@ func (c *C7000) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.L
 				"resource", "Ldap",
 				"IP", c.ip,
 				"Model", c.HardwareType(),
-				"Error", err.Error(),
+				"Error", err,
 			)
 			return
 		}
@@ -278,7 +278,7 @@ func (c *C7000) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.L
 				"resource", "Ldap",
 				"IP", c.ip,
 				"Model", c.HardwareType(),
-				"Error", err.Error(),
+				"Error", err,
 			)
 			return
 		}
@@ -385,7 +385,7 @@ func (c *C7000) applyLdapGroupBayACL(role string, group string) (err error) {
 			"IP", c.ip,
 			"Model", c.HardwareType(),
 			"statusCode", statusCode,
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -470,7 +470,7 @@ func (c *C7000) applyAddLdapGroupBayAccess(group string) (err error) {
 			"IP", c.ip,
 			"Model", c.HardwareType(),
 			"statusCode", statusCode,
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -600,7 +600,7 @@ func (c *C7000) setUserPassword(user string, password string) (err error) {
 			"IP", c.ip,
 			"Model", c.HardwareType(),
 			"return code", statusCode,
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -636,7 +636,7 @@ func (c *C7000) setUserACL(user string, role string) (err error) {
 			"IP", c.ip,
 			"Model", c.HardwareType(),
 			"return code", statusCode,
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -697,7 +697,7 @@ func (c *C7000) applyAddUserBayAccess(user string) (err error) {
 			"IP", c.ip,
 			"Model", c.HardwareType(),
 			"statusCode", statusCode,
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -766,7 +766,7 @@ func (c *C7000) Ntp(cfg *cfgresources.Ntp) (err error) {
 			"IP", c.ip,
 			"Model", c.HardwareType(),
 			"StatusCode", statusCode,
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -777,7 +777,7 @@ func (c *C7000) Ntp(cfg *cfgresources.Ntp) (err error) {
 			"step", "applyNtpParams",
 			"IP", c.ip,
 			"Model", c.HardwareType(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -802,7 +802,7 @@ func (c *C7000) applyNtpTimezoneParam(timezone string) (err error) {
 			"step", "applyNtpTimezoneParam",
 			"IP", c.ip,
 			"Model", c.HardwareType(),
-			"Error", err.Error(),
+			"Error", err,
 			"StatusCode", statusCode,
 		)
 		return err
@@ -877,7 +877,7 @@ func (c *C7000) applySyslogServer(server string) {
 			"step", "applySyslogServer",
 			"IP", c.ip,
 			"Model", c.HardwareType(),
-			"Error", err.Error(),
+			"Error", err,
 			"StatusCode", statusCode,
 		)
 		return
@@ -901,7 +901,7 @@ func (c *C7000) applySyslogPort(port int) {
 			"step", "applySyslogPort",
 			"IP", c.ip,
 			"Model", c.HardwareType(),
-			"Error", err.Error(),
+			"Error", err,
 			"StatusCode", statusCode,
 		)
 		return
@@ -926,7 +926,7 @@ func (c *C7000) applySyslogEnabled(enabled bool) {
 			"step", "SetRemoteSyslogEnabled",
 			"IP", c.ip,
 			"Model", c.HardwareType(),
-			"Error", err.Error(),
+			"Error", err,
 			"StatusCode", statusCode,
 		)
 		return

--- a/providers/hp/ilo/configure.go
+++ b/providers/hp/ilo/configure.go
@@ -98,7 +98,7 @@ func (i *Ilo) User(users []*cfgresources.User) (err error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", "applyUserParams",
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return errors.New(msg)
 	}
@@ -185,7 +185,7 @@ func (i *Ilo) User(users []*cfgresources.User) (err error) {
 					"Model", i.HardwareType(),
 					"step", helper.WhosCalling(),
 					"User", user.Name,
-					"Error", err.Error(),
+					"Error", err,
 				)
 				continue
 			}
@@ -202,7 +202,7 @@ func (i *Ilo) User(users []*cfgresources.User) (err error) {
 					"User", user.Name,
 					"StatusCode", statusCode,
 					"response", string(response),
-					"Error", err.Error(),
+					"Error", err,
 				)
 
 				continue
@@ -260,7 +260,7 @@ func (i *Ilo) Syslog(cfg *cfgresources.Syslog) (err error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return errors.New(msg)
 	}
@@ -276,7 +276,7 @@ func (i *Ilo) Syslog(cfg *cfgresources.Syslog) (err error) {
 			"step", helper.WhosCalling(),
 			"StatusCode", statusCode,
 			"response", string(response),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return errors.New(msg)
 	}
@@ -309,7 +309,7 @@ func (i *Ilo) SetLicense(cfg *cfgresources.License) (err error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return errors.New(msg)
 	}
@@ -325,7 +325,7 @@ func (i *Ilo) SetLicense(cfg *cfgresources.License) (err error) {
 			"step", helper.WhosCalling(),
 			"StatusCode", statusCode,
 			"response", string(response),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return errors.New(msg)
 	}
@@ -381,7 +381,7 @@ func (i *Ilo) Ntp(cfg *cfgresources.Ntp) (err error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return errors.New(msg)
 	}
@@ -414,7 +414,7 @@ func (i *Ilo) Ntp(cfg *cfgresources.Ntp) (err error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return errors.New(msg)
 	}
@@ -430,7 +430,7 @@ func (i *Ilo) Ntp(cfg *cfgresources.Ntp) (err error) {
 			"step", helper.WhosCalling(),
 			"StatusCode", statusCode,
 			"response", string(response),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return errors.New(msg)
 	}
@@ -452,7 +452,7 @@ func (i *Ilo) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.Lda
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return errors.New(msg)
 	}
@@ -532,7 +532,7 @@ func (i *Ilo) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.Lda
 					"Model", i.HardwareType(),
 					"step", helper.WhosCalling(),
 					"Group", group.Group,
-					"Error", err.Error(),
+					"Error", err,
 				)
 				continue
 			}
@@ -548,7 +548,7 @@ func (i *Ilo) LdapGroup(cfg []*cfgresources.LdapGroup, cfgLdap *cfgresources.Lda
 					"Group", group.Group,
 					"StatusCode", statusCode,
 					"response", string(response),
-					"Error", err.Error(),
+					"Error", err,
 				)
 				continue
 			}
@@ -623,7 +623,7 @@ func (i *Ilo) Ldap(cfg *cfgresources.Ldap) (err error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}
@@ -639,7 +639,7 @@ func (i *Ilo) Ldap(cfg *cfgresources.Ldap) (err error) {
 			"step", helper.WhosCalling(),
 			"StatusCode", statusCode,
 			"response", string(response),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return err
 	}

--- a/providers/hp/ilo/query.go
+++ b/providers/hp/ilo/query.go
@@ -67,7 +67,7 @@ func (i *Ilo) queryDirectoryGroups() (directoryGroups []DirectoryGroups, err err
 			"Model", i.HardwareType(),
 			"endpoint", endpoint,
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return directoryGroups, err
 	}
@@ -81,7 +81,7 @@ func (i *Ilo) queryDirectoryGroups() (directoryGroups []DirectoryGroups, err err
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return directoryGroups, err
 	}
@@ -101,7 +101,7 @@ func (i *Ilo) queryUsers() (usersInfo []UserInfo, err error) {
 			"Model", i.HardwareType(),
 			"endpoint", endpoint,
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return usersInfo, err
 	}
@@ -116,7 +116,7 @@ func (i *Ilo) queryUsers() (usersInfo []UserInfo, err error) {
 			"Model", i.HardwareType(),
 			"resource", "User",
 			"step", "queryUserInfo",
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return usersInfo, err
 	}
@@ -136,7 +136,7 @@ func (i *Ilo) queryNetworkSntp() (networkSntp NetworkSntp, err error) {
 			"Model", i.HardwareType(),
 			"endpoint", endpoint,
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return networkSntp, err
 	}
@@ -148,7 +148,7 @@ func (i *Ilo) queryNetworkSntp() (networkSntp NetworkSntp, err error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return networkSntp, err
 	}
@@ -170,7 +170,7 @@ func (i *Ilo) queryAccessSettings() (AccessSettings, error) {
 			"Model", i.HardwareType(),
 			"endpoint", endpoint,
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return accessSettings, err
 	}
@@ -182,7 +182,7 @@ func (i *Ilo) queryAccessSettings() (AccessSettings, error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return accessSettings, err
 	}
@@ -204,7 +204,7 @@ func (i *Ilo) queryNetworkIPv4() (NetworkIPv4, error) {
 			"Model", i.HardwareType(),
 			"endpoint", endpoint,
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return networkIPv4, err
 	}
@@ -216,7 +216,7 @@ func (i *Ilo) queryNetworkIPv4() (NetworkIPv4, error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return networkIPv4, err
 	}
@@ -238,7 +238,7 @@ func (i *Ilo) queryPowerRegulator() (PowerRegulator, error) {
 			"Model", i.HardwareType(),
 			"endpoint", endpoint,
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return PowerRegulator{}, err
 	}
@@ -250,7 +250,7 @@ func (i *Ilo) queryPowerRegulator() (PowerRegulator, error) {
 			"IP", i.ip,
 			"Model", i.HardwareType(),
 			"step", helper.WhosCalling(),
-			"Error", err.Error(),
+			"Error", err,
 		)
 		return PowerRegulator{}, err
 	}

--- a/providers/supermicro/supermicrox/configure.go
+++ b/providers/supermicro/supermicrox/configure.go
@@ -83,7 +83,7 @@ func (s *SupermicroX) queryUserAccounts() (userAccounts map[string]int, err erro
 	userAccounts = make(map[string]int)
 	ipmi, err := s.query("CONFIG_INFO.XML=(0,0)")
 	if err != nil {
-		s.log.V(1).Info("error querying user accounts", "error", err.Error())
+		s.log.V(1).Info("error querying user accounts", "error", err)
 		return userAccounts, err
 	}
 
@@ -106,7 +106,7 @@ func (s *SupermicroX) User(users []*cfgresources.User) (err error) {
 	currentUsers, err := s.queryUserAccounts()
 	if err != nil {
 		msg := "Unable to query current user accounts."
-		s.log.V(1).Info(msg, "ip", s.ip, "model", s.HardwareType(), "step", helper.WhosCalling(), "error", err.Error())
+		s.log.V(1).Info(msg, "ip", s.ip, "model", s.HardwareType(), "step", helper.WhosCalling(), "error", err)
 		return errors.New(msg)
 	}
 
@@ -169,7 +169,7 @@ func (s *SupermicroX) User(users []*cfgresources.User) (err error) {
 				"endpoint", endpoint,
 				"statusCode", statusCode,
 				"step", helper.WhosCalling(),
-				"error", err.Error())
+				"error", err)
 			return errors.New(msg)
 		}
 
@@ -221,7 +221,7 @@ func (s *SupermicroX) Network(cfg *cfgresources.Network) (reset bool, err error)
 			"endpoint", endpoint,
 			"statusCode", statusCode,
 			"step", helper.WhosCalling(),
-			"error", err.Error())
+			"error", err)
 		return reset, errors.New(msg)
 	}
 
@@ -254,7 +254,7 @@ func (s *SupermicroX) Ntp(cfg *cfgresources.Ntp) (err error) {
 			"step", "applyNtpParams",
 			"model", s.HardwareType(),
 			"declaredTtimezone", cfg.Timezone,
-			"error", err.Error())
+			"error", err)
 		return
 	}
 
@@ -307,7 +307,7 @@ func (s *SupermicroX) Ntp(cfg *cfgresources.Ntp) (err error) {
 			"endpoint", endpoint,
 			"statusCode", statusCode,
 			"step", helper.WhosCalling(),
-			"error", err.Error())
+			"error", err)
 		return errors.New(msg)
 	}
 
@@ -431,7 +431,7 @@ func (s *SupermicroX) LdapGroup(cfgGroup []*cfgresources.LdapGroup, cfgLdap *cfg
 				"model", s.HardwareType(),
 				"endpoint", endpoint,
 				"statusCode", statusCode,
-				"error", err.Error())
+				"error", err)
 			return errors.New(msg)
 		}
 	}
@@ -493,7 +493,7 @@ func (s *SupermicroX) Syslog(cfg *cfgresources.Syslog) (err error) {
 			"model", s.HardwareType(),
 			"endpoint", endpoint,
 			"statusCode", statusCode,
-			"error", err.Error())
+			"error", err)
 		return errors.New(msg)
 	}
 
@@ -512,7 +512,7 @@ func (s *SupermicroX) Syslog(cfg *cfgresources.Syslog) (err error) {
 			"model", s.HardwareType(),
 			"endpoint", endpoint,
 			"statusCode", statusCode,
-			"error", err.Error())
+			"error", err)
 		return errors.New(msg)
 	}
 
@@ -575,7 +575,7 @@ func (s *SupermicroX) UploadHTTPSCert(cert []byte, certFileName string, key []by
 			"model", s.HardwareType(),
 			"endpoint", endpoint,
 			"statusCode", status,
-			"error", err.Error())
+			"error", err)
 		return false, err
 	}
 
@@ -617,7 +617,7 @@ func (s *SupermicroX) validateSSL() error {
 			"model", s.HardwareType(),
 			"endpoint", endpoint,
 			"statusCode", status,
-			"error", err.Error())
+			"error", err)
 		return err
 	}
 
@@ -642,7 +642,7 @@ func (s *SupermicroX) statusSSL() error {
 			"model", s.HardwareType(),
 			"endpoint", endpoint,
 			"statusCode", status,
-			"error", err.Error())
+			"error", err)
 		return err
 	}
 

--- a/providers/supermicro/supermicrox/supermicrox.go
+++ b/providers/supermicro/supermicrox/supermicrox.go
@@ -247,7 +247,7 @@ func (s *SupermicroX) HardwareType() (model string) {
 	m, err := s.Model()
 	if err != nil {
 		// Here is your sin
-		s.log.V(1).Info("error getting hardwaretype", "err", err.Error())
+		s.log.V(1).Info("error getting hardwaretype", "err", err)
 		return model
 	}
 	if strings.Contains(strings.ToLower(m), X10) {


### PR DESCRIPTION
bmcbutler started to crash after updating bmclib module to v0.4.4. This
happens in cases like `if err != nil || statusCode != 200 { ... }`

Examples of stacktraces:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xb2b9ae]

goroutine 140743 [running]:
github.com/bmc-toolbox/bmclib/providers/hp/ilo.(*Ilo).User(0xc004e56480, 0xc000112580, 0x3, 0x3, 0x1, 0xc005464c30)
    bmcbutler/vendor/github.com/bmc-toolbox/bmclib/providers/hp/ilo/configure.go:205 +0xa6e
github.com/bmc-toolbox/bmcbutler/pkg/butler/configure.(*Bmc).Apply(0xc00617f540)

---

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xb3007b]

goroutine 29007 [running]:
github.com/bmc-toolbox/bmclib/providers/hp/ilo.(*Ilo).Ntp(0xc0068ca000, 0xc004246c80, 0xc005820398, 0x1)
    bmcbutler/vendor/github.com/bmc-toolbox/bmclib/providers/hp/ilo/configure.go:433 +0xe7b
github.com/bmc-toolbox/bmcbutler/pkg/butler/configure.(*Bmc).Apply(0xc0001dba40)

---

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xb2d1b5]

goroutine 511214 [running]:
github.com/bmc-toolbox/bmclib/providers/hp/ilo.(*Ilo).Syslog(0xc001d46180, 0xc0005f8700, 0xc0008c4398, 0x1)
    bmcbutler/vendor/github.com/bmc-toolbox/bmclib/providers/hp/ilo/configure.go:279 +0x795
github.com/bmc-toolbox/bmcbutler/pkg/butler/configure.(*Bmc).Apply(0xc0007685a0)