### PR TITLE
Identify the provider that executed successfully:

### DIFF
--- a/bmc/bmc.go
+++ b/bmc/bmc.go
@@ -1,0 +1,9 @@
+package bmc
+
+// Metadata represents details about a bmc method
+type Metadata struct {
+	// SuccessfulProvider is the name of the provider that successfully executed
+	SuccessfulProvider string
+	// ProvidersAttempted is a slice of all providers that were attempt to execute
+	ProvidersAttempted []string
+}

--- a/bmc/bmc.go
+++ b/bmc/bmc.go
@@ -6,4 +6,8 @@ type Metadata struct {
 	SuccessfulProvider string
 	// ProvidersAttempted is a slice of all providers that were attempt to execute
 	ProvidersAttempted []string
+	// SuccessfulOpenConns is a slice of provider names that were opened successfully
+	SuccessfulOpenConns []string
+	// SuccessfulCloseConns is a slice of provider names that were closed successfully
+	SuccessfulCloseConns []string
 }

--- a/bmc/boot_device.go
+++ b/bmc/boot_device.go
@@ -43,7 +43,7 @@ Loop:
 					err = multierror.Append(err, errors.New("failed to set boot device"))
 					continue
 				}
-				*metadata[0] = Metadata{SuccessfulProvider: elem.name, ProvidersAttempted: append(metadata[0].ProvidersAttempted, elem.name)}
+				*metadata[0] = Metadata{SuccessfulProvider: elem.name, ProvidersAttempted: metadata[0].ProvidersAttempted}
 				return ok, nil
 			}
 		}

--- a/bmc/boot_device.go
+++ b/bmc/boot_device.go
@@ -13,8 +13,15 @@ type BootDeviceSetter interface {
 	BootDeviceSet(ctx context.Context, bootDevice string, setPersistent, efiBoot bool) (ok bool, err error)
 }
 
+// powerProviders is an internal struct to correlate an implementation/provider and its name
+type bootDeviceProviders struct {
+	name             string
+	bootDeviceSetter BootDeviceSetter
+}
+
 // SetBootDevice sets the boot device. Next boot only unless setPersistent=true
-func SetBootDevice(ctx context.Context, bootDevice string, setPersistent, efiBoot bool, b []BootDeviceSetter) (ok bool, err error) {
+// if a successfulProviderName is passed in, it will be updated to be the name of the provider that successfully executed
+func SetBootDevice(ctx context.Context, bootDevice string, setPersistent, efiBoot bool, b []bootDeviceProviders, successfulProviderName ...*string) (ok bool, err error) {
 Loop:
 	for _, elem := range b {
 		select {
@@ -22,8 +29,8 @@ Loop:
 			err = multierror.Append(err, ctx.Err())
 			break Loop
 		default:
-			if elem != nil {
-				ok, setErr := elem.BootDeviceSet(ctx, bootDevice, setPersistent, efiBoot)
+			if elem.bootDeviceSetter != nil {
+				ok, setErr := elem.bootDeviceSetter.BootDeviceSet(ctx, bootDevice, setPersistent, efiBoot)
 				if setErr != nil {
 					err = multierror.Append(err, setErr)
 					continue
@@ -31,6 +38,9 @@ Loop:
 				if !ok {
 					err = multierror.Append(err, errors.New("failed to set boot device"))
 					continue
+				}
+				if len(successfulProviderName) > 0 && successfulProviderName[0] != nil {
+					*successfulProviderName[0] = elem.name
 				}
 				return ok, nil
 			}
@@ -40,12 +50,19 @@ Loop:
 }
 
 // SetBootDeviceFromInterfaces pass through to library function
-func SetBootDeviceFromInterfaces(ctx context.Context, bootDevice string, setPersistent, efiBoot bool, generic []interface{}) (ok bool, err error) {
-	bdSetters := make([]BootDeviceSetter, 0)
+// if a successfulProviderName is passed in, it will be updated to be the name of the provider that successfully executed
+func SetBootDeviceFromInterfaces(ctx context.Context, bootDevice string, setPersistent, efiBoot bool, generic []interface{}, successfulProviderName ...*string) (ok bool, err error) {
+	bdSetters := make([]bootDeviceProviders, 0)
 	for _, elem := range generic {
+		var temp bootDeviceProviders
+		switch p := elem.(type) {
+		case Provider:
+			temp.name = p.Name()
+		}
 		switch p := elem.(type) {
 		case BootDeviceSetter:
-			bdSetters = append(bdSetters, p)
+			temp.bootDeviceSetter = p
+			bdSetters = append(bdSetters, temp)
 		default:
 			e := fmt.Sprintf("not a BootDeviceSetter implementation: %T", p)
 			err = multierror.Append(err, errors.New(e))
@@ -54,5 +71,5 @@ func SetBootDeviceFromInterfaces(ctx context.Context, bootDevice string, setPers
 	if len(bdSetters) == 0 {
 		return ok, multierror.Append(err, errors.New("no BootDeviceSetter implementations found"))
 	}
-	return SetBootDevice(ctx, bootDevice, setPersistent, efiBoot, bdSetters)
+	return SetBootDevice(ctx, bootDevice, setPersistent, efiBoot, bdSetters, successfulProviderName...)
 }

--- a/bmc/boot_device_test.go
+++ b/bmc/boot_device_test.go
@@ -63,7 +63,7 @@ func TestSetBootDevice(t *testing.T) {
 				}
 
 			} else {
-				diff := cmp.Diff(expectedResult, result)
+				diff := cmp.Diff(result, expectedResult)
 				if diff != "" {
 					t.Fatal(diff)
 				}
@@ -101,7 +101,7 @@ func TestSetBootDeviceFromInterfaces(t *testing.T) {
 			expectedResult := tc.want
 			var result bool
 			var err error
-			var successfulProvider string
+			var successfulProvider Metadata
 			if tc.withName {
 				result, err = SetBootDeviceFromInterfaces(context.Background(), tc.bootDevice, false, false, generic, &successfulProvider)
 			} else {
@@ -119,7 +119,7 @@ func TestSetBootDeviceFromInterfaces(t *testing.T) {
 				}
 			}
 			if tc.withName {
-				if diff := cmp.Diff("test provider", successfulProvider); diff != "" {
+				if diff := cmp.Diff(successfulProvider.SuccessfulProvider, "test provider"); diff != "" {
 					t.Fatal(diff)
 				}
 			}

--- a/bmc/boot_device_test.go
+++ b/bmc/boot_device_test.go
@@ -30,8 +30,7 @@ func (b *bootDeviceTester) Name() string {
 }
 
 func TestSetBootDevice(t *testing.T) {
-	testCases := []struct {
-		name         string
+	testCases := map[string]struct {
 		bootDevice   string
 		makeErrorOut bool
 		makeNotOk    bool
@@ -39,15 +38,14 @@ func TestSetBootDevice(t *testing.T) {
 		err          error
 		ctxTimeout   time.Duration
 	}{
-		{name: "success", bootDevice: "pxe", want: true},
-		{name: "not ok return", bootDevice: "pxe", want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("failed to set boot device"), errors.New("failed to set boot device")}}},
-		{name: "error", bootDevice: "pxe", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("boot device set failed"), errors.New("failed to set boot device")}}},
-		{name: "error context timeout", bootDevice: "pxe", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to set boot device")}}, ctxTimeout: time.Nanosecond * 1},
+		"success":               {bootDevice: "pxe", want: true},
+		"not ok return":         {bootDevice: "pxe", want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("failed to set boot device"), errors.New("failed to set boot device")}}},
+		"error":                 {bootDevice: "pxe", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("boot device set failed"), errors.New("failed to set boot device")}}},
+		"error context timeout": {bootDevice: "pxe", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to set boot device")}}, ctxTimeout: time.Nanosecond * 1},
 	}
 
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			testImplementation := bootDeviceTester{MakeErrorOut: tc.makeErrorOut, MakeNotOK: tc.makeNotOk}
 			expectedResult := tc.want
 			if tc.ctxTimeout == 0 {
@@ -57,7 +55,7 @@ func TestSetBootDevice(t *testing.T) {
 			defer cancel()
 			result, err := SetBootDevice(ctx, tc.bootDevice, false, false, []bootDeviceProviders{{"", &testImplementation}})
 			if err != nil {
-				diff := cmp.Diff(tc.err.Error(), err.Error())
+				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {
 					t.Fatal(diff)
 				}
@@ -74,22 +72,20 @@ func TestSetBootDevice(t *testing.T) {
 }
 
 func TestSetBootDeviceFromInterfaces(t *testing.T) {
-	testCases := []struct {
-		name              string
+	testCases := map[string]struct {
 		bootDevice        string
 		err               error
 		badImplementation bool
 		want              bool
 		withName          bool
 	}{
-		{name: "success", bootDevice: "pxe", want: true},
-		{name: "success", bootDevice: "pxe", want: true, withName: true},
-		{name: "no implementations found", bootDevice: "pxe", want: false, badImplementation: true, err: &multierror.Error{Errors: []error{errors.New("not a BootDeviceSetter implementation: *struct {}"), errors.New("no BootDeviceSetter implementations found")}}},
+		"success":                  {bootDevice: "pxe", want: true},
+		"success with metadata":    {bootDevice: "pxe", want: true, withName: true},
+		"no implementations found": {bootDevice: "pxe", want: false, badImplementation: true, err: &multierror.Error{Errors: []error{errors.New("not a BootDeviceSetter implementation: *struct {}"), errors.New("no BootDeviceSetter implementations found")}}},
 	}
 
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			var generic []interface{}
 			if tc.badImplementation {
 				badImplementation := struct{}{}
@@ -101,9 +97,9 @@ func TestSetBootDeviceFromInterfaces(t *testing.T) {
 			expectedResult := tc.want
 			var result bool
 			var err error
-			var successfulProvider Metadata
+			var metadata Metadata
 			if tc.withName {
-				result, err = SetBootDeviceFromInterfaces(context.Background(), tc.bootDevice, false, false, generic, &successfulProvider)
+				result, err = SetBootDeviceFromInterfaces(context.Background(), tc.bootDevice, false, false, generic, &metadata)
 			} else {
 				result, err = SetBootDeviceFromInterfaces(context.Background(), tc.bootDevice, false, false, generic)
 			}
@@ -113,13 +109,13 @@ func TestSetBootDeviceFromInterfaces(t *testing.T) {
 					t.Fatal(diff)
 				}
 			} else {
-				diff := cmp.Diff(expectedResult, result)
+				diff := cmp.Diff(result, expectedResult)
 				if diff != "" {
 					t.Fatal(diff)
 				}
 			}
 			if tc.withName {
-				if diff := cmp.Diff(successfulProvider.SuccessfulProvider, "test provider"); diff != "" {
+				if diff := cmp.Diff(metadata.SuccessfulProvider, "test provider"); diff != "" {
 					t.Fatal(diff)
 				}
 			}

--- a/bmc/power.go
+++ b/bmc/power.go
@@ -60,7 +60,7 @@ Loop:
 					err = multierror.Append(err, errors.New("failed to set power state"))
 					continue
 				}
-				*metadata[0] = Metadata{SuccessfulProvider: elem.name, ProvidersAttempted: append(metadata[0].ProvidersAttempted, elem.name)}
+				*metadata[0] = Metadata{SuccessfulProvider: elem.name, ProvidersAttempted: metadata[0].ProvidersAttempted}
 				return ok, nil
 			}
 		}
@@ -113,7 +113,7 @@ Loop:
 					err = multierror.Append(err, stateErr)
 					continue
 				}
-				*metadata[0] = Metadata{SuccessfulProvider: elem.name, ProvidersAttempted: append(metadata[0].ProvidersAttempted, elem.name)}
+				*metadata[0] = Metadata{SuccessfulProvider: elem.name, ProvidersAttempted: metadata[0].ProvidersAttempted}
 				return state, nil
 			}
 		}

--- a/bmc/power_test.go
+++ b/bmc/power_test.go
@@ -70,7 +70,7 @@ func TestSetPowerState(t *testing.T) {
 				}
 
 			} else {
-				diff := cmp.Diff(expectedResult, result)
+				diff := cmp.Diff(result, expectedResult)
 				if diff != "" {
 					t.Fatal(diff)
 				}
@@ -108,7 +108,7 @@ func TestSetPowerStateFromInterfaces(t *testing.T) {
 			expectedResult := tc.want
 			var result bool
 			var err error
-			var successfulProvider string
+			var successfulProvider Metadata
 			if tc.withName {
 				result, err = SetPowerStateFromInterfaces(context.Background(), tc.state, generic, &successfulProvider)
 			} else {
@@ -124,13 +124,13 @@ func TestSetPowerStateFromInterfaces(t *testing.T) {
 					t.Fatal(err)
 				}
 			} else {
-				diff := cmp.Diff(expectedResult, result)
+				diff := cmp.Diff(result, expectedResult)
 				if diff != "" {
 					t.Fatal(diff)
 				}
 			}
 			if tc.withName {
-				if diff := cmp.Diff("test provider", successfulProvider); diff != "" {
+				if diff := cmp.Diff(successfulProvider.SuccessfulProvider, "test provider"); diff != "" {
 					t.Fatal(diff)
 				}
 			}
@@ -168,7 +168,7 @@ func TestGetPowerState(t *testing.T) {
 					t.Fatal(diff)
 				}
 			} else {
-				diff := cmp.Diff(expectedResult, result)
+				diff := cmp.Diff(result, expectedResult)
 				if diff != "" {
 					t.Fatal(diff)
 				}
@@ -206,7 +206,7 @@ func TestGetPowerStateFromInterfaces(t *testing.T) {
 			expectedResult := tc.want
 			var result string
 			var err error
-			var successfulProvider string
+			var successfulProvider Metadata
 			if tc.withName {
 				result, err = GetPowerStateFromInterfaces(context.Background(), generic, &successfulProvider)
 			} else {
@@ -222,13 +222,13 @@ func TestGetPowerStateFromInterfaces(t *testing.T) {
 					t.Fatal(err)
 				}
 			} else {
-				diff := cmp.Diff(expectedResult, result)
+				diff := cmp.Diff(result, expectedResult)
 				if diff != "" {
 					t.Fatal(diff)
 				}
 			}
 			if tc.withName {
-				if diff := cmp.Diff("test provider", successfulProvider); diff != "" {
+				if diff := cmp.Diff(successfulProvider.SuccessfulProvider, "test provider"); diff != "" {
 					t.Fatal(diff)
 				}
 			}

--- a/bmc/provider.go
+++ b/bmc/provider.go
@@ -1,0 +1,7 @@
+package bmc
+
+// Provider interface describes details about a provider
+type Provider interface {
+	// Name of the provider
+	Name() string
+}

--- a/bmc/reset.go
+++ b/bmc/reset.go
@@ -45,7 +45,7 @@ Loop:
 					err = multierror.Append(err, errors.New("failed to reset BMC"))
 					continue
 				}
-				*metadata[0] = Metadata{SuccessfulProvider: elem.name, ProvidersAttempted: append(metadata[0].ProvidersAttempted, elem.name)}
+				*metadata[0] = Metadata{SuccessfulProvider: elem.name, ProvidersAttempted: metadata[0].ProvidersAttempted}
 				return ok, nil
 			}
 		}

--- a/bmc/reset_test.go
+++ b/bmc/reset_test.go
@@ -30,8 +30,7 @@ func (r *resetTester) Name() string {
 }
 
 func TestResetBMC(t *testing.T) {
-	testCases := []struct {
-		name         string
+	testCases := map[string]struct {
 		resetType    string
 		makeErrorOut bool
 		makeNotOk    bool
@@ -39,15 +38,14 @@ func TestResetBMC(t *testing.T) {
 		err          error
 		ctxTimeout   time.Duration
 	}{
-		{name: "success", resetType: "cold", want: true},
-		{name: "not ok return", resetType: "warm", want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("failed to reset BMC"), errors.New("failed to reset BMC")}}},
-		{name: "error", resetType: "cold", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("bmc reset failed"), errors.New("failed to reset BMC")}}},
-		{name: "error context timeout", resetType: "cold", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to reset BMC")}}, ctxTimeout: time.Nanosecond * 1},
+		"success":               {resetType: "cold", want: true},
+		"not ok return":         {resetType: "warm", want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("failed to reset BMC"), errors.New("failed to reset BMC")}}},
+		"error":                 {resetType: "cold", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("bmc reset failed"), errors.New("failed to reset BMC")}}},
+		"error context timeout": {resetType: "cold", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to reset BMC")}}, ctxTimeout: time.Nanosecond * 1},
 	}
 
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			testImplementation := resetTester{MakeErrorOut: tc.makeErrorOut, MakeNotOK: tc.makeNotOk}
 			expectedResult := tc.want
 			if tc.ctxTimeout == 0 {
@@ -57,39 +55,35 @@ func TestResetBMC(t *testing.T) {
 			defer cancel()
 			result, err := ResetBMC(ctx, tc.resetType, []bmcProviders{{"", &testImplementation}})
 			if err != nil {
-				diff := cmp.Diff(tc.err.Error(), err.Error())
+				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {
 					t.Fatal(diff)
 				}
-
 			} else {
 				diff := cmp.Diff(result, expectedResult)
 				if diff != "" {
 					t.Fatal(diff)
 				}
 			}
-
 		})
 	}
 }
 
 func TestResetBMCFromInterfaces(t *testing.T) {
-	testCases := []struct {
-		name              string
+	testCases := map[string]struct {
 		resetType         string
 		err               error
 		badImplementation bool
 		want              bool
 		withName          bool
 	}{
-		{name: "success", resetType: "cold", want: true},
-		{name: "success", resetType: "cold", want: true, withName: true},
-		{name: "no implementations found", resetType: "warm", want: false, badImplementation: true, err: &multierror.Error{Errors: []error{errors.New("not a BMCResetter implementation: *struct {}"), errors.New("no BMCResetter implementations found")}}},
+		"success":                  {resetType: "cold", want: true},
+		"success with metadata":    {resetType: "cold", want: true, withName: true},
+		"no implementations found": {resetType: "warm", want: false, badImplementation: true, err: &multierror.Error{Errors: []error{errors.New("not a BMCResetter implementation: *struct {}"), errors.New("no BMCResetter implementations found")}}},
 	}
 
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			var generic []interface{}
 			if tc.badImplementation {
 				badImplementation := struct{}{}
@@ -101,15 +95,15 @@ func TestResetBMCFromInterfaces(t *testing.T) {
 			expectedResult := tc.want
 			var result bool
 			var err error
-			var successfulProvider Metadata
+			var metadata Metadata
 			if tc.withName {
-				result, err = ResetBMCFromInterfaces(context.Background(), tc.resetType, generic, &successfulProvider)
+				result, err = ResetBMCFromInterfaces(context.Background(), tc.resetType, generic, &metadata)
 			} else {
 				result, err = ResetBMCFromInterfaces(context.Background(), tc.resetType, generic)
 			}
 			if err != nil {
 				if tc.err != nil {
-					diff := cmp.Diff(tc.err.Error(), err.Error())
+					diff := cmp.Diff(err.Error(), tc.err.Error())
 					if diff != "" {
 						t.Fatal(diff)
 					}
@@ -117,13 +111,13 @@ func TestResetBMCFromInterfaces(t *testing.T) {
 					t.Fatal(err)
 				}
 			} else {
-				diff := cmp.Diff(expectedResult, result)
+				diff := cmp.Diff(result, expectedResult)
 				if diff != "" {
 					t.Fatal(diff)
 				}
 			}
 			if tc.withName {
-				if diff := cmp.Diff(successfulProvider.SuccessfulProvider, "test provider"); diff != "" {
+				if diff := cmp.Diff(metadata.SuccessfulProvider, "test provider"); diff != "" {
 					t.Fatal(diff)
 				}
 			}

--- a/bmc/reset_test.go
+++ b/bmc/reset_test.go
@@ -63,7 +63,7 @@ func TestResetBMC(t *testing.T) {
 				}
 
 			} else {
-				diff := cmp.Diff(expectedResult, result)
+				diff := cmp.Diff(result, expectedResult)
 				if diff != "" {
 					t.Fatal(diff)
 				}
@@ -101,7 +101,7 @@ func TestResetBMCFromInterfaces(t *testing.T) {
 			expectedResult := tc.want
 			var result bool
 			var err error
-			var successfulProvider string
+			var successfulProvider Metadata
 			if tc.withName {
 				result, err = ResetBMCFromInterfaces(context.Background(), tc.resetType, generic, &successfulProvider)
 			} else {
@@ -123,7 +123,7 @@ func TestResetBMCFromInterfaces(t *testing.T) {
 				}
 			}
 			if tc.withName {
-				if diff := cmp.Diff("test provider", successfulProvider); diff != "" {
+				if diff := cmp.Diff(successfulProvider.SuccessfulProvider, "test provider"); diff != "" {
 					t.Fatal(diff)
 				}
 			}

--- a/bmc/reset_test.go
+++ b/bmc/reset_test.go
@@ -25,6 +25,10 @@ func (r *resetTester) BmcReset(ctx context.Context, resetType string) (ok bool, 
 	return true, nil
 }
 
+func (r *resetTester) Name() string {
+	return "test provider"
+}
+
 func TestResetBMC(t *testing.T) {
 	testCases := []struct {
 		name         string
@@ -51,7 +55,7 @@ func TestResetBMC(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, err := ResetBMC(ctx, tc.resetType, []BMCResetter{&testImplementation})
+			result, err := ResetBMC(ctx, tc.resetType, []bmcProviders{{"", &testImplementation}})
 			if err != nil {
 				diff := cmp.Diff(tc.err.Error(), err.Error())
 				if diff != "" {
@@ -76,8 +80,10 @@ func TestResetBMCFromInterfaces(t *testing.T) {
 		err               error
 		badImplementation bool
 		want              bool
+		withName          bool
 	}{
 		{name: "success", resetType: "cold", want: true},
+		{name: "success", resetType: "cold", want: true, withName: true},
 		{name: "no implementations found", resetType: "warm", want: false, badImplementation: true, err: &multierror.Error{Errors: []error{errors.New("not a BMCResetter implementation: *struct {}"), errors.New("no BMCResetter implementations found")}}},
 	}
 
@@ -93,20 +99,34 @@ func TestResetBMCFromInterfaces(t *testing.T) {
 				generic = []interface{}{&testImplementation}
 			}
 			expectedResult := tc.want
-			result, err := ResetBMCFromInterfaces(context.Background(), tc.resetType, generic)
+			var result bool
+			var err error
+			var successfulProvider string
+			if tc.withName {
+				result, err = ResetBMCFromInterfaces(context.Background(), tc.resetType, generic, &successfulProvider)
+			} else {
+				result, err = ResetBMCFromInterfaces(context.Background(), tc.resetType, generic)
+			}
 			if err != nil {
-				diff := cmp.Diff(tc.err.Error(), err.Error())
-				if diff != "" {
-					t.Fatal(diff)
+				if tc.err != nil {
+					diff := cmp.Diff(tc.err.Error(), err.Error())
+					if diff != "" {
+						t.Fatal(diff)
+					}
+				} else {
+					t.Fatal(err)
 				}
-
 			} else {
 				diff := cmp.Diff(expectedResult, result)
 				if diff != "" {
 					t.Fatal(diff)
 				}
 			}
-
+			if tc.withName {
+				if diff := cmp.Diff("test provider", successfulProvider); diff != "" {
+					t.Fatal(diff)
+				}
+			}
 		})
 	}
 }

--- a/bmc/user.go
+++ b/bmc/user.go
@@ -61,7 +61,7 @@ Loop:
 					err = multierror.Append(err, errors.New("failed to create user"))
 					continue
 				}
-				*metadata[0] = Metadata{SuccessfulProvider: elem.name, ProvidersAttempted: append(metadata[0].ProvidersAttempted, elem.name)}
+				*metadata[0] = Metadata{SuccessfulProvider: elem.name, ProvidersAttempted: metadata[0].ProvidersAttempted}
 				return ok, nil
 			}
 		}
@@ -118,7 +118,7 @@ Loop:
 					err = multierror.Append(err, errors.New("failed to update user"))
 					continue
 				}
-				*metadata[0] = Metadata{SuccessfulProvider: elem.name, ProvidersAttempted: append(metadata[0].ProvidersAttempted, elem.name)}
+				*metadata[0] = Metadata{SuccessfulProvider: elem.name, ProvidersAttempted: metadata[0].ProvidersAttempted}
 				return ok, nil
 			}
 		}
@@ -175,7 +175,7 @@ Loop:
 					err = multierror.Append(err, errors.New("failed to delete user"))
 					continue
 				}
-				*metadata[0] = Metadata{SuccessfulProvider: elem.name, ProvidersAttempted: append(metadata[0].ProvidersAttempted, elem.name)}
+				*metadata[0] = Metadata{SuccessfulProvider: elem.name, ProvidersAttempted: metadata[0].ProvidersAttempted}
 				return ok, nil
 			}
 		}
@@ -228,7 +228,7 @@ Loop:
 					err = multierror.Append(err, readErr)
 					continue
 				}
-				*metadata[0] = Metadata{SuccessfulProvider: elem.name, ProvidersAttempted: append(metadata[0].ProvidersAttempted, elem.name)}
+				*metadata[0] = Metadata{SuccessfulProvider: elem.name, ProvidersAttempted: metadata[0].ProvidersAttempted}
 				return users, nil
 			}
 		}

--- a/bmc/user_test.go
+++ b/bmc/user_test.go
@@ -101,7 +101,7 @@ func TestUserCreate(t *testing.T) {
 					t.Fatal(diff)
 				}
 			} else {
-				diff := cmp.Diff(expectedResult, result)
+				diff := cmp.Diff(result, expectedResult)
 				if diff != "" {
 					t.Fatal(diff)
 				}
@@ -140,7 +140,7 @@ func TestCreateUserFromInterfaces(t *testing.T) {
 			role := "admin"
 			var result bool
 			var err error
-			var successfulProvider string
+			var successfulProvider Metadata
 			if tc.withName {
 				result, err = CreateUserFromInterfaces(context.Background(), user, pass, role, generic, &successfulProvider)
 			} else {
@@ -162,7 +162,7 @@ func TestCreateUserFromInterfaces(t *testing.T) {
 				}
 			}
 			if tc.withName {
-				if diff := cmp.Diff("test provider", successfulProvider); diff != "" {
+				if diff := cmp.Diff(successfulProvider.SuccessfulProvider, "test provider"); diff != "" {
 					t.Fatal(diff)
 				}
 			}
@@ -205,7 +205,7 @@ func TestUpdateUser(t *testing.T) {
 					t.Fatal(diff)
 				}
 			} else {
-				diff := cmp.Diff(expectedResult, result)
+				diff := cmp.Diff(result, expectedResult)
 				if diff != "" {
 					t.Fatal(diff)
 				}
@@ -244,7 +244,7 @@ func TestUpdateUserFromInterfaces(t *testing.T) {
 			role := "admin"
 			var result bool
 			var err error
-			var successfulProvider string
+			var successfulProvider Metadata
 			if tc.withName {
 				result, err = UpdateUserFromInterfaces(context.Background(), user, pass, role, generic, &successfulProvider)
 			} else {
@@ -260,13 +260,13 @@ func TestUpdateUserFromInterfaces(t *testing.T) {
 					t.Fatal(err)
 				}
 			} else {
-				diff := cmp.Diff(expectedResult, result)
+				diff := cmp.Diff(result, expectedResult)
 				if diff != "" {
 					t.Fatal(diff)
 				}
 			}
 			if tc.withName {
-				if diff := cmp.Diff("test provider", successfulProvider); diff != "" {
+				if diff := cmp.Diff(successfulProvider.SuccessfulProvider, "test provider"); diff != "" {
 					t.Fatal(diff)
 				}
 			}
@@ -307,7 +307,7 @@ func TestDeleteUser(t *testing.T) {
 					t.Fatal(diff)
 				}
 			} else {
-				diff := cmp.Diff(expectedResult, result)
+				diff := cmp.Diff(result, expectedResult)
 				if diff != "" {
 					t.Fatal(diff)
 				}
@@ -344,7 +344,7 @@ func TestDeleteUserFromInterfaces(t *testing.T) {
 			user := "ADMIN"
 			var result bool
 			var err error
-			var successfulProvider string
+			var successfulProvider Metadata
 			if tc.withName {
 				result, err = DeleteUserFromInterfaces(context.Background(), user, generic, &successfulProvider)
 			} else {
@@ -360,13 +360,13 @@ func TestDeleteUserFromInterfaces(t *testing.T) {
 					t.Fatal(err)
 				}
 			} else {
-				diff := cmp.Diff(expectedResult, result)
+				diff := cmp.Diff(result, expectedResult)
 				if diff != "" {
 					t.Fatal(diff)
 				}
 			}
 			if tc.withName {
-				if diff := cmp.Diff("test provider", successfulProvider); diff != "" {
+				if diff := cmp.Diff(successfulProvider.SuccessfulProvider, "test provider"); diff != "" {
 					t.Fatal(diff)
 				}
 			}
@@ -413,7 +413,7 @@ func TestReadUsers(t *testing.T) {
 					t.Fatal(diff)
 				}
 			} else {
-				diff := cmp.Diff(expectedResult, result)
+				diff := cmp.Diff(result, expectedResult)
 				if diff != "" {
 					t.Fatal(diff)
 				}
@@ -458,7 +458,7 @@ func TestReadUsersFromInterfaces(t *testing.T) {
 			expectedResult := users
 			var result []map[string]string
 			var err error
-			var successfulProvider string
+			var successfulProvider Metadata
 			if tc.withName {
 				result, err = ReadUsersFromInterfaces(context.Background(), generic, &successfulProvider)
 			} else {
@@ -474,13 +474,13 @@ func TestReadUsersFromInterfaces(t *testing.T) {
 					t.Fatal(err)
 				}
 			} else {
-				diff := cmp.Diff(expectedResult, result)
+				diff := cmp.Diff(result, expectedResult)
 				if diff != "" {
 					t.Fatal(diff)
 				}
 			}
 			if tc.withName {
-				if diff := cmp.Diff("test provider", successfulProvider); diff != "" {
+				if diff := cmp.Diff(successfulProvider.SuccessfulProvider, "test provider"); diff != "" {
 					t.Fatal(diff)
 				}
 			}

--- a/client.go
+++ b/client.go
@@ -78,13 +78,13 @@ func (c *Client) registerProviders() {
 }
 
 // Open pass through to library function
-func (c *Client) Open(ctx context.Context) (err error) {
-	return bmc.OpenConnectionFromInterfaces(ctx, c.Registry.GetDriverInterfaces())
+func (c *Client) Open(ctx context.Context, metadata ...*bmc.Metadata) (err error) {
+	return bmc.OpenConnectionFromInterfaces(ctx, c.Registry.GetDriverInterfaces(), metadata...)
 }
 
 // Close pass through to library function
-func (c *Client) Close(ctx context.Context) (err error) {
-	return bmc.CloseConnectionFromInterfaces(ctx, c.Registry.GetDriverInterfaces())
+func (c *Client) Close(ctx context.Context, metadata ...*bmc.Metadata) (err error) {
+	return bmc.CloseConnectionFromInterfaces(ctx, c.Registry.GetDriverInterfaces(), metadata...)
 }
 
 // GetPowerState pass through to library function

--- a/client.go
+++ b/client.go
@@ -88,43 +88,51 @@ func (c *Client) Close(ctx context.Context) (err error) {
 }
 
 // GetPowerState pass through to library function
-func (c *Client) GetPowerState(ctx context.Context) (state string, err error) {
-	return bmc.GetPowerStateFromInterfaces(ctx, c.Registry.GetDriverInterfaces())
+// if a successfulProviderName is passed in, it will be updated to be the name of the provider that successfully executed
+func (c *Client) GetPowerState(ctx context.Context, successfulProviderName ...*string) (state string, err error) {
+	return bmc.GetPowerStateFromInterfaces(ctx, c.Registry.GetDriverInterfaces(), successfulProviderName...)
 }
 
 // SetPowerState pass through to library function
-func (c *Client) SetPowerState(ctx context.Context, state string) (ok bool, err error) {
-	return bmc.SetPowerStateFromInterfaces(ctx, state, c.Registry.GetDriverInterfaces())
+// if a successfulProviderName is passed in, it will be updated to be the name of the provider that successfully executed
+func (c *Client) SetPowerState(ctx context.Context, state string, successfulProviderName ...*string) (ok bool, err error) {
+	return bmc.SetPowerStateFromInterfaces(ctx, state, c.Registry.GetDriverInterfaces(), successfulProviderName...)
 }
 
 // CreateUser pass through to library function
-func (c *Client) CreateUser(ctx context.Context, user, pass, role string) (ok bool, err error) {
-	return bmc.CreateUserFromInterfaces(ctx, user, pass, role, c.Registry.GetDriverInterfaces())
+// if a successfulProviderName is passed in, it will be updated to be the name of the provider that successfully executed
+func (c *Client) CreateUser(ctx context.Context, user, pass, role string, successfulProviderName ...*string) (ok bool, err error) {
+	return bmc.CreateUserFromInterfaces(ctx, user, pass, role, c.Registry.GetDriverInterfaces(), successfulProviderName...)
 }
 
 // UpdateUser pass through to library function
-func (c *Client) UpdateUser(ctx context.Context, user, pass, role string) (ok bool, err error) {
-	return bmc.UpdateUserFromInterfaces(ctx, user, pass, role, c.Registry.GetDriverInterfaces())
+// if a successfulProviderName is passed in, it will be updated to be the name of the provider that successfully executed
+func (c *Client) UpdateUser(ctx context.Context, user, pass, role string, successfulProviderName ...*string) (ok bool, err error) {
+	return bmc.UpdateUserFromInterfaces(ctx, user, pass, role, c.Registry.GetDriverInterfaces(), successfulProviderName...)
 }
 
 // DeleteUser pass through to library function
-func (c *Client) DeleteUser(ctx context.Context, user string) (ok bool, err error) {
-	return bmc.DeleteUserFromInterfaces(ctx, user, c.Registry.GetDriverInterfaces())
+// if a successfulProviderName is passed in, it will be updated to be the name of the provider that successfully executed
+func (c *Client) DeleteUser(ctx context.Context, user string, successfulProviderName ...*string) (ok bool, err error) {
+	return bmc.DeleteUserFromInterfaces(ctx, user, c.Registry.GetDriverInterfaces(), successfulProviderName...)
 }
 
 // ReadUsers pass through to library function
-func (c *Client) ReadUsers(ctx context.Context) (users []map[string]string, err error) {
-	return bmc.ReadUsersFromInterfaces(ctx, c.Registry.GetDriverInterfaces())
+// if a successfulProviderName is passed in, it will be updated to be the name of the provider that successfully executed
+func (c *Client) ReadUsers(ctx context.Context, successfulProviderName ...*string) (users []map[string]string, err error) {
+	return bmc.ReadUsersFromInterfaces(ctx, c.Registry.GetDriverInterfaces(), successfulProviderName...)
 }
 
 // SetBootDevice pass through to library function
-func (c *Client) SetBootDevice(ctx context.Context, bootDevice string, setPersistent, efiBoot bool) (ok bool, err error) {
-	return bmc.SetBootDeviceFromInterfaces(ctx, bootDevice, setPersistent, efiBoot, c.Registry.GetDriverInterfaces())
+// if a successfulProviderName is passed in, it will be updated to be the name of the provider that successfully executed
+func (c *Client) SetBootDevice(ctx context.Context, bootDevice string, setPersistent, efiBoot bool, successfulProviderName ...*string) (ok bool, err error) {
+	return bmc.SetBootDeviceFromInterfaces(ctx, bootDevice, setPersistent, efiBoot, c.Registry.GetDriverInterfaces(), successfulProviderName...)
 }
 
 // ResetBMC pass through to library function
-func (c *Client) ResetBMC(ctx context.Context, resetType string) (ok bool, err error) {
-	return bmc.ResetBMCFromInterfaces(ctx, resetType, c.Registry.GetDriverInterfaces())
+// if a successfulProviderName is passed in, it will be updated to be the name of the provider that successfully executed
+func (c *Client) ResetBMC(ctx context.Context, resetType string, successfulProviderName ...*string) (ok bool, err error) {
+	return bmc.ResetBMCFromInterfaces(ctx, resetType, c.Registry.GetDriverInterfaces(), successfulProviderName...)
 }
 
 // GetBMCVersion pass through library function

--- a/client.go
+++ b/client.go
@@ -88,51 +88,51 @@ func (c *Client) Close(ctx context.Context) (err error) {
 }
 
 // GetPowerState pass through to library function
-// if a successfulProviderName is passed in, it will be updated to be the name of the provider that successfully executed
-func (c *Client) GetPowerState(ctx context.Context, successfulProviderName ...*string) (state string, err error) {
-	return bmc.GetPowerStateFromInterfaces(ctx, c.Registry.GetDriverInterfaces(), successfulProviderName...)
+// if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
+func (c *Client) GetPowerState(ctx context.Context, metadata ...*bmc.Metadata) (state string, err error) {
+	return bmc.GetPowerStateFromInterfaces(ctx, c.Registry.GetDriverInterfaces(), metadata...)
 }
 
 // SetPowerState pass through to library function
-// if a successfulProviderName is passed in, it will be updated to be the name of the provider that successfully executed
-func (c *Client) SetPowerState(ctx context.Context, state string, successfulProviderName ...*string) (ok bool, err error) {
-	return bmc.SetPowerStateFromInterfaces(ctx, state, c.Registry.GetDriverInterfaces(), successfulProviderName...)
+// if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
+func (c *Client) SetPowerState(ctx context.Context, state string, metadata ...*bmc.Metadata) (ok bool, err error) {
+	return bmc.SetPowerStateFromInterfaces(ctx, state, c.Registry.GetDriverInterfaces(), metadata...)
 }
 
 // CreateUser pass through to library function
-// if a successfulProviderName is passed in, it will be updated to be the name of the provider that successfully executed
-func (c *Client) CreateUser(ctx context.Context, user, pass, role string, successfulProviderName ...*string) (ok bool, err error) {
-	return bmc.CreateUserFromInterfaces(ctx, user, pass, role, c.Registry.GetDriverInterfaces(), successfulProviderName...)
+// if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
+func (c *Client) CreateUser(ctx context.Context, user, pass, role string, metadata ...*bmc.Metadata) (ok bool, err error) {
+	return bmc.CreateUserFromInterfaces(ctx, user, pass, role, c.Registry.GetDriverInterfaces(), metadata...)
 }
 
 // UpdateUser pass through to library function
-// if a successfulProviderName is passed in, it will be updated to be the name of the provider that successfully executed
-func (c *Client) UpdateUser(ctx context.Context, user, pass, role string, successfulProviderName ...*string) (ok bool, err error) {
-	return bmc.UpdateUserFromInterfaces(ctx, user, pass, role, c.Registry.GetDriverInterfaces(), successfulProviderName...)
+// if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
+func (c *Client) UpdateUser(ctx context.Context, user, pass, role string, metadata ...*bmc.Metadata) (ok bool, err error) {
+	return bmc.UpdateUserFromInterfaces(ctx, user, pass, role, c.Registry.GetDriverInterfaces(), metadata...)
 }
 
 // DeleteUser pass through to library function
-// if a successfulProviderName is passed in, it will be updated to be the name of the provider that successfully executed
-func (c *Client) DeleteUser(ctx context.Context, user string, successfulProviderName ...*string) (ok bool, err error) {
-	return bmc.DeleteUserFromInterfaces(ctx, user, c.Registry.GetDriverInterfaces(), successfulProviderName...)
+// if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
+func (c *Client) DeleteUser(ctx context.Context, user string, metadata ...*bmc.Metadata) (ok bool, err error) {
+	return bmc.DeleteUserFromInterfaces(ctx, user, c.Registry.GetDriverInterfaces(), metadata...)
 }
 
 // ReadUsers pass through to library function
-// if a successfulProviderName is passed in, it will be updated to be the name of the provider that successfully executed
-func (c *Client) ReadUsers(ctx context.Context, successfulProviderName ...*string) (users []map[string]string, err error) {
-	return bmc.ReadUsersFromInterfaces(ctx, c.Registry.GetDriverInterfaces(), successfulProviderName...)
+// if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
+func (c *Client) ReadUsers(ctx context.Context, metadata ...*bmc.Metadata) (users []map[string]string, err error) {
+	return bmc.ReadUsersFromInterfaces(ctx, c.Registry.GetDriverInterfaces(), metadata...)
 }
 
 // SetBootDevice pass through to library function
-// if a successfulProviderName is passed in, it will be updated to be the name of the provider that successfully executed
-func (c *Client) SetBootDevice(ctx context.Context, bootDevice string, setPersistent, efiBoot bool, successfulProviderName ...*string) (ok bool, err error) {
-	return bmc.SetBootDeviceFromInterfaces(ctx, bootDevice, setPersistent, efiBoot, c.Registry.GetDriverInterfaces(), successfulProviderName...)
+// if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
+func (c *Client) SetBootDevice(ctx context.Context, bootDevice string, setPersistent, efiBoot bool, metadata ...*bmc.Metadata) (ok bool, err error) {
+	return bmc.SetBootDeviceFromInterfaces(ctx, bootDevice, setPersistent, efiBoot, c.Registry.GetDriverInterfaces(), metadata...)
 }
 
 // ResetBMC pass through to library function
-// if a successfulProviderName is passed in, it will be updated to be the name of the provider that successfully executed
-func (c *Client) ResetBMC(ctx context.Context, resetType string, successfulProviderName ...*string) (ok bool, err error) {
-	return bmc.ResetBMCFromInterfaces(ctx, resetType, c.Registry.GetDriverInterfaces(), successfulProviderName...)
+// if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
+func (c *Client) ResetBMC(ctx context.Context, resetType string, metadata ...*bmc.Metadata) (ok bool, err error) {
+	return bmc.ResetBMCFromInterfaces(ctx, resetType, c.Registry.GetDriverInterfaces(), metadata...)
 }
 
 // GetBMCVersion pass through library function

--- a/client_test.go
+++ b/client_test.go
@@ -37,11 +37,17 @@ func TestBMC(t *testing.T) {
 	if err != nil {
 		t.Log(err)
 	}
-	state, err = cl.GetPowerState(ctx)
+
+	var providerName string
+	// if you pass in a string pointer to any function
+	// it will be updated with the name of the provider
+	// that successfully execute
+	state, err = cl.GetPowerState(ctx, &providerName)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Log(state)
+	t.Log(providerName)
 
 	users, err := cl.ReadUsers(ctx)
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bmc-toolbox/bmclib/bmc"
 	"github.com/bmc-toolbox/bmclib/logging"
 )
 
@@ -26,7 +27,7 @@ func TestBMC(t *testing.T) {
 	}
 	defer cl.Close(ctx)
 
-	cl.Registry.Drivers = cl.Registry.PreferProtocol("redfish")
+	cl.Registry.Drivers = cl.Registry.PreferDriver("other")
 	state, err := cl.GetPowerState(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -38,16 +39,16 @@ func TestBMC(t *testing.T) {
 		t.Log(err)
 	}
 
-	var providerName string
-	// if you pass in a string pointer to any function
-	// it will be updated with the name of the provider
-	// that successfully execute
-	state, err = cl.GetPowerState(ctx, &providerName)
+	var metadata bmc.Metadata
+	// if you pass in a the metadata as a pointer to any function
+	// it will be updated with details about the call. name of the provider
+	// that successfully execute and providers attempted.
+	state, err = cl.GetPowerState(ctx, &metadata)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Log(state)
-	t.Log(providerName)
+	t.Logf("%+v", metadata)
 
 	users, err := cl.ReadUsers(ctx)
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -21,11 +21,13 @@ func TestBMC(t *testing.T) {
 	log := logging.DefaultLogger()
 	cl := NewClient(host, port, user, pass, WithLogger(log))
 	cl.Registry.Drivers = cl.Registry.FilterForCompatible(ctx)
-	err := cl.Open(ctx)
+	var metadata bmc.Metadata
+	err := cl.Open(ctx, &metadata)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cl.Close(ctx)
+	t.Logf("%+v", metadata)
 
 	cl.Registry.Drivers = cl.Registry.PreferDriver("other")
 	state, err := cl.GetPowerState(ctx)
@@ -39,7 +41,6 @@ func TestBMC(t *testing.T) {
 		t.Log(err)
 	}
 
-	var metadata bmc.Metadata
 	// if you pass in a the metadata as a pointer to any function
 	// it will be updated with details about the call. name of the provider
 	// that successfully execute and providers attempted.

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/go-querystring v1.0.0
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.0
-	github.com/jacobweinstock/registrar v0.3.2
+	github.com/jacobweinstock/registrar v0.4.2
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/magefile/mage v1.11.0 // indirect
 	github.com/magiconair/properties v1.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/jacobweinstock/registrar v0.3.2 h1:hINoN2hzuZuoryQjR5pyCtl0vR2FWqolf1ZKI69QFls=
-github.com/jacobweinstock/registrar v0.3.2/go.mod h1:69P9dxcMVsAKUwiVRwkchq/BJyBXSFSMJcvl7PhsI2k=
+github.com/jacobweinstock/registrar v0.4.2 h1:ifM6NNKpU3xrUIEZjwMLZZEeom5q7V8NfwDEEhdsAHo=
+github.com/jacobweinstock/registrar v0.4.2/go.mod h1:69P9dxcMVsAKUwiVRwkchq/BJyBXSFSMJcvl7PhsI2k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/providers/ipmitool/ipmitool.go
+++ b/providers/ipmitool/ipmitool.go
@@ -65,6 +65,10 @@ func (c *Conn) Compatible(ctx context.Context) bool {
 	return err == nil
 }
 
+func (c *Conn) Name() string {
+	return ProviderName
+}
+
 // BootDeviceSet sets the next boot device with options
 func (c *Conn) BootDeviceSet(ctx context.Context, bootDevice string, setPersistent, efiBoot bool) (ok bool, err error) {
 	return c.con.BootDeviceSet(ctx, bootDevice, setPersistent, efiBoot)


### PR DESCRIPTION
Without breaking clients, this adds the capability of relaying to the end-user metadata about the method call, like the name of the provider that successfully executed. This gives info back to end-users to help if they need to use a certain provider for certain hardware, for other determinations that only happen on the end-user side, for troubleshooting, and removes some of the mystery around what happens when a method is called.

addresses https://github.com/bmc-toolbox/bmclib/issues/210

example usage in [`client_test.go`](https://github.com/bmc-toolbox/bmclib/pull/212/files#diff-4dc56e64f310cd8c12bb00f75c09e83f5d875563ea9901788e525487dc6788b3)