### PR TITLE
Update Supermicro X11 PXE boot command

### DIFF
--- a/providers/supermicro/supermicrox11/actions.go
+++ b/providers/supermicro/supermicrox11/actions.go
@@ -53,7 +53,7 @@ func (s *SupermicroX) PxeOnce() (status bool, err error) {
 	if err != nil {
 		return status, err
 	}
-	_, err = i.PxeOnceEfi(context.Background())
+	_, err = i.PxeOnceMbr(context.Background())
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
The difference between the 2 commands is `chassis bootdev pxe` vs
`chassis bootdev pxe options=efiboot`. The one with options=efiboot does
not really work (if the server has OS installed on disk, it will boot
it).

Tested on Supermicro X11DSC+ with BIOS 3.1 and firmware 1.68.