### PR TITLE
Add context parameter to Close()

### DIFF
--- a/devices/interfaces.go
+++ b/devices/interfaces.go
@@ -1,6 +1,7 @@
 package devices
 
 import (
+	"context"
 	"crypto/x509"
 
 	"github.com/bmc-toolbox/bmclib/cfgresources"
@@ -15,7 +16,7 @@ type Bmc interface {
 	BmcCollection
 
 	CheckCredentials() error
-	Close() error
+	Close(context.Context) error
 	PowerOn() (bool, error)       // PowerSetter
 	PowerOff() (bool, error)      // PowerSetter
 	PxeOnce() (bool, error)       // BootDeviceSetter

--- a/examples/main.go
+++ b/examples/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/bmc-toolbox/bmclib/devices"
@@ -58,7 +59,7 @@ func printStatus(connection interface{}, logger *logrus.Logger) {
 	switch con := connection.(type) {
 	case devices.Bmc:
 		conn := con
-		defer conn.Close()
+		defer conn.Close(context.TODO())
 
 		sr, err := conn.Serial()
 		if err != nil {

--- a/providers/dell/idrac8/setupConnections.go
+++ b/providers/dell/idrac8/setupConnections.go
@@ -2,6 +2,7 @@ package idrac8
 
 import (
 	"bytes"
+	"context"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -102,7 +103,7 @@ func (i *IDrac8) loadHwData() (err error) {
 }
 
 // Close closes the connection properly
-func (i *IDrac8) Close() error {
+func (i *IDrac8) Close(ctx context.Context) error {
 	var multiErr error
 
 	if i.httpClient != nil {

--- a/providers/dell/idrac9/setupConnections.go
+++ b/providers/dell/idrac9/setupConnections.go
@@ -1,6 +1,7 @@
 package idrac9
 
 import (
+	"context"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
@@ -106,7 +107,7 @@ func (i *IDrac9) loadHwData() (err error) {
 }
 
 // Close closes the connection properly
-func (i *IDrac9) Close() error {
+func (i *IDrac9) Close(ctx context.Context) error {
 	var multiErr error
 
 	if i.httpClient != nil {

--- a/providers/dummy/ibmc/ibmc.go
+++ b/providers/dummy/ibmc/ibmc.go
@@ -1,8 +1,11 @@
 package ibmc
 
 import (
+	"context"
+
 	"github.com/bmc-toolbox/bmclib/cfgresources"
 	"github.com/bmc-toolbox/bmclib/devices"
+	"github.com/bmc-toolbox/bmclib/errors"
 )
 
 // The ibmc model is part of the dummy vendor,
@@ -72,7 +75,7 @@ func (i *Ibmc) License() (string, string, error) {
 }
 
 // Close implements the Bmc interface
-func (i *Ibmc) Close() error {
+func (i *Ibmc) Close(ctx context.Context) error {
 	return nil
 }
 

--- a/providers/dummy/ibmc/ibmc.go
+++ b/providers/dummy/ibmc/ibmc.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/bmc-toolbox/bmclib/cfgresources"
 	"github.com/bmc-toolbox/bmclib/devices"
-	"github.com/bmc-toolbox/bmclib/errors"
 )
 
 // The ibmc model is part of the dummy vendor,

--- a/providers/hp/ilo/setupConnection.go
+++ b/providers/hp/ilo/setupConnection.go
@@ -2,6 +2,7 @@ package ilo
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -83,7 +84,7 @@ func (i *Ilo) httpLogin() (err error) {
 }
 
 // Close closes the connection properly
-func (i *Ilo) Close() error {
+func (i *Ilo) Close(ctx context.Context) error {
 	var multiErr error
 
 	if i.httpClient != nil {

--- a/providers/supermicro/supermicrox/setupConnection.go
+++ b/providers/supermicro/supermicrox/setupConnection.go
@@ -2,6 +2,7 @@ package supermicrox
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -60,7 +61,7 @@ func (s *SupermicroX) httpLogin() (err error) {
 }
 
 // Close closes the connection properly
-func (s *SupermicroX) Close() (err error) {
+func (s *SupermicroX) Close(ctx context.Context) (err error) {
 	if s.httpClient != nil {
 		bmcURL := fmt.Sprintf("https://%s/cgi/logout.cgi", s.ip)
 		s.log.V(1).Info("logout from bmc", "step", "bmc connection", "vendor", supermicro.VendorID, "ip", s.ip)

--- a/providers/supermicro/supermicrox11/setupConnection.go
+++ b/providers/supermicro/supermicrox11/setupConnection.go
@@ -2,6 +2,7 @@ package supermicrox11
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -69,7 +70,7 @@ func (s *SupermicroX) httpLogin() (err error) {
 }
 
 // Close closes the connection properly
-func (s *SupermicroX) Close() (err error) {
+func (s *SupermicroX) Close(ctx context.Context) (err error) {
 	if s.httpClient != nil {
 		bmcURL := fmt.Sprintf("https://%s/cgi/logout.cgi", s.ip)
 		log.WithFields(log.Fields{"step": "bmc connection", "vendor": supermicro.VendorID, "ip": s.ip}).Debug("logout from bmc")


### PR DESCRIPTION
This enables the existing codebase to be implemented by both the current
and newer interfaces.

the current interface (bmclib v0)
https://github.com/bmc-toolbox/bmclib/blob/c1fed9df833628df57796245d085c97187f06f9a/devices/interfaces.go

the newer interface (bmclib v2)
https://github.com/bmc-toolbox/bmclib/blob/c1fed9df833628df57796245d085c97187f06f9a/bmc/connection.go#L17