### PR TITLE
Fix nil values in provider registration:

### DIFF
--- a/client.go
+++ b/client.go
@@ -47,7 +47,6 @@ func NewClient(host, port, user, pass string, opts ...Option) *Client {
 		Registry: registrar.NewRegistry(),
 	}
 	defaultClient.Registry.Logger = defaultClient.Logger
-	defaultClient.registerProviders()
 
 	for _, opt := range opts {
 		opt(defaultClient)
@@ -57,6 +56,10 @@ func NewClient(host, port, user, pass string, opts ...Option) *Client {
 	defaultClient.Auth.Port = port
 	defaultClient.Auth.User = user
 	defaultClient.Auth.Pass = pass
+	// len of 0 means that no Registry, with any registered providers was passed in.
+	if len(defaultClient.Registry.Drivers) == 0 {
+		defaultClient.registerProviders()
+	}
 
 	return defaultClient
 }


### PR DESCRIPTION
fix for broken `NewClient` in v0.4.9.

In `NewClient`, calling `defaultClient.registerProviders()` before setting the `host`, `port`, `user`, and `pass` causes registering providers to not have `host`, `port`, `user`, and `pass` set and results in cascading errors.