### PR TITLE
Bug! The chassis number is almost always there. Without this change, …

### DIFF
--- a/providers/hp/ilo/ilo.go
+++ b/providers/hp/ilo/ilo.go
@@ -662,7 +662,7 @@ func (i *Ilo) IsBlade() (isBlade bool, err error) {
 		return false, err
 	}
 
-	return chassisInfo.ChassisType == "Blade" || chassisInfo.ChassisSn != "", nil
+	return chassisInfo.ChassisType == "Blade", nil
 }
 
 // Slot returns the current slot within the chassis


### PR DESCRIPTION
…a lot of servers are considered as blades (while they are not).