### PR TITLE
Fix non nil error on success

### DIFF
--- a/bmc/boot_device.go
+++ b/bmc/boot_device.go
@@ -26,7 +26,7 @@ func SetBootDevice(ctx context.Context, bootDevice string, setPersistent, efiBoo
 				err = multierror.Append(err, errors.New("failed to set boot device"))
 				continue
 			}
-			return ok, err
+			return ok, nil
 		}
 	}
 	return ok, multierror.Append(err, errors.New("failed to set boot device"))

--- a/bmc/power.go
+++ b/bmc/power.go
@@ -42,7 +42,7 @@ func SetPowerState(ctx context.Context, state string, p []PowerSetter) (ok bool,
 				err = multierror.Append(err, errors.New("failed to set power state"))
 				continue
 			}
-			return ok, err
+			return ok, nil
 		}
 	}
 	return ok, multierror.Append(err, errors.New("failed to set power state"))
@@ -75,7 +75,7 @@ func GetPowerState(ctx context.Context, p []PowerStateGetter) (state string, err
 				err = multierror.Append(err, stateErr)
 				continue
 			}
-			return state, err
+			return state, nil
 		}
 	}
 
@@ -86,7 +86,6 @@ func GetPowerState(ctx context.Context, p []PowerStateGetter) (state string, err
 func GetPowerStateFromInterfaces(ctx context.Context, generic []interface{}) (state string, err error) {
 	var powerStateGetter []PowerStateGetter
 	for _, elem := range generic {
-
 		switch p := elem.(type) {
 		case PowerStateGetter:
 			powerStateGetter = append(powerStateGetter, p)

--- a/bmc/reset.go
+++ b/bmc/reset.go
@@ -28,7 +28,7 @@ func ResetBMC(ctx context.Context, resetType string, b []BMCResetter) (ok bool, 
 				err = multierror.Append(err, errors.New("failed to reset BMC"))
 				continue
 			}
-			return ok, err
+			return ok, nil
 		}
 	}
 	return ok, multierror.Append(err, errors.New("failed to reset BMC"))

--- a/bmc/user.go
+++ b/bmc/user.go
@@ -41,7 +41,7 @@ func CreateUser(ctx context.Context, user, pass, role string, u []UserCreator) (
 				err = multierror.Append(err, errors.New("failed to create user"))
 				continue
 			}
-			return ok, err
+			return ok, nil
 		}
 	}
 	return ok, multierror.Append(err, errors.New("failed to create user"))
@@ -78,7 +78,7 @@ func UpdateUser(ctx context.Context, user, pass, role string, u []UserUpdater) (
 				err = multierror.Append(err, errors.New("failed to update user"))
 				continue
 			}
-			return ok, err
+			return ok, nil
 		}
 	}
 	return ok, multierror.Append(err, errors.New("failed to update user"))
@@ -115,7 +115,7 @@ func DeleteUser(ctx context.Context, user string, u []UserDeleter) (ok bool, err
 				err = multierror.Append(err, errors.New("failed to delete user"))
 				continue
 			}
-			return ok, err
+			return ok, nil
 		}
 	}
 	return ok, multierror.Append(err, errors.New("failed to delete user"))


### PR DESCRIPTION
A successful interface method call would return a non-nil error if a previous method call did return an error. This was because we were returning err instead of nil. This PR will fix this bug.