### PR TITLE
Add client package

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,0 +1,112 @@
+// Package bmclib client.go is intended to be the main the public API.
+// Its purpose is to make interacting with bmclib as friendly as possible.
+package bmclib
+
+import (
+	"context"
+
+	"github.com/bmc-toolbox/bmclib/bmc"
+	"github.com/bmc-toolbox/bmclib/logging"
+	"github.com/bmc-toolbox/bmclib/registry"
+	"github.com/go-logr/logr"
+	// register providers here
+	//_ "github.com/bmc-toolbox/bmclib/providers/ipmitool"
+)
+
+// Client for BMC interactions
+type Client struct {
+	Auth     Auth
+	Logger   logr.Logger
+	Registry registry.Collection
+}
+
+// Auth details for connecting to a BMC
+type Auth struct {
+	Host string
+	Port string
+	User string
+	Pass string
+}
+
+// Option for setting optional Client values
+type Option func(*Client)
+
+// WithLogger sets the logger
+func WithLogger(logger logr.Logger) Option {
+	return func(args *Client) { args.Logger = logger }
+}
+
+// WithRegistry sets the Registry
+func WithRegistry(registry registry.Collection) Option {
+	return func(args *Client) { args.Registry = registry }
+}
+
+// NewClient returns a new Client struct
+func NewClient(host, user, pass string, opts ...Option) *Client {
+	var (
+		defaultLogger = logging.DefaultLogger()
+		defaultClient = &Client{
+			Logger:   defaultLogger,
+			Registry: registry.All(),
+		}
+	)
+	for _, opt := range opts {
+		opt(defaultClient)
+	}
+
+	defaultClient.Auth.Host = host
+	defaultClient.Auth.User = user
+	defaultClient.Auth.Pass = pass
+
+	return defaultClient
+}
+
+// getProviders returns a slice of interfaces for all registered implementations
+func (c *Client) getProviders() []interface{} {
+	var results []interface{}
+	for _, reg := range c.Registry {
+		i, _ := reg.InitFn(c.Auth.Host, c.Auth.User, c.Auth.Pass)
+		results = append(results, i)
+	}
+	return results
+}
+
+// GetPowerState pass through to library function
+func (c *Client) GetPowerState(ctx context.Context) (state string, err error) {
+	return bmc.GetPowerStateFromInterfaces(ctx, c.getProviders())
+}
+
+// SetPowerState pass through to library function
+func (c *Client) SetPowerState(ctx context.Context, state string) (ok bool, err error) {
+	return bmc.SetPowerStateFromInterfaces(ctx, state, c.getProviders())
+}
+
+// CreateUser pass through to library function
+func (c *Client) CreateUser(ctx context.Context, user, pass, role string) (ok bool, err error) {
+	return bmc.CreateUserFromInterfaces(ctx, user, pass, role, c.getProviders())
+}
+
+// UpdateUser pass through to library function
+func (c *Client) UpdateUser(ctx context.Context, user, pass, role string) (ok bool, err error) {
+	return bmc.UpdateUserFromInterfaces(ctx, user, pass, role, c.getProviders())
+}
+
+// DeleteUser pass through to library function
+func (c *Client) DeleteUser(ctx context.Context, user string) (ok bool, err error) {
+	return bmc.DeleteUserFromInterfaces(ctx, user, c.getProviders())
+}
+
+// ReadUsers pass through to library function
+func (c *Client) ReadUsers(ctx context.Context) (users []map[string]string, err error) {
+	return bmc.ReadUsersFromInterfaces(ctx, c.getProviders())
+}
+
+// SetBootDevice pass through to library function
+func (c *Client) SetBootDevice(ctx context.Context, bootDevice string, setPersistent, efiBoot bool) (ok bool, err error) {
+	return bmc.SetBootDeviceFromInterfaces(ctx, bootDevice, setPersistent, efiBoot, c.getProviders())
+}
+
+// ResetBMC pass through to library function
+func (c *Client) ResetBMC(ctx context.Context, resetType string) (ok bool, err error) {
+	return bmc.ResetBMCFromInterfaces(ctx, resetType, c.getProviders())
+}

--- a/client_test.go
+++ b/client_test.go
@@ -12,11 +12,15 @@ func TestBMC(t *testing.T) {
 	t.Skip("needs ipmitool and real ipmi server")
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	host := "127.0.0.1"
-	user := "ADMIN"
-	pass := "ADMIN"
+	host := "10.250.29.57"
+	user := "root"
+	pass := "calvin"
 
 	cl := NewClient(host, user, pass, WithLogger(logging.DefaultLogger()))
+	dErr := cl.DiscoverProviders(ctx)
+	if dErr != nil {
+		t.Fatal(dErr)
+	}
 	state, err := cl.GetPowerState(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,33 @@
+package bmclib
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bmc-toolbox/bmclib/logging"
+)
+
+func TestBMC(t *testing.T) {
+	t.Skip("needs ipmitool and real ipmi server")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	host := "127.0.0.1"
+	user := "ADMIN"
+	pass := "ADMIN"
+
+	cl := NewClient(host, user, pass, WithLogger(logging.DefaultLogger()))
+	state, err := cl.GetPowerState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(state)
+
+	users, err := cl.ReadUsers(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(users)
+
+	t.Fatal()
+}


### PR DESCRIPTION
Client package purpose is to be the primary interaction that a bmclib user would use. It interacts with the registry to initialize registered providers with auth and then has pass-through functions to call the interface executor functions.