### PR TITLE
Update ipmi provider IsCompatible Func

### DIFF
--- a/providers/ipmitool/ipmitool.go
+++ b/providers/ipmitool/ipmitool.go
@@ -58,7 +58,7 @@ func (c *Conn) Compatible(ctx context.Context) bool {
 		return false
 	}
 	defer c.Close(ctx)
-	_, err = c.con.IsOn(ctx)
+	_, err = c.con.PowerState(ctx)
 	if err != nil {
 		c.Log.V(0).Error(err, "error checking compatibility through power status")
 	}

--- a/providers/ipmitool/ipmitool_test.go
+++ b/providers/ipmitool/ipmitool_test.go
@@ -53,11 +53,11 @@ func TestIsCompatible(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var ipm *ipmi.Ipmi
-			monkey.PatchInstanceMethod(reflect.TypeOf(ipm), "IsOn", func(_ *ipmi.Ipmi, _ context.Context) (status bool, err error) {
+			monkey.PatchInstanceMethod(reflect.TypeOf(ipm), "PowerState", func(_ *ipmi.Ipmi, _ context.Context) (status string, err error) {
 				if !tc.ok {
 					err = errors.New("not compatible")
 				}
-				return true, err
+				return "on", err
 			})
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()


### PR DESCRIPTION
Checking if a machine is on for the compatibility check will cause the check to fail if the BMC is up, is compatible, but the host machine is powered off. Just checking if a power state call returned successfully should allow the check to be more accurate and work even if the host machine is off. 