### PR TITLE
Add context timeout/cancel checking

### DIFF
--- a/bmc/boot_device_test.go
+++ b/bmc/boot_device_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-multierror"
@@ -32,10 +33,12 @@ func TestSetBootDevice(t *testing.T) {
 		makeNotOk    bool
 		want         bool
 		err          error
+		ctxTimeout   time.Duration
 	}{
 		{name: "success", bootDevice: "pxe", want: true},
 		{name: "not ok return", bootDevice: "pxe", want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("failed to set boot device"), errors.New("failed to set boot device")}}},
 		{name: "error", bootDevice: "pxe", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("boot device set failed"), errors.New("failed to set boot device")}}},
+		{name: "error context timeout", bootDevice: "pxe", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to set boot device")}}, ctxTimeout: time.Nanosecond * 1},
 	}
 
 	for _, tc := range testCases {
@@ -43,7 +46,12 @@ func TestSetBootDevice(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			testImplementation := bootDeviceTester{MakeErrorOut: tc.makeErrorOut, MakeNotOK: tc.makeNotOk}
 			expectedResult := tc.want
-			result, err := SetBootDevice(context.Background(), tc.bootDevice, false, false, []BootDeviceSetter{&testImplementation})
+			if tc.ctxTimeout == 0 {
+				tc.ctxTimeout = time.Second * 3
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
+			defer cancel()
+			result, err := SetBootDevice(ctx, tc.bootDevice, false, false, []BootDeviceSetter{&testImplementation})
 			if err != nil {
 				diff := cmp.Diff(tc.err.Error(), err.Error())
 				if diff != "" {


### PR DESCRIPTION
If implementations don't or can't handle checking for context timeouts/cancels, this will check for them before each implementation is run in the executor functions.