### PR TITLE
Add log interface to register function

### DIFF
--- a/client.go
+++ b/client.go
@@ -47,9 +47,8 @@ func WithRegistry(registry registry.Collection) Option {
 // NewClient returns a new Client struct
 func NewClient(host, port, user, pass string, opts ...Option) *Client {
 	var (
-		defaultLogger = logging.DefaultLogger()
 		defaultClient = &Client{
-			Logger:   defaultLogger,
+			Logger:   logging.DefaultLogger(),
 			Registry: registry.All(),
 		}
 	)
@@ -73,7 +72,7 @@ func (c *Client) DiscoverProviders(ctx context.Context) (err error) {
 		c.Logger.V(1).Info("no vendor specific controller discovered", "error", scanErr.Error())
 		err = multierror.Append(err, scanErr)
 	} else {
-		registry.Register("vendor", "vendor", func(host, port, user, pass string) (interface{}, error) {
+		registry.Register("vendor", "vendor", func(host, port, user, pass string, log logr.Logger) (interface{}, error) {
 			return vendor, nil
 		}, []registry.Feature{})
 		c.Registry = registry.All()
@@ -86,7 +85,7 @@ func (c *Client) DiscoverProviders(ctx context.Context) (err error) {
 func (c *Client) getProviders() []interface{} {
 	results := make([]interface{}, len(c.Registry))
 	for index, elem := range c.Registry {
-		results[index], _ = elem.InitFn(c.Auth.Host, c.Auth.Port, c.Auth.User, c.Auth.Pass)
+		results[index], _ = elem.InitFn(c.Auth.Host, c.Auth.Port, c.Auth.User, c.Auth.Pass, c.Logger)
 	}
 
 	return results

--- a/providers/ipmitool/ipmitool.go
+++ b/providers/ipmitool/ipmitool.go
@@ -22,8 +22,8 @@ type Conn struct {
 }
 
 func init() {
-	registry.Register(ProviderName, ProviderProtocol, func(host, port, user, pass string) (interface{}, error) {
-		return &Conn{Host: host, User: user, Pass: pass, Port: port}, nil
+	registry.Register(ProviderName, ProviderProtocol, func(host, port, user, pass string, log logr.Logger) (interface{}, error) {
+		return &Conn{Host: host, User: user, Pass: pass, Port: port, Log: log}, nil
 	}, []registry.Feature{
 		registry.FeaturePowerSet,
 		registry.FeaturePowerState,

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,6 +1,10 @@
 package registry
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/go-logr/logr"
+)
 
 var (
 	registries Collection
@@ -30,7 +34,7 @@ type Feature string
 type Collection []*Registry
 
 // InitRegistry function for setting connection details of a provider
-type InitRegistry func(host, port, user, pass string) (interface{}, error)
+type InitRegistry func(host, port, user, pass string, log logr.Logger) (interface{}, error)
 
 // Registry holds the info about a provider
 type Registry struct {


### PR DESCRIPTION
Client defined logging wasn't making it into provider implementations. This allows the client to define the logger or if not defined by the client we use `logging.DefaultLogger()`.