### PR TITLE
Open close interfaces

### DIFF
--- a/bmc/connection.go
+++ b/bmc/connection.go
@@ -1,0 +1,107 @@
+package bmc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// Opener interface for opening a connection to a BMC
+type Opener interface {
+	Open(ctx context.Context) error
+}
+
+// Closer interface for closing a connection to a BMC
+type Closer interface {
+	Close(ctx context.Context) error
+}
+
+// OpenConnection opens a connection to a BMC, trying all interface implementations passed in
+func OpenConnection(ctx context.Context, o []Opener) (err error) {
+	var connOpen bool
+Loop:
+	for _, elem := range o {
+		select {
+		case <-ctx.Done():
+			err = multierror.Append(err, ctx.Err())
+			break Loop
+		default:
+			if elem != nil {
+				openErr := elem.Open(ctx)
+				if openErr != nil {
+					err = multierror.Append(err, openErr)
+					continue
+				}
+				connOpen = true
+			}
+		}
+	}
+	if connOpen {
+		return nil
+	}
+	return multierror.Append(err, errors.New("failed to open connection"))
+}
+
+// OpenConnectionFromInterfaces pass through to library function
+func OpenConnectionFromInterfaces(ctx context.Context, generic []interface{}) (err error) {
+	var openers []Opener
+	for _, elem := range generic {
+		switch p := elem.(type) {
+		case Opener:
+			openers = append(openers, p)
+		default:
+			e := fmt.Sprintf("not a Opener implementation: %T", p)
+			err = multierror.Append(err, errors.New(e))
+		}
+	}
+	if len(openers) == 0 {
+		return multierror.Append(err, errors.New("no Opener implementations found"))
+	}
+	return OpenConnection(ctx, openers)
+}
+
+// CloseConnection closes a connection to a BMC, trying all interface implementations passed in
+func CloseConnection(ctx context.Context, c []Closer) (err error) {
+	var connClosed bool
+Loop:
+	for _, elem := range c {
+		select {
+		case <-ctx.Done():
+			err = multierror.Append(err, ctx.Err())
+			break Loop
+		default:
+			if elem != nil {
+				openErr := elem.Close(ctx)
+				if openErr != nil {
+					err = multierror.Append(err, openErr)
+					continue
+				}
+				connClosed = true
+			}
+		}
+	}
+	if connClosed {
+		return nil
+	}
+	return multierror.Append(err, errors.New("failed to close connection"))
+}
+
+// CloseConnectionFromInterfaces pass through to library function
+func CloseConnectionFromInterfaces(ctx context.Context, generic []interface{}) (err error) {
+	var closers []Closer
+	for _, elem := range generic {
+		switch p := elem.(type) {
+		case Closer:
+			closers = append(closers, p)
+		default:
+			e := fmt.Sprintf("not a Closer implementation: %T", p)
+			err = multierror.Append(err, errors.New(e))
+		}
+	}
+	if len(closers) == 0 {
+		return multierror.Append(err, errors.New("no Closer implementations found"))
+	}
+	return CloseConnection(ctx, closers)
+}

--- a/bmc/connection_test.go
+++ b/bmc/connection_test.go
@@ -1,0 +1,159 @@
+package bmc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-multierror"
+)
+
+type connTester struct {
+	MakeErrorOut bool
+}
+
+func (r *connTester) Open(ctx context.Context) (err error) {
+	if r.MakeErrorOut {
+		return errors.New("open connection failed")
+	}
+
+	return nil
+}
+
+func (r *connTester) Close(ctx context.Context) (err error) {
+	if r.MakeErrorOut {
+		return errors.New("close connection failed")
+	}
+
+	return nil
+}
+
+func TestOpenConnection(t *testing.T) {
+	testCases := []struct {
+		name         string
+		makeErrorOut bool
+		err          error
+		ctxTimeout   time.Duration
+	}{
+		{name: "success"},
+		{name: "error context deadline", err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to open connection")}}, ctxTimeout: time.Nanosecond * 1},
+		{name: "error", makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("open connection failed"), errors.New("failed to open connection")}}},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			testImplementation := connTester{MakeErrorOut: tc.makeErrorOut}
+			if tc.ctxTimeout == 0 {
+				tc.ctxTimeout = time.Second * 3
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
+			defer cancel()
+			err := OpenConnection(ctx, []Opener{&testImplementation})
+			if err != nil {
+				diff := cmp.Diff(tc.err.Error(), err.Error())
+				if diff != "" {
+					t.Fatal(diff)
+				}
+			}
+		})
+	}
+}
+
+func TestOpenConnectionFromInterfaces(t *testing.T) {
+	testCases := []struct {
+		name              string
+		err               error
+		badImplementation bool
+	}{
+		{name: "success"},
+		{name: "no implementations found", badImplementation: true, err: &multierror.Error{Errors: []error{errors.New("not a Opener implementation: *struct {}"), errors.New("no Opener implementations found")}}},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var generic []interface{}
+			if tc.badImplementation {
+				badImplementation := struct{}{}
+				generic = []interface{}{&badImplementation}
+			} else {
+				testImplementation := connTester{}
+				generic = []interface{}{&testImplementation}
+			}
+			err := OpenConnectionFromInterfaces(context.Background(), generic)
+			if err != nil {
+				diff := cmp.Diff(tc.err.Error(), err.Error())
+				if diff != "" {
+					t.Fatal(diff)
+				}
+			}
+		})
+	}
+}
+
+func TestCloseConnection(t *testing.T) {
+	testCases := []struct {
+		name         string
+		makeErrorOut bool
+		err          error
+		ctxTimeout   time.Duration
+	}{
+		{name: "success"},
+		{name: "error context deadline", err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to close connection")}}, ctxTimeout: time.Nanosecond * 1},
+		{name: "error", makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("close connection failed"), errors.New("failed to close connection")}}},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			testImplementation := connTester{MakeErrorOut: tc.makeErrorOut}
+			if tc.ctxTimeout == 0 {
+				tc.ctxTimeout = time.Second * 3
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
+			defer cancel()
+			err := CloseConnection(ctx, []Closer{&testImplementation})
+			if err != nil {
+				diff := cmp.Diff(tc.err.Error(), err.Error())
+				if diff != "" {
+					t.Fatal(diff)
+				}
+			}
+		})
+	}
+}
+
+func TestCloseConnectionFromInterfaces(t *testing.T) {
+	testCases := []struct {
+		name              string
+		err               error
+		badImplementation bool
+	}{
+		{name: "success"},
+		{name: "no implementations found", badImplementation: true, err: &multierror.Error{Errors: []error{errors.New("not a Closer implementation: *struct {}"), errors.New("no Closer implementations found")}}},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var generic []interface{}
+			if tc.badImplementation {
+				badImplementation := struct{}{}
+				generic = []interface{}{&badImplementation}
+			} else {
+				testImplementation := connTester{}
+				generic = []interface{}{&testImplementation}
+			}
+			err := CloseConnectionFromInterfaces(context.Background(), generic)
+			if err != nil {
+				diff := cmp.Diff(tc.err.Error(), err.Error())
+				if diff != "" {
+					t.Fatal(diff)
+				}
+			}
+		})
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -19,13 +19,13 @@ func TestBMC(t *testing.T) {
 
 	log := logging.DefaultLogger()
 	cl := NewClient(host, port, user, pass, WithLogger(log))
-
-	dErr := cl.DiscoverProviders(ctx)
-	if dErr != nil {
-		t.Log(dErr)
+	err := cl.Open(ctx)
+	if err != nil {
+		t.Fatal(err)
 	}
+	defer cl.Close(ctx)
 
-	cl.Registry = cl.Registry.PreferProtocol("web")
+	cl.Registry = cl.Registry.PreferProtocol("redfish")
 	state, err := cl.GetPowerState(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -33,6 +33,9 @@ func TestBMC(t *testing.T) {
 	t.Log(state)
 
 	cl.Registry = cl.Registry.PreferProtocol("ipmi")
+	if err != nil {
+		t.Log(err)
+	}
 	state, err = cl.GetPowerState(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/ipmi/ipmi.go
+++ b/internal/ipmi/ipmi.go
@@ -53,7 +53,7 @@ func (i *Ipmi) run(ctx context.Context, command []string) (output string, err er
 	if ctx.Err() == context.DeadlineExceeded {
 		return string(out), ctx.Err()
 	}
-	return string(out), err
+	return string(out), errors.Wrap(err, strings.TrimSpace(string(out)))
 }
 
 // PowerCycle reboots the machine via bmc

--- a/providers/ipmitool/ipmitool.go
+++ b/providers/ipmitool/ipmitool.go
@@ -29,6 +29,9 @@ type Conn struct {
 
 func init() {
 	registry.Register(ProviderName, ProviderProtocol, func(host, port, user, pass string, log logr.Logger) (interface{}, error) {
+		if port == "" {
+			port = "623"
+		}
 		i, err := ipmi.New(user, pass, host+":"+port)
 		return &Conn{Host: host, User: user, Pass: pass, Port: port, Log: log, con: i}, err
 	}, []registry.Feature{
@@ -38,6 +41,16 @@ func init() {
 		registry.FeatureBmcReset,
 		registry.FeatureBootDeviceSet,
 	})
+}
+
+// Open a connection to a BMC
+func (c *Conn) Open(ctx context.Context) (err error) {
+	return nil
+}
+
+// Close a connection to a BMC
+func (c *Conn) Close(ctx context.Context) (err error) {
+	return nil
 }
 
 // BootDeviceSet sets the next boot device with options

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -38,10 +38,11 @@ type InitRegistry func(host, port, user, pass string, log logr.Logger) (interfac
 
 // Registry holds the info about a provider
 type Registry struct {
-	Provider string
-	Protocol string
-	InitFn   InitRegistry
-	Features Features
+	Provider          string
+	Protocol          string
+	InitFn            InitRegistry
+	Features          Features
+	ProviderInterface interface{}
 }
 
 // Include does the actual work of filtering for specific features


### PR DESCRIPTION
implementations that have stateful connections need an open/close method to connect and disconnect. this PR adds theses as main interface methods.

The client package is also updated to handle the open/close functionality. This way multiple calls can all use the same connection(s)/session(s). Another nice thing here is that you can use different registry filters for different calls. For example, if you want to set the next boot using redfish, but get users using ipmitool you can do that. Here's a snippet example, `client_test.go` also has a similar example.
```go
client := NewClient(host, port, user, pass, WithLogger(log))
err := client.Open(ctx)
if err != nil {
 panic(err)
}
defer client.Close(ctx)

client.Registry = client.Registry.PreferProtocol("redfish")
ok, err := client.SetBootDevice(ctx, "pxe")
if err != nil {
 panic(err)
}
fmt.Println(ok)

client.Registry = client.Registry.PreferProtocol("ipmitool")
users, err := client.ReadUsers(ctx)
if err != nil {
 panic(err)
}
fmt.Println(users)
```