### PR TITLE
Add basic OpenBMC support

### DIFF
--- a/devices/constants.go
+++ b/devices/constants.go
@@ -16,6 +16,8 @@ const (
 	Cloudline = "Cloudline"
 	// Quanta is the contant to identify Quanta hardware
 	Quanta = "Quanta"
+
+	OpenBmc = "OpenBMC"
 	// Common is the constant of thinks we could use across multiple vendors
 	Common = "Common"
 

--- a/discover/discover.go
+++ b/discover/discover.go
@@ -22,6 +22,7 @@ const (
 	ProbeM1000e        = "m1000e"
 	ProbeQuanta        = "quanta"
 	ProbeHpCl100       = "hpcl100"
+	ProbeOpenBmc       = "openbmc"
 )
 
 // ScanAndConnect will scan the bmc trying to learn the device type and return a working connection.
@@ -60,9 +61,11 @@ func ScanAndConnect(host string, username string, password string, options ...Op
 		ProbeM1000e:        probe.m1000e,
 		ProbeQuanta:        probe.quanta,
 		ProbeHpCl100:       probe.hpCl100,
+		ProbeOpenBmc:       probe.openBmc,
 	}
 
-	order := []string{ProbeHpIlo,
+	order := []string{ProbeOpenBmc,
+		ProbeHpIlo,
 		ProbeIdrac8,
 		ProbeIdrac9,
 		ProbeSupermicrox11,

--- a/providers/openbmc/openbmc.go
+++ b/providers/openbmc/openbmc.go
@@ -1,0 +1,227 @@
+package openbmc
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/bmc-toolbox/bmclib/cfgresources"
+	"github.com/bmc-toolbox/bmclib/devices"
+
+	"github.com/go-logr/logr"
+)
+
+type OpenBmc struct {
+	ip         string
+	username   string
+	password   string
+	httpClient *http.Client
+	ctx        context.Context
+	log        logr.Logger
+}
+
+func (b *OpenBmc) Bios(cfg *cfgresources.Bios) (err error) {
+	return err
+}
+
+func (b *OpenBmc) BiosVersion() (version string, err error) {
+	return version, err
+}
+
+func (b *OpenBmc) CPU() (cpu string, cpuCount int, coreCount int, hyperthreadCount int, err error) {
+	return cpu, cpuCount, coreCount, hyperthreadCount, err
+}
+
+func (b *OpenBmc) ChassisSerial() (serial string, err error) {
+	return serial, err
+}
+
+func (b *OpenBmc) CheckCredentials() (err error) {
+	return err
+}
+
+func (b *OpenBmc) Close() (err error) {
+	return err
+}
+
+func (b *OpenBmc) CurrentHTTPSCert() ([]*x509.Certificate, bool, error) {
+
+	dialer := &net.Dialer{
+		Timeout: time.Duration(10) * time.Second,
+	}
+
+	conn, err := tls.DialWithDialer(dialer, "tcp", b.ip+":"+"443", &tls.Config{InsecureSkipVerify: true})
+
+	if err != nil {
+		return []*x509.Certificate{{}}, false, err
+	}
+
+	defer conn.Close()
+
+	return conn.ConnectionState().PeerCertificates, false, nil
+
+}
+
+func (b *OpenBmc) Disks() (disks []*devices.Disk, err error) {
+	return disks, err
+}
+
+func (b *OpenBmc) GenerateCSR(cert *cfgresources.HTTPSCertAttributes) ([]byte, error) {
+	return []byte{}, nil
+}
+
+func (b *OpenBmc) HardwareType() (model string) {
+	return model
+}
+
+func (b *OpenBmc) IsBlade() (isBlade bool, err error) {
+	return isBlade, err
+}
+
+func (b *OpenBmc) IsOn() (status bool, err error) {
+	return status, err
+}
+
+func (b *OpenBmc) Ldap(cfgLdap *cfgresources.Ldap) error {
+	return nil
+}
+
+func (b *OpenBmc) LdapGroup(cfgGroup []*cfgresources.LdapGroup, cfgLdap *cfgresources.Ldap) (err error) {
+	return err
+}
+
+func (b *OpenBmc) License() (name string, licType string, err error) {
+	return name, licType, err
+}
+
+func (b *OpenBmc) Memory() (mem int, err error) {
+	return mem, err
+}
+
+func (b *OpenBmc) Model() (model string, err error) {
+	return model, err
+}
+
+func (b *OpenBmc) Name() (name string, err error) {
+	return name, err
+}
+
+func (b *OpenBmc) Network(cfg *cfgresources.Network) (reset bool, err error) {
+	return reset, err
+}
+
+func (b *OpenBmc) Nics() (nics []*devices.Nic, err error) {
+	return nics, err
+}
+
+func (b *OpenBmc) Ntp(cfg *cfgresources.Ntp) (err error) {
+	return err
+}
+
+func (b *OpenBmc) Power(cfg *cfgresources.Power) (err error) {
+	return err
+}
+
+func (b *OpenBmc) PowerCycle() (status bool, err error) {
+	return status, err
+}
+
+func (b *OpenBmc) PowerCycleBmc() (status bool, err error) {
+	return status, err
+}
+
+func (b *OpenBmc) PowerKw() (power float64, err error) {
+	return power, err
+}
+
+func (b *OpenBmc) PowerOn() (status bool, err error) {
+	return status, err
+}
+
+func (b *OpenBmc) PowerOff() (status bool, err error) {
+	return status, err
+}
+
+func (b *OpenBmc) PowerState() (state string, err error) {
+	return state, err
+}
+
+func (b *OpenBmc) PxeOnce() (status bool, err error) {
+	return status, err
+}
+
+func (b *OpenBmc) Resources() []string {
+	return []string{}
+}
+
+func (b *OpenBmc) Screenshot() (response []byte, extension string, err error) {
+	return response, extension, err
+}
+
+func (b *OpenBmc) Serial() (serial string, err error) {
+	return serial, err
+}
+
+func (b *OpenBmc) ServerSnapshot() (server interface{}, err error) {
+	return server, err
+}
+
+func (b *OpenBmc) SetLicense(cfg *cfgresources.License) (err error) {
+	return err
+}
+
+func (b *OpenBmc) Slot() (slot int, err error) {
+	return slot, err
+}
+
+func (b *OpenBmc) Status() (health string, err error) {
+	return health, err
+}
+
+func (b *OpenBmc) Syslog(cfg *cfgresources.Syslog) (err error) {
+	return err
+}
+
+func (b *OpenBmc) TempC() (temp int, err error) {
+	return temp, err
+}
+
+func (b *OpenBmc) UpdateCredentials(username string, password string) {
+	b.username = username
+	b.password = password
+}
+
+func (b *OpenBmc) UpdateFirmware(source, file string) (status bool, err error) {
+	return true, fmt.Errorf("NYI")
+}
+
+func (b *OpenBmc) UploadHTTPSCert(cert []byte, certFileName string, key []byte, keyFileName string) (bool, error) {
+	return false, fmt.Errorf("NYI")
+}
+
+func (b *OpenBmc) User(users []*cfgresources.User) (err error) {
+	return err
+}
+
+func (b *OpenBmc) Vendor() (vendor string) {
+	return "OpenBMC"
+}
+
+func (b *OpenBmc) Version() (bmcVersion string, err error) {
+	return bmcVersion, err
+}
+
+func New(ctx context.Context, ip string, username string, password string, log logr.Logger) (obmc *OpenBmc, err error) {
+	var _ devices.Bmc = &OpenBmc{}
+	return &OpenBmc{
+		ip:       ip,
+		username: username,
+		password: password,
+		ctx:      ctx,
+		log:      log,
+	}, err
+}


### PR DESCRIPTION
The only implements a small subset of the `devices.Bmc` interface, but hopefully it's enough for baseline PBnJ support?  Currently it's entirely redfish-based, though many of these operation could probably be alternatively implemented via IPMI or ssh (or perhaps the OpenBMC-specific HTTP API under `/xyz/openbmc_project/...`).

Also, I'm very much neither a Go expert nor real familiar with bmclib, so careful review is probably warranted to make sure I haven't done something egregiously foolish...
