### PR TITLE
providers/asrockrack: update flash progress and check interval timeouts

### DIFF
--- a/providers/asrockrack/asrockrack.go
+++ b/providers/asrockrack/asrockrack.go
@@ -170,9 +170,9 @@ func (a *ASRockRack) FirmwareUpdateBMC(ctx context.Context, fileReader io.Reader
 	}
 
 	// progress check interval
-	progressT := time.NewTicker(2 * time.Second).C
+	progressT := time.NewTicker(500 * time.Millisecond).C
 	// timeout interval
-	timeoutT := time.NewTicker(30 * time.Minute).C
+	timeoutT := time.NewTicker(20 * time.Minute).C
 	maxErrors := 20
 	var errorsCount int
 


### PR DESCRIPTION
the BMC resets a few seconds after an update, we increase the flash progress check interval 
and reduce the flash timeout value, since 30 minutes is way too long - a BMC/BIOS flash takes a max of 10 minutes.