### PR TITLE
fix nil reference exception in device probe

### DIFF
--- a/discover/discover.go
+++ b/discover/discover.go
@@ -22,7 +22,6 @@ const (
 	ProbeM1000e        = "m1000e"
 	ProbeQuanta        = "quanta"
 	ProbeHpCl100       = "hpcl100"
-	ProbeASRockRack    = "asrockrack"
 )
 
 // ScanAndConnect will scan the bmc trying to learn the device type and return a working connection.
@@ -75,7 +74,6 @@ func ScanAndConnect(host string, username string, password string, options ...Op
 		ProbeM1000e,
 		ProbeQuanta,
 		ProbeHpCl100,
-		ProbeASRockRack,
 	}
 
 	if opts.Hint != "" {


### PR DESCRIPTION
Both the "order" and the "devices" arrays must be equal in length, because of
    for _, probeID := range order {
        probeDevice := devices[probeID]
        bmcConnection, err := probeDevice(opts.Context, opts.Logger) // Boom!
    }