### PR TITLE
Add discovery of compatible providers

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -19,6 +19,7 @@ func TestBMC(t *testing.T) {
 
 	log := logging.DefaultLogger()
 	cl := NewClient(host, port, user, pass, WithLogger(log))
+	cl.DiscoverCompatible(ctx)
 	err := cl.Open(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"context"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -34,7 +35,11 @@ type Feature string
 type Collection []*Registry
 
 // InitRegistry function for setting connection details of a provider
-type InitRegistry func(host, port, user, pass string, log logr.Logger) (interface{}, error)
+// The return values are as follows:
+// interface{} -> the implementation specific struct
+// func(context.Context) bool -> a function that determines if the implementation is compatible with a given BMC
+// error -> standard error if the initRegistry function fails
+type InitRegistry func(host, port, user, pass string, log logr.Logger) (interface{}, func(context.Context) bool, error)
 
 // Registry holds the info about a provider
 type Registry struct {


### PR DESCRIPTION
Fixes https://github.com/bmc-toolbox/bmclib/issues/162. This is an update to `ScanAndDiscover` for the `Client.Registry`. It will run a function (implemented by the provider) to determine if the provider is compatible with the given BMC. This will be done for all registered providers and then it will update the `Client.Registry` with all compatible providers that were discovered.

This (eventually) moves all the `discover/probe.go` functionality into each specific provider.