### PR TITLE
Fix bug in provider ipmitool:

### DIFF
--- a/internal/ipmi/ipmi.go
+++ b/internal/ipmi/ipmi.go
@@ -112,11 +112,10 @@ func (i *Ipmi) PowerResetBmc(ctx context.Context, resetType string) (ok bool, er
 func (i *Ipmi) PowerOn(ctx context.Context) (status bool, err error) {
 	s, err := i.IsOn(ctx)
 	if err != nil {
-		return false, err
+		return false, errors.Wrap(err, "error checking power state")
 	}
-
 	if s {
-		return false, fmt.Errorf("server is already on")
+		return true, nil
 	}
 
 	output, err := i.run(ctx, []string{"chassis", "power", "on"})
@@ -125,9 +124,9 @@ func (i *Ipmi) PowerOn(ctx context.Context) (status bool, err error) {
 	}
 
 	if strings.HasPrefix(output, "Chassis Power Control: Up/On") {
-		return true, err
+		return true, nil
 	}
-	return false, fmt.Errorf("%v: %v", err, output)
+	return false, fmt.Errorf("stderr/stdout: %v", output)
 }
 
 // PowerOnForce power on the machine via bmc even when the machine is already on (Thanks HP!)

--- a/providers/ipmitool/ipmitool.go
+++ b/providers/ipmitool/ipmitool.go
@@ -93,19 +93,14 @@ func (c *Conn) PowerStateGet(ctx context.Context) (state string, err error) {
 func (c *Conn) PowerSet(ctx context.Context, state string) (ok bool, err error) {
 	switch strings.ToLower(state) {
 	case "on":
-		on, _ := c.con.IsOn(ctx)
-		if on {
-			ok = true
-		} else {
+		on, errOn := c.con.IsOn(ctx)
+		if errOn != nil || !on {
 			ok, err = c.con.PowerOn(ctx)
+		} else {
+			ok = true
 		}
 	case "off":
-		on, _ := c.con.IsOn(ctx)
-		if !on {
-			ok = true
-		} else {
-			ok, err = c.con.PowerOff(ctx)
-		}
+		ok, err = c.con.PowerOff(ctx)
 	case "soft":
 		ok, err = c.con.PowerSoft(ctx)
 	case "reset":


### PR DESCRIPTION
Power off in ipmitool was duplicating the internal ipmi
package functionality in PowerOff but doing it poorly.
Specifically not checking for an error when calling `IsOn`.

Also, the internal ipmi package `PowerOn` has been updated.
It now follows how ipmitool behaves when calling `chassis power on`.
ipmitool will return an exit code of 0 if calling `chassis power on`
against a machine in a powered-on state.
