### PR TITLE
Add PowerEdge C6320 support

### DIFF
--- a/discover/probe.go
+++ b/discover/probe.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	idrac8SysDesc = []string{"PowerEdge M630", "PowerEdge R630"}
+	idrac8SysDesc = []string{"PowerEdge M630", "PowerEdge R630", "PowerEdge C6320"}
 	idrac9SysDesc = []string{"PowerEdge M640", "PowerEdge R640", "PowerEdge R6415", "PowerEdge R6515", "PowerEdge R740xd"}
 	m1000eSysDesc = []string{"PowerEdge M1000e"}
 )

--- a/providers/dell/idrac8/helpers.go
+++ b/providers/dell/idrac8/helpers.go
@@ -47,7 +47,11 @@ func getEmptyUserSlot(idracUsers UserInfo) (userID int, user User, err error) {
 			continue
 		}
 
-		if user.UserName == "" {
+		// from the web UI idrac8 doesn't allow removing users only disabling users.
+		// There is a case where all user.UserName are NOT == "". This doens't mean that a new
+		// user cannot be created. Disabled users regardless of whether user.UserName == "" can be
+		// used for new user creation. FYI, ipmitool can remove the name: ipmitool user set name <id> ""
+		if user.UserName == "" || user.Enable == "disabled" {
 			return userID, user, err
 		}
 	}


### PR DESCRIPTION
Updated the way we check for available slots in the UI. disabled with a nonempty username should be a candidate for use as idrac8 UI doesn't allow empty usernames.