### PR TITLE
Add registry package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-logr/logr v0.3.0
 	github.com/go-playground/universal-translator v0.17.0 // indirect
+	github.com/google/go-cmp v0.3.0
 	github.com/google/go-querystring v1.0.0
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,7 @@ github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,0 +1,125 @@
+package registry
+
+var (
+	registries Collection
+)
+
+const (
+	// FeaturePowerState represents the powerstate functionality
+	// an implementation will use these when they have implemented
+	// corresponding interface method.
+	FeaturePowerState    Feature = "powerstate"
+	FeaturePowerSet      Feature = "powerset"
+	FeatureUserCreate    Feature = "usercreate"
+	FeatureUserDelete    Feature = "userdelete"
+	FeatureUserUpdate    Feature = "userupdate"
+	FeatureUserRead      Feature = "userread"
+	FeatureBmcReset      Feature = "bmcreset"
+	FeatureBootDeviceSet Feature = "bootdeviceset"
+)
+
+// Features holds the features a provider supports
+type Features []Feature
+
+// Feature represents a single feature available
+type Feature string
+
+// Collection holds a slice of Registry types
+type Collection []*Registry
+
+// InitRegistry function for setting connection details of a provider
+type InitRegistry func(host, user, pass string) (interface{}, error)
+
+// Registry holds the info about a provider
+type Registry struct {
+	Provider string
+	Protocol string
+	InitFn   InitRegistry
+	Features Features
+}
+
+// Include does the actual work of filtering for specific features
+func (rf Features) Include(features ...Feature) bool {
+	if len(features) > len(rf) {
+		return false
+	}
+	fKeys := make(map[Feature]bool)
+	for _, v := range rf {
+		fKeys[v] = true
+	}
+	for _, f := range features {
+		if _, ok := fKeys[f]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// Supports does the actual work of filtering for specific features
+func (rc Collection) Supports(features ...Feature) Collection {
+	supportedRegistries := make(Collection, 0)
+	for _, reg := range rc {
+		if reg.Features.Include(features...) {
+			supportedRegistries = append(supportedRegistries, reg)
+		}
+	}
+	return supportedRegistries
+}
+
+// Using does the actual work of filtering for a specific protocol type
+func (rc Collection) Using(proto string) Collection {
+	supportedRegistries := make(Collection, 0)
+	for _, reg := range rc {
+		if reg.Protocol == proto {
+			supportedRegistries = append(supportedRegistries, reg)
+		}
+	}
+	return supportedRegistries
+}
+
+// For does the actual work of filtering for a specific provider name
+func (rc Collection) For(provider string) Collection {
+	supportedRegistries := make(Collection, 0)
+	for _, reg := range rc {
+		if reg.Provider == provider {
+			supportedRegistries = append(supportedRegistries, reg)
+		}
+	}
+	return supportedRegistries
+}
+
+// All returns all the providers in the registry collection
+func All() Collection {
+	return registries
+}
+
+// Supports will filter the registry collection for providers that support a specific
+// implemented feature
+func Supports(features ...Feature) Collection {
+	return All().Supports(features...)
+}
+
+// Using will filter the registry collection for providers using a specific protocol
+func Using(proto string) Collection {
+	return All().Using(proto)
+}
+
+// For will filter the registry collection for the name of a specific type of provider
+func For(provider string) Collection {
+	return All().For(provider)
+}
+
+// Register will add a provider with details to the main registryCollection
+func Register(provider, protocol string, initfn InitRegistry, features []Feature) {
+	regFeatures := make(Features, len(features))
+	for i, v := range features {
+		regFeatures[i] = v
+	}
+
+	registries = append(registries, &Registry{
+		Provider: provider,
+		Protocol: protocol,
+		InitFn:   initfn,
+		Features: regFeatures,
+	})
+}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,0 +1,309 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestInclude(t *testing.T) {
+	testCases := []struct {
+		name     string
+		features Features
+		includes Features
+		want     bool
+	}{
+		{name: "feature is not included 1", features: Features{}, includes: Features{FeaturePowerSet}, want: false},
+		{name: "feature is not included 2", features: Features{FeatureUserCreate}, includes: Features{FeaturePowerSet}, want: false},
+		{name: "feature included", features: Features{FeaturePowerSet}, includes: Features{FeaturePowerSet}, want: true},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.features.Include(tc.includes...)
+			diff := cmp.Diff(tc.want, result)
+			if diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestSupports(t *testing.T) {
+	testCases := []struct {
+		name       string
+		collection Collection
+		supports   Features
+		want       Collection
+	}{
+		{
+			name: "no registry supports UserCreate",
+			collection: []*Registry{
+				&Registry{
+					Provider: "ipmitool",
+					Protocol: "ipmi",
+					Features: []Feature{FeaturePowerSet},
+					InitFn:   nil,
+				}},
+			supports: Features{
+				FeatureUserCreate,
+			},
+			want: []*Registry{},
+		},
+		{
+			name: "one registry supports UserCreate",
+			collection: []*Registry{
+				&Registry{
+					Provider: "ipmitool",
+					Protocol: "ipmi",
+					Features: []Feature{FeatureUserCreate},
+					InitFn:   nil,
+				}},
+			supports: Features{
+				FeatureUserCreate,
+			},
+			want: []*Registry{&Registry{
+				Provider: "ipmitool",
+				Protocol: "ipmi",
+				InitFn:   nil,
+				Features: []Feature{FeatureUserCreate},
+			}},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.collection.Supports(tc.supports...)
+			diff := cmp.Diff(tc.want, result)
+			if diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestUsing(t *testing.T) {
+	testCases := []struct {
+		name       string
+		collection Collection
+		proto      string
+		want       Collection
+	}{
+		{
+			name: "proto is not found",
+			collection: []*Registry{
+				&Registry{
+					Provider: "ipmitool",
+					Protocol: "ipmi",
+					Features: []Feature{FeaturePowerSet},
+					InitFn:   nil,
+				}},
+			proto: "web",
+			want:  []*Registry{},
+		},
+		{
+			name: "proto is found",
+			collection: []*Registry{
+				&Registry{
+					Provider: "ipmitool",
+					Protocol: "ipmi",
+					Features: []Feature{FeaturePowerSet},
+					InitFn:   nil,
+				}},
+			proto: "ipmi",
+			want: []*Registry{
+				&Registry{
+					Provider: "ipmitool",
+					Protocol: "ipmi",
+					Features: []Feature{FeaturePowerSet},
+					InitFn:   nil,
+				}},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.collection.Using(tc.proto)
+			diff := cmp.Diff(tc.want, result)
+			if diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestFor(t *testing.T) {
+	testCases := []struct {
+		name       string
+		collection Collection
+		provider   string
+		want       Collection
+	}{
+		{
+			name: "proto is not found",
+			collection: []*Registry{
+				&Registry{
+					Provider: "ipmitool",
+					Protocol: "ipmi",
+					Features: []Feature{FeaturePowerSet},
+					InitFn:   nil,
+				}},
+			provider: "dell",
+			want:     []*Registry{},
+		},
+		{
+			name: "proto is found",
+			collection: []*Registry{
+				&Registry{
+					Provider: "ipmitool",
+					Protocol: "ipmi",
+					Features: []Feature{FeaturePowerSet},
+					InitFn:   nil,
+				}},
+			provider: "ipmitool",
+			want: []*Registry{
+				&Registry{
+					Provider: "ipmitool",
+					Protocol: "ipmi",
+					Features: []Feature{FeaturePowerSet},
+					InitFn:   nil,
+				}},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.collection.For(tc.provider)
+			diff := cmp.Diff(tc.want, result)
+			if diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestAll(t *testing.T) {
+	testCases := []struct {
+		name         string
+		addARegistry bool
+		want         Collection
+	}{
+		{name: "empty collection", want: nil},
+		{name: "single collection", addARegistry: true, want: []*Registry{&Registry{
+			Provider: "dell",
+			Protocol: "web",
+			InitFn:   nil,
+			Features: []Feature{FeaturePowerSet},
+		}}},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// register
+			if tc.addARegistry {
+				Register("dell", "web", nil, []Feature{FeaturePowerSet})
+			}
+			result := All()
+			diff := cmp.Diff(tc.want, result)
+			if diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestSupportFn(t *testing.T) {
+	testCases := []struct {
+		name         string
+		addARegistry bool
+		features     []Feature
+		want         Collection
+	}{
+		{name: "empty collection", want: []*Registry{}},
+		{name: "single collection", features: []Feature{FeatureUserCreate}, addARegistry: true, want: []*Registry{&Registry{
+			Provider: "dell",
+			Protocol: "web",
+			InitFn:   nil,
+			Features: []Feature{FeatureUserCreate},
+		}}},
+	}
+	registries = nil
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// register
+			if tc.addARegistry {
+				Register("dell", "web", nil, []Feature{FeatureUserCreate})
+			}
+			result := Supports(tc.features...)
+			diff := cmp.Diff(tc.want, result)
+			if diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestUsingFn(t *testing.T) {
+	testCases := []struct {
+		name         string
+		addARegistry bool
+		proto        string
+		want         Collection
+	}{
+		{name: "empty collection", want: []*Registry{}},
+		{name: "single collection", proto: "web", addARegistry: true, want: []*Registry{&Registry{
+			Provider: "dell",
+			Protocol: "web",
+			InitFn:   nil,
+			Features: []Feature{FeatureUserCreate},
+		}}},
+	}
+	registries = nil
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// register
+			if tc.addARegistry {
+				Register("dell", "web", nil, []Feature{FeatureUserCreate})
+			}
+			result := Using(tc.proto)
+			diff := cmp.Diff(tc.want, result)
+			if diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func TestForFn(t *testing.T) {
+	testCases := []struct {
+		name         string
+		addARegistry bool
+		provider     string
+		want         Collection
+	}{
+		{name: "empty collection", want: []*Registry{}},
+		{name: "single collection", provider: "dell", addARegistry: true, want: []*Registry{&Registry{
+			Provider: "dell",
+			Protocol: "web",
+			InitFn:   nil,
+			Features: []Feature{FeatureUserCreate},
+		}}},
+	}
+	registries = nil
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// register
+			if tc.addARegistry {
+				Register("dell", "web", nil, []Feature{FeatureUserCreate})
+			}
+			result := For(tc.provider)
+			diff := cmp.Diff(tc.want, result)
+			if diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds the ability to register implementations. `InitRegistry()` returns a generic `interface{}` that will be type asserted or switch(ed) on to convert it to a corresponding concrete interface. The interfaces are mapped to `Feature` types (like `FeaturePowerState`), so implementations can define what functionality they have implemented.