### PR TITLE
Pass logger like context

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/bmc-toolbox/bmclib/bmc"
 	"github.com/bmc-toolbox/bmclib/discover"
-	"github.com/bmc-toolbox/bmclib/logging"
 	"github.com/bmc-toolbox/bmclib/registry"
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"
@@ -19,7 +18,6 @@ import (
 // Client for BMC interactions
 type Client struct {
 	Auth     Auth
-	Logger   logr.Logger
 	Registry registry.Collection
 }
 
@@ -34,11 +32,6 @@ type Auth struct {
 // Option for setting optional Client values
 type Option func(*Client)
 
-// WithLogger sets the logger
-func WithLogger(logger logr.Logger) Option {
-	return func(args *Client) { args.Logger = logger }
-}
-
 // WithRegistry sets the Registry
 func WithRegistry(registry registry.Collection) Option {
 	return func(args *Client) { args.Registry = registry }
@@ -47,9 +40,7 @@ func WithRegistry(registry registry.Collection) Option {
 // NewClient returns a new Client struct
 func NewClient(host, user, pass string, opts ...Option) *Client {
 	var (
-		defaultLogger = logging.DefaultLogger()
 		defaultClient = &Client{
-			Logger:   defaultLogger,
 			Registry: registry.All(),
 		}
 	)
@@ -65,11 +56,11 @@ func NewClient(host, user, pass string, opts ...Option) *Client {
 }
 
 // DiscoverProviders probes a BMC to discover what providers are compatible
-func (c *Client) DiscoverProviders(ctx context.Context) (err error) {
+func (c *Client) DiscoverProviders(ctx context.Context, log logr.Logger) (err error) {
 	// try discovering and registering a vendor specific provider
-	vendor, scanErr := discover.ScanAndConnect(c.Auth.Host, c.Auth.User, c.Auth.Pass, discover.WithContext(ctx), discover.WithLogger(c.Logger))
+	vendor, scanErr := discover.ScanAndConnect(c.Auth.Host, c.Auth.User, c.Auth.Pass, discover.WithContext(ctx), discover.WithLogger(log))
 	if scanErr != nil {
-		c.Logger.V(1).Info("no vendor specific controller discovered", "error", scanErr.Error())
+		log.V(1).Info("no vendor specific controller discovered", "error", scanErr.Error())
 		err = multierror.Append(err, scanErr)
 	} else {
 		registry.Register("vendor", "vendor", func(host, user, pass string) (interface{}, error) {
@@ -92,41 +83,41 @@ func (c *Client) getProviders() []interface{} {
 }
 
 // GetPowerState pass through to library function
-func (c *Client) GetPowerState(ctx context.Context) (state string, err error) {
-	return bmc.GetPowerStateFromInterfaces(ctx, c.getProviders())
+func (c *Client) GetPowerState(ctx context.Context, log logr.Logger) (state string, err error) {
+	return bmc.GetPowerStateFromInterfaces(ctx, log, c.getProviders())
 }
 
 // SetPowerState pass through to library function
-func (c *Client) SetPowerState(ctx context.Context, state string) (ok bool, err error) {
-	return bmc.SetPowerStateFromInterfaces(ctx, state, c.getProviders())
+func (c *Client) SetPowerState(ctx context.Context, log logr.Logger, state string) (ok bool, err error) {
+	return bmc.SetPowerStateFromInterfaces(ctx, log, state, c.getProviders())
 }
 
 // CreateUser pass through to library function
-func (c *Client) CreateUser(ctx context.Context, user, pass, role string) (ok bool, err error) {
-	return bmc.CreateUserFromInterfaces(ctx, user, pass, role, c.getProviders())
+func (c *Client) CreateUser(ctx context.Context, log logr.Logger, user, pass, role string) (ok bool, err error) {
+	return bmc.CreateUserFromInterfaces(ctx, log, user, pass, role, c.getProviders())
 }
 
 // UpdateUser pass through to library function
-func (c *Client) UpdateUser(ctx context.Context, user, pass, role string) (ok bool, err error) {
-	return bmc.UpdateUserFromInterfaces(ctx, user, pass, role, c.getProviders())
+func (c *Client) UpdateUser(ctx context.Context, log logr.Logger, user, pass, role string) (ok bool, err error) {
+	return bmc.UpdateUserFromInterfaces(ctx, log, user, pass, role, c.getProviders())
 }
 
 // DeleteUser pass through to library function
-func (c *Client) DeleteUser(ctx context.Context, user string) (ok bool, err error) {
-	return bmc.DeleteUserFromInterfaces(ctx, user, c.getProviders())
+func (c *Client) DeleteUser(ctx context.Context, log logr.Logger, user string) (ok bool, err error) {
+	return bmc.DeleteUserFromInterfaces(ctx, log, user, c.getProviders())
 }
 
 // ReadUsers pass through to library function
-func (c *Client) ReadUsers(ctx context.Context) (users []map[string]string, err error) {
-	return bmc.ReadUsersFromInterfaces(ctx, c.getProviders())
+func (c *Client) ReadUsers(ctx context.Context, log logr.Logger) (users []map[string]string, err error) {
+	return bmc.ReadUsersFromInterfaces(ctx, log, c.getProviders())
 }
 
 // SetBootDevice pass through to library function
-func (c *Client) SetBootDevice(ctx context.Context, bootDevice string, setPersistent, efiBoot bool) (ok bool, err error) {
-	return bmc.SetBootDeviceFromInterfaces(ctx, bootDevice, setPersistent, efiBoot, c.getProviders())
+func (c *Client) SetBootDevice(ctx context.Context, log logr.Logger, bootDevice string, setPersistent, efiBoot bool) (ok bool, err error) {
+	return bmc.SetBootDeviceFromInterfaces(ctx, log, bootDevice, setPersistent, efiBoot, c.getProviders())
 }
 
 // ResetBMC pass through to library function
-func (c *Client) ResetBMC(ctx context.Context, resetType string) (ok bool, err error) {
-	return bmc.ResetBMCFromInterfaces(ctx, resetType, c.getProviders())
+func (c *Client) ResetBMC(ctx context.Context, log logr.Logger, resetType string) (ok bool, err error) {
+	return bmc.ResetBMCFromInterfaces(ctx, log, resetType, c.getProviders())
 }

--- a/client_test.go
+++ b/client_test.go
@@ -16,18 +16,19 @@ func TestBMC(t *testing.T) {
 	user := "ADMIN"
 	pass := "ADMIN"
 
-	cl := NewClient(host, user, pass, WithLogger(logging.DefaultLogger()))
-	dErr := cl.DiscoverProviders(ctx)
+	log := logging.DefaultLogger()
+	cl := NewClient(host, user, pass)
+	dErr := cl.DiscoverProviders(ctx, log)
 	if dErr != nil {
 		t.Fatal(dErr)
 	}
-	state, err := cl.GetPowerState(ctx)
+	state, err := cl.GetPowerState(ctx, log)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Log(state)
 
-	users, err := cl.ReadUsers(ctx)
+	users, err := cl.ReadUsers(ctx, log)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/ipmitool/boot_device.go
+++ b/providers/ipmitool/boot_device.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	"github.com/bmc-toolbox/bmclib/internal/ipmi"
+	"github.com/go-logr/logr"
 )
 
 // BootDeviceSet sets the next boot device with options
-func (c *Conn) BootDeviceSet(ctx context.Context, bootDevice string, setPersistent, efiBoot bool) (ok bool, err error) {
+func (c *Conn) BootDeviceSet(ctx context.Context, log logr.Logger, bootDevice string, setPersistent, efiBoot bool) (ok bool, err error) {
 	i, err := ipmi.New(c.User, c.Pass, c.Host+":"+c.Port)
 	if err != nil {
 		return ok, err

--- a/providers/ipmitool/ipmitool.go
+++ b/providers/ipmitool/ipmitool.go
@@ -2,7 +2,6 @@ package ipmitool
 
 import (
 	"github.com/bmc-toolbox/bmclib/registry"
-	"github.com/go-logr/logr"
 )
 
 const (
@@ -18,7 +17,6 @@ type Conn struct {
 	Port string
 	User string
 	Pass string
-	Log  logr.Logger
 }
 
 func init() {

--- a/providers/ipmitool/ipmitool_test.go
+++ b/providers/ipmitool/ipmitool_test.go
@@ -14,9 +14,8 @@ func TestPowerState(t *testing.T) {
 		Port: "623",
 		User: "ADMIN",
 		Pass: "ADMIN",
-		Log:  logging.DefaultLogger(),
 	}
-	state, err := i.PowerStateGet(context.Background())
+	state, err := i.PowerStateGet(context.Background(), logging.DefaultLogger())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,9 +31,8 @@ func TestPowerSet(t *testing.T) {
 		Port: "623",
 		User: "ADMIN",
 		Pass: "ADMIN",
-		Log:  logging.DefaultLogger(),
 	}
-	state, err := i.PowerSet(context.Background(), "soft")
+	state, err := i.PowerSet(context.Background(), logging.DefaultLogger(), "soft")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,9 +48,8 @@ func TestBootDeviceSet(t *testing.T) {
 		Port: "623",
 		User: "ADMIN",
 		Pass: "ADMIN",
-		Log:  logging.DefaultLogger(),
 	}
-	state, err := i.BootDeviceSet(context.Background(), "disk", false, false)
+	state, err := i.BootDeviceSet(context.Background(), logging.DefaultLogger(), "disk", false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,9 +65,8 @@ func TestBMCReset(t *testing.T) {
 		Port: "623",
 		User: "ADMIN",
 		Pass: "ADMIN",
-		Log:  logging.DefaultLogger(),
 	}
-	state, err := i.BmcReset(context.Background(), "warm")
+	state, err := i.BmcReset(context.Background(), logging.DefaultLogger(), "warm")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/ipmitool/power.go
+++ b/providers/ipmitool/power.go
@@ -6,10 +6,11 @@ import (
 	"strings"
 
 	"github.com/bmc-toolbox/bmclib/internal/ipmi"
+	"github.com/go-logr/logr"
 )
 
 // PowerStateGet gets the power state of a BMC machine
-func (c *Conn) PowerStateGet(ctx context.Context) (state string, err error) {
+func (c *Conn) PowerStateGet(ctx context.Context, log logr.Logger) (state string, err error) {
 	i, err := ipmi.New(c.User, c.Pass, c.Host+":"+c.Port)
 	if err != nil {
 		return state, err
@@ -18,7 +19,7 @@ func (c *Conn) PowerStateGet(ctx context.Context) (state string, err error) {
 }
 
 // PowerSet sets the power state of a BMC machine
-func (c *Conn) PowerSet(ctx context.Context, state string) (ok bool, err error) {
+func (c *Conn) PowerSet(ctx context.Context, log logr.Logger, state string) (ok bool, err error) {
 	i, err := ipmi.New(c.User, c.Pass, c.Host+":"+c.Port)
 	if err != nil {
 		return ok, err

--- a/providers/ipmitool/reset.go
+++ b/providers/ipmitool/reset.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	"github.com/bmc-toolbox/bmclib/internal/ipmi"
+	"github.com/go-logr/logr"
 )
 
 // BmcReset will reset a BMC
-func (c *Conn) BmcReset(ctx context.Context, resetType string) (ok bool, err error) {
+func (c *Conn) BmcReset(ctx context.Context, log logr.Logger, resetType string) (ok bool, err error) {
 	i, err := ipmi.New(c.User, c.Pass, c.Host+":"+c.Port)
 	if err != nil {
 		return ok, err

--- a/providers/ipmitool/user.go
+++ b/providers/ipmitool/user.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	"github.com/bmc-toolbox/bmclib/internal/ipmi"
+	"github.com/go-logr/logr"
 )
 
 // UserRead list all users
-func (c *Conn) UserRead(ctx context.Context) (users []map[string]string, err error) {
+func (c *Conn) UserRead(ctx context.Context, log logr.Logger) (users []map[string]string, err error) {
 	i, err := ipmi.New(c.User, c.Pass, c.Host)
 	if err != nil {
 		return users, err


### PR DESCRIPTION
Pass a logging interface all the way down to the interface definitions allows us to add log entries in the interface executors/functions and is in line with the way context is passed around.