### PR TITLE
Bug! We have to make sure that the chassis is on before power cycling!

### DIFF
--- a/providers/hp/ilo/actions.go
+++ b/providers/hp/ilo/actions.go
@@ -71,22 +71,21 @@ func (i *Ilo) PowerOff() (bool, error) {
 
 // PxeOnce makes the machine to boot via pxe once
 func (i *Ilo) PxeOnce() (bool, error) {
-	im, err := ipmi.New(i.username, i.password, i.ip)
+	p, err := ipmi.New(i.username, i.password, i.ip)
 	if err != nil {
 		return false, err
 	}
-	// PXE using uefi, does't work for some models
-	// directly. It only works if you pxe, powercycle and
-	// power on.
-	if _, err = im.PxeOnceEfi(context.Background()); err != nil {
+	// PXE using UEFI does't work for some models directly.
+	// It only works if you PXE, PowerCycle, and PowerOn.
+	if _, err = p.PxeOnceEfi(context.Background()); err != nil {
 		return false, err
 	}
 
-	if _, err := im.PowerCycle(context.Background()); err != nil {
+	if _, err := p.ForceRestart(context.Background()); err != nil {
 		return false, err
 	}
 
-	return im.PowerOnForce(context.Background())
+	return p.PowerOn(context.Background())
 }
 
 // IsOn tells if a machine is currently powered on

--- a/providers/supermicro/supermicrox/actions.go
+++ b/providers/supermicro/supermicrox/actions.go
@@ -57,7 +57,7 @@ func (s *SupermicroX) PxeOnce() (status bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	return i.PowerCycle(context.Background())
+	return i.ForceRestart(context.Background())
 }
 
 // IsOn tells if a machine is currently powered on

--- a/providers/supermicro/supermicrox11/actions.go
+++ b/providers/supermicro/supermicrox11/actions.go
@@ -57,7 +57,7 @@ func (s *SupermicroX) PxeOnce() (status bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	return i.PowerCycle(context.Background())
+	return i.ForceRestart(context.Background())
 }
 
 // IsOn tells if a machine is currently powered on


### PR DESCRIPTION
Without this change, we get "Set Chassis Power Control to Cycle failed: Command not supported in present state" if the chassis is turned off.