### PR TITLE
Move provider registration error check

### DIFF
--- a/client.go
+++ b/client.go
@@ -67,20 +67,20 @@ func NewClient(host, port, user, pass string, opts ...Option) *Client {
 // setProviders updates the Registry with corresponding interfaces for all registered implementations
 func (c *Client) setProviders() {
 	for _, elem := range c.Registry {
-		elem.ProviderInterface, _, _ = elem.InitFn(c.Auth.Host, c.Auth.Port, c.Auth.User, c.Auth.Pass, c.Logger)
+		r, _, err := elem.InitFn(c.Auth.Host, c.Auth.Port, c.Auth.User, c.Auth.Pass, c.Logger)
+		if err != nil {
+			c.Logger.V(0).Info("provider registration error", "error", err.Error(), "provider", elem.Provider)
+			continue
+		}
+		elem.ProviderInterface = r
 	}
 }
 
 // getProviders returns a slice of interfaces for all registered implementations
 func (c *Client) getProviders() []interface{} {
 	results := make([]interface{}, len(c.Registry))
-	for index, elem := range c.Registry {
-		r, _, err := elem.InitFn(c.Auth.Host, c.Auth.Port, c.Auth.User, c.Auth.Pass, c.Logger)
-		if err != nil {
-			c.Logger.V(0).Info("provider registration error", "error", err.Error(), "provider", elem.Provider)
-			continue
-		}
-		results[index] = r
+	for _, elem := range c.Registry {
+		results = append(results, elem.ProviderInterface)
 	}
 	return results
 }


### PR DESCRIPTION
To fix the [nil pointer error](https://github.com/bmc-toolbox/bmclib/commit/0323a20e87821ba9bd6509b8b122a0b3f8259ba9) that can happen if an error is not checked from a providers `InitFn`, we skip adding the provider to the registry. This should happen in`setProviders`, not in `getProvider`. This way we limit the times we call the `initFn` and `setProviders` already puts the provider interface into the registry so`getProviders` does not need to call `initFn` again to get it, it can just get the interface from the `Registry.ProviderInterface`.