### PR TITLE
Add new smc support

### DIFF
--- a/discover/probe.go
+++ b/discover/probe.go
@@ -259,7 +259,10 @@ func (p *Probe) supermicrox(ctx context.Context, log logr.Logger) (bmcConnection
 		if err != nil {
 			return bmcConnection, err
 		}
-		if conn.HardwareType() == supermicrox.X10 {
+		// empty string means that either HardwareType() was unable to get the model or the model returned was empty
+		// if HardwareType() returned something more than empty than the call worked, we'll assume other calls will
+		// also work
+		if conn.HardwareType() != "" {
 			return conn, err
 		}
 	}
@@ -291,7 +294,10 @@ func (p *Probe) supermicrox11(ctx context.Context, log logr.Logger) (bmcConnecti
 		if err != nil {
 			return bmcConnection, err
 		}
-		if conn.HardwareType() == supermicrox11.X11 {
+		// empty string means that either HardwareType() was unable to get the model or the model returned was empty
+		// if HardwareType() returned something more than empty than the call worked, we'll assume other calls will
+		// also work
+		if conn.HardwareType() != "" {
 			return conn, err
 		}
 	}

--- a/providers/supermicro/supermicrox/supermicrox.go
+++ b/providers/supermicro/supermicrox/supermicrox.go
@@ -251,11 +251,7 @@ func (s *SupermicroX) HardwareType() (model string) {
 		s.log.V(1).Info("error getting hardwaretype", "err", internal.ErrStringOrEmpty(err))
 		return model
 	}
-	if strings.Contains(strings.ToLower(m), X10) {
-		return X10
-	}
-
-	return BmcType
+	return m
 }
 
 // Model returns the device model

--- a/providers/supermicro/supermicrox/supermicrox_test.go
+++ b/providers/supermicro/supermicrox/supermicrox_test.go
@@ -207,7 +207,7 @@ func TestModel(t *testing.T) {
 }
 
 func TestBmcType(t *testing.T) {
-	expectedAnswer := "x10"
+	expectedAnswer := "X10DRFF-CTG"
 
 	bmc, err := setup()
 	if err != nil {

--- a/providers/supermicro/supermicrox11/supermicrox.go
+++ b/providers/supermicro/supermicrox11/supermicrox.go
@@ -254,12 +254,7 @@ func (s *SupermicroX) HardwareType() (model string) {
 		// Here is your sin
 		return model
 	}
-
-	if strings.Contains(strings.ToLower(m), X11) {
-		return X11
-	}
-
-	return BmcType
+	return m
 }
 
 // Model returns the device model

--- a/providers/supermicro/supermicrox11/supermicrox_test.go
+++ b/providers/supermicro/supermicrox11/supermicrox_test.go
@@ -276,7 +276,7 @@ func TestModel(t *testing.T) {
 }
 
 func TestBmcType(t *testing.T) {
-	expectedAnswer := "x11"
+	expectedAnswer := "X11SCM-F"
 
 	bmc, err := setup()
 	if err != nil {


### PR DESCRIPTION
fixes https://github.com/bmc-toolbox/bmclib/issues/183

Changed the way Supermicro does probing. We don't only look for `x10` or `x11` when getting the model type. If the call to get the model works, we use it. So If the x11 `HardwareType()` response is not an empty string, meaning that the call to get its model WAS successful, then we use the x11 provider code. Same for the x10 code.  

Also, updated the user mgmt code for x10 because with the existing code If a single user was passed in it would always add/update/delete that user from slot 2 (index 1) on the BMC. This means that if an existing user, say `ADMIN`, was configured there, but I passed in to create a new user, named `TestUser`, then `TestUser` would overwrite `ADMIN`. This PR fixes that and the `ADMIN` user in this example would not be overwritten but `TestUser` would be created in its own unique slot.

This PR allows the x10 and x11 code to support a greater range of Supermicro models. 