### PR TITLE
Update metadata user experience:

### DIFF
--- a/bmc/bmc.go
+++ b/bmc/bmc.go
@@ -1,7 +1,5 @@
 package bmc
 
-import "fmt"
-
 // Metadata represents details about a bmc method
 type Metadata struct {
 	// SuccessfulProvider is the name of the provider that successfully executed
@@ -12,12 +10,4 @@ type Metadata struct {
 	SuccessfulOpenConns []string
 	// SuccessfulCloseConns is a slice of provider names that were closed successfully
 	SuccessfulCloseConns []string
-}
-
-func getProviderName(provider interface{}) string {
-	switch p := provider.(type) {
-	case Provider:
-		return p.Name()
-	}
-	return fmt.Sprintf("%T", provider)
 }

--- a/bmc/boot_device_test.go
+++ b/bmc/boot_device_test.go
@@ -53,7 +53,7 @@ func TestSetBootDevice(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, err := SetBootDevice(ctx, tc.bootDevice, false, false, []bootDeviceProviders{{"", &testImplementation}})
+			result, _, err := SetBootDevice(ctx, tc.bootDevice, false, false, []bootDeviceProviders{{"", &testImplementation}})
 			if err != nil {
 				if tc.err != nil {
 					diff := cmp.Diff(err.Error(), tc.err.Error())
@@ -99,14 +99,7 @@ func TestSetBootDeviceFromInterfaces(t *testing.T) {
 				generic = []interface{}{&testImplementation}
 			}
 			expectedResult := tc.want
-			var result bool
-			var err error
-			var metadata Metadata
-			if tc.withName {
-				result, err = SetBootDeviceFromInterfaces(context.Background(), tc.bootDevice, false, false, generic, &metadata)
-			} else {
-				result, err = SetBootDeviceFromInterfaces(context.Background(), tc.bootDevice, false, false, generic)
-			}
+			result, metadata, err := SetBootDeviceFromInterfaces(context.Background(), tc.bootDevice, false, false, generic)
 			if err != nil {
 				diff := cmp.Diff(tc.err.Error(), err.Error())
 				if diff != "" {

--- a/bmc/connection_test.go
+++ b/bmc/connection_test.go
@@ -62,14 +62,7 @@ func TestOpenConnectionFromInterfaces(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			var err error
-			var metadata Metadata
-			var opened []interface{}
-			if tc.withMetadata {
-				opened, err = OpenConnectionFromInterfaces(ctx, generic, &metadata)
-			} else {
-				opened, err = OpenConnectionFromInterfaces(ctx, generic)
-			}
+			opened, metadata, err := OpenConnectionFromInterfaces(ctx, generic)
 			if err != nil {
 				if tc.err != nil {
 					if diff := cmp.Diff(err.Error(), tc.err.Error()); diff != "" {
@@ -112,7 +105,7 @@ func TestCloseConnection(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			err := CloseConnection(ctx, []connectionProviders{{"", &testImplementation}})
+			_, err := CloseConnection(ctx, []connectionProviders{{"", &testImplementation}})
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {
@@ -144,13 +137,8 @@ func TestCloseConnectionFromInterfaces(t *testing.T) {
 				testImplementation := connTester{}
 				generic = []interface{}{&testImplementation}
 			}
-			var err error
-			var metadata Metadata
-			if tc.withMetadata {
-				err = CloseConnectionFromInterfaces(context.Background(), generic, &metadata)
-			} else {
-				err = CloseConnectionFromInterfaces(context.Background(), generic)
-			}
+
+			metadata, err := CloseConnectionFromInterfaces(context.Background(), generic)
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {

--- a/bmc/power_test.go
+++ b/bmc/power_test.go
@@ -60,7 +60,7 @@ func TestSetPowerState(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, err := SetPowerState(ctx, tc.state, []powerProviders{{"", nil, &testImplementation}})
+			result, _, err := SetPowerState(ctx, tc.state, []powerProviders{{"", nil, &testImplementation}})
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {
@@ -100,14 +100,7 @@ func TestSetPowerStateFromInterfaces(t *testing.T) {
 				generic = []interface{}{&testImplementation}
 			}
 			expectedResult := tc.want
-			var result bool
-			var err error
-			var metadata Metadata
-			if tc.withMetadata {
-				result, err = SetPowerStateFromInterfaces(context.Background(), tc.state, generic, &metadata)
-			} else {
-				result, err = SetPowerStateFromInterfaces(context.Background(), tc.state, generic)
-			}
+			result, metadata, err := SetPowerStateFromInterfaces(context.Background(), tc.state, generic)
 			if err != nil {
 				if tc.err != nil {
 					diff := cmp.Diff(err.Error(), tc.err.Error())
@@ -153,7 +146,7 @@ func TestGetPowerState(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, err := GetPowerState(ctx, []powerProviders{{"", &testImplementation, nil}})
+			result, _, err := GetPowerState(ctx, []powerProviders{{"", &testImplementation, nil}})
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {
@@ -193,14 +186,7 @@ func TestGetPowerStateFromInterfaces(t *testing.T) {
 				generic = []interface{}{&testImplementation}
 			}
 			expectedResult := tc.want
-			var result string
-			var err error
-			var metadata Metadata
-			if tc.withMetadata {
-				result, err = GetPowerStateFromInterfaces(context.Background(), generic, &metadata)
-			} else {
-				result, err = GetPowerStateFromInterfaces(context.Background(), generic)
-			}
+			result, metadata, err := GetPowerStateFromInterfaces(context.Background(), generic)
 			if err != nil {
 				if tc.err != nil {
 					diff := cmp.Diff(err.Error(), tc.err.Error())

--- a/bmc/provider.go
+++ b/bmc/provider.go
@@ -1,7 +1,19 @@
 package bmc
 
+import "fmt"
+
 // Provider interface describes details about a provider
 type Provider interface {
 	// Name of the provider
 	Name() string
+}
+
+// getProviderName returns the name a provider supplies if they implement the Provider interface
+// if not implemented then the contrete type is returned
+func getProviderName(provider interface{}) string {
+	switch p := provider.(type) {
+	case Provider:
+		return p.Name()
+	}
+	return fmt.Sprintf("%T", provider)
 }

--- a/bmc/reset_test.go
+++ b/bmc/reset_test.go
@@ -53,7 +53,7 @@ func TestResetBMC(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, err := ResetBMC(ctx, tc.resetType, []bmcProviders{{"", &testImplementation}})
+			result, _, err := ResetBMC(ctx, tc.resetType, []bmcProviders{{"", &testImplementation}})
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {
@@ -93,14 +93,7 @@ func TestResetBMCFromInterfaces(t *testing.T) {
 				generic = []interface{}{&testImplementation}
 			}
 			expectedResult := tc.want
-			var result bool
-			var err error
-			var metadata Metadata
-			if tc.withName {
-				result, err = ResetBMCFromInterfaces(context.Background(), tc.resetType, generic, &metadata)
-			} else {
-				result, err = ResetBMCFromInterfaces(context.Background(), tc.resetType, generic)
-			}
+			result, metadata, err := ResetBMCFromInterfaces(context.Background(), tc.resetType, generic)
 			if err != nil {
 				if tc.err != nil {
 					diff := cmp.Diff(err.Error(), tc.err.Error())

--- a/bmc/user.go
+++ b/bmc/user.go
@@ -39,13 +39,8 @@ type userProviders struct {
 
 // CreateUser creates a user using the passed in implementation
 // if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
-func CreateUser(ctx context.Context, user, pass, role string, u []userProviders, metadata ...*Metadata) (ok bool, err error) {
+func CreateUser(ctx context.Context, user, pass, role string, u []userProviders) (ok bool, metadata Metadata, err error) {
 	var metadataLocal Metadata
-	defer func() {
-		if len(metadata) > 0 && metadata[0] != nil {
-			*metadata[0] = metadataLocal
-		}
-	}()
 Loop:
 	for _, elem := range u {
 		if elem.userCreator == nil {
@@ -67,15 +62,15 @@ Loop:
 				continue
 			}
 			metadataLocal.SuccessfulProvider = elem.name
-			return ok, nil
+			return ok, metadataLocal, nil
 		}
 	}
-	return ok, multierror.Append(err, errors.New("failed to create user"))
+	return ok, metadataLocal, multierror.Append(err, errors.New("failed to create user"))
 }
 
 // CreateUserFromInterfaces pass through to library function
 // if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
-func CreateUserFromInterfaces(ctx context.Context, user, pass, role string, generic []interface{}, metadata ...*Metadata) (ok bool, err error) {
+func CreateUserFromInterfaces(ctx context.Context, user, pass, role string, generic []interface{}) (ok bool, metadata Metadata, err error) {
 	userCreators := make([]userProviders, 0)
 	for _, elem := range generic {
 		temp := userProviders{name: getProviderName(elem)}
@@ -89,20 +84,15 @@ func CreateUserFromInterfaces(ctx context.Context, user, pass, role string, gene
 		}
 	}
 	if len(userCreators) == 0 {
-		return ok, multierror.Append(err, errors.New("no UserCreator implementations found"))
+		return ok, metadata, multierror.Append(err, errors.New("no UserCreator implementations found"))
 	}
-	return CreateUser(ctx, user, pass, role, userCreators, metadata...)
+	return CreateUser(ctx, user, pass, role, userCreators)
 }
 
 // UpdateUser updates a user's settings
 // if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
-func UpdateUser(ctx context.Context, user, pass, role string, u []userProviders, metadata ...*Metadata) (ok bool, err error) {
+func UpdateUser(ctx context.Context, user, pass, role string, u []userProviders) (ok bool, metadata Metadata, err error) {
 	var metadataLocal Metadata
-	defer func() {
-		if len(metadata) > 0 && metadata[0] != nil {
-			*metadata[0] = metadataLocal
-		}
-	}()
 Loop:
 	for _, elem := range u {
 		if elem.userUpdater == nil {
@@ -124,15 +114,15 @@ Loop:
 				continue
 			}
 			metadataLocal.SuccessfulProvider = elem.name
-			return ok, nil
+			return ok, metadataLocal, nil
 		}
 	}
-	return ok, multierror.Append(err, errors.New("failed to update user"))
+	return ok, metadataLocal, multierror.Append(err, errors.New("failed to update user"))
 }
 
 // UpdateUserFromInterfaces pass through to library function
 // if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
-func UpdateUserFromInterfaces(ctx context.Context, user, pass, role string, generic []interface{}, metadata ...*Metadata) (ok bool, err error) {
+func UpdateUserFromInterfaces(ctx context.Context, user, pass, role string, generic []interface{}) (ok bool, metadata Metadata, err error) {
 	userUpdaters := make([]userProviders, 0)
 	for _, elem := range generic {
 		temp := userProviders{name: getProviderName(elem)}
@@ -146,20 +136,15 @@ func UpdateUserFromInterfaces(ctx context.Context, user, pass, role string, gene
 		}
 	}
 	if len(userUpdaters) == 0 {
-		return ok, multierror.Append(err, errors.New("no UserUpdater implementations found"))
+		return ok, metadata, multierror.Append(err, errors.New("no UserUpdater implementations found"))
 	}
-	return UpdateUser(ctx, user, pass, role, userUpdaters, metadata...)
+	return UpdateUser(ctx, user, pass, role, userUpdaters)
 }
 
 // DeleteUser deletes a user from a BMC
 // if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
-func DeleteUser(ctx context.Context, user string, u []userProviders, metadata ...*Metadata) (ok bool, err error) {
+func DeleteUser(ctx context.Context, user string, u []userProviders) (ok bool, metadata Metadata, err error) {
 	var metadataLocal Metadata
-	defer func() {
-		if len(metadata) > 0 && metadata[0] != nil {
-			*metadata[0] = metadataLocal
-		}
-	}()
 Loop:
 	for _, elem := range u {
 		if elem.userDeleter == nil {
@@ -181,15 +166,15 @@ Loop:
 				continue
 			}
 			metadataLocal.SuccessfulProvider = elem.name
-			return ok, nil
+			return ok, metadataLocal, nil
 		}
 	}
-	return ok, multierror.Append(err, errors.New("failed to delete user"))
+	return ok, metadataLocal, multierror.Append(err, errors.New("failed to delete user"))
 }
 
 // DeleteUserFromInterfaces pass through to library function
 // if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
-func DeleteUserFromInterfaces(ctx context.Context, user string, generic []interface{}, metadata ...*Metadata) (ok bool, err error) {
+func DeleteUserFromInterfaces(ctx context.Context, user string, generic []interface{}) (ok bool, metadata Metadata, err error) {
 	userDeleters := make([]userProviders, 0)
 	for _, elem := range generic {
 		temp := userProviders{name: getProviderName(elem)}
@@ -203,20 +188,15 @@ func DeleteUserFromInterfaces(ctx context.Context, user string, generic []interf
 		}
 	}
 	if len(userDeleters) == 0 {
-		return ok, multierror.Append(err, errors.New("no UserDeleter implementations found"))
+		return ok, metadata, multierror.Append(err, errors.New("no UserDeleter implementations found"))
 	}
-	return DeleteUser(ctx, user, userDeleters, metadata...)
+	return DeleteUser(ctx, user, userDeleters)
 }
 
 // ReadUsers returns all users from a BMC
 // if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
-func ReadUsers(ctx context.Context, u []userProviders, metadata ...*Metadata) (users []map[string]string, err error) {
+func ReadUsers(ctx context.Context, u []userProviders) (users []map[string]string, metadata Metadata, err error) {
 	var metadataLocal Metadata
-	defer func() {
-		if len(metadata) > 0 && metadata[0] != nil {
-			*metadata[0] = metadataLocal
-		}
-	}()
 Loop:
 	for _, elem := range u {
 		if elem.userReader == nil {
@@ -234,15 +214,15 @@ Loop:
 				continue
 			}
 			metadataLocal.SuccessfulProvider = elem.name
-			return users, nil
+			return users, metadataLocal, nil
 		}
 	}
-	return users, multierror.Append(err, errors.New("failed to read users"))
+	return users, metadataLocal, multierror.Append(err, errors.New("failed to read users"))
 }
 
 // ReadUsersFromInterfaces pass through to library function
 // if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
-func ReadUsersFromInterfaces(ctx context.Context, generic []interface{}, metadata ...*Metadata) (users []map[string]string, err error) {
+func ReadUsersFromInterfaces(ctx context.Context, generic []interface{}) (users []map[string]string, metadata Metadata, err error) {
 	userReaders := make([]userProviders, 0)
 	for _, elem := range generic {
 		temp := userProviders{name: getProviderName(elem)}
@@ -256,7 +236,7 @@ func ReadUsersFromInterfaces(ctx context.Context, generic []interface{}, metadat
 		}
 	}
 	if len(userReaders) == 0 {
-		return users, multierror.Append(err, errors.New("no UserReader implementations found"))
+		return users, metadata, multierror.Append(err, errors.New("no UserReader implementations found"))
 	}
-	return ReadUsers(ctx, userReaders, metadata...)
+	return ReadUsers(ctx, userReaders)
 }

--- a/bmc/user_test.go
+++ b/bmc/user_test.go
@@ -92,7 +92,7 @@ func TestUserCreate(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, err := CreateUser(ctx, user, pass, role, []userProviders{{"", &testImplementation, nil, nil, nil}})
+			result, _, err := CreateUser(ctx, user, pass, role, []userProviders{{"", &testImplementation, nil, nil, nil}})
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {
@@ -134,14 +134,7 @@ func TestCreateUserFromInterfaces(t *testing.T) {
 			user := "ADMIN"
 			pass := "ADMIN"
 			role := "admin"
-			var result bool
-			var err error
-			var metadata Metadata
-			if tc.withMetadata {
-				result, err = CreateUserFromInterfaces(context.Background(), user, pass, role, generic, &metadata)
-			} else {
-				result, err = CreateUserFromInterfaces(context.Background(), user, pass, role, generic)
-			}
+			result, metadata, err := CreateUserFromInterfaces(context.Background(), user, pass, role, generic)
 			if err != nil {
 				if tc.err != nil {
 					diff := cmp.Diff(err.Error(), tc.err.Error())
@@ -159,6 +152,7 @@ func TestCreateUserFromInterfaces(t *testing.T) {
 			}
 			if tc.withMetadata {
 				if diff := cmp.Diff(metadata.SuccessfulProvider, "test provider"); diff != "" {
+					t.Logf("%+v", metadata)
 					t.Fatal(diff)
 				}
 			}
@@ -192,7 +186,7 @@ func TestUpdateUser(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, err := UpdateUser(ctx, user, pass, role, []userProviders{{"", nil, &testImplementation, nil, nil}})
+			result, _, err := UpdateUser(ctx, user, pass, role, []userProviders{{"", nil, &testImplementation, nil, nil}})
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {
@@ -234,14 +228,7 @@ func TestUpdateUserFromInterfaces(t *testing.T) {
 			user := "ADMIN"
 			pass := "ADMIN"
 			role := "admin"
-			var result bool
-			var err error
-			var metadata Metadata
-			if tc.withMetadata {
-				result, err = UpdateUserFromInterfaces(context.Background(), user, pass, role, generic, &metadata)
-			} else {
-				result, err = UpdateUserFromInterfaces(context.Background(), user, pass, role, generic)
-			}
+			result, metadata, err := UpdateUserFromInterfaces(context.Background(), user, pass, role, generic)
 			if err != nil {
 				if tc.err != nil {
 					diff := cmp.Diff(err.Error(), tc.err.Error())
@@ -290,7 +277,7 @@ func TestDeleteUser(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, err := DeleteUser(ctx, user, []userProviders{{"", nil, nil, &testImplementation, nil}})
+			result, _, err := DeleteUser(ctx, user, []userProviders{{"", nil, nil, &testImplementation, nil}})
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {
@@ -330,14 +317,7 @@ func TestDeleteUserFromInterfaces(t *testing.T) {
 			}
 			expectedResult := tc.want
 			user := "ADMIN"
-			var result bool
-			var err error
-			var metadata Metadata
-			if tc.withMetadata {
-				result, err = DeleteUserFromInterfaces(context.Background(), user, generic, &metadata)
-			} else {
-				result, err = DeleteUserFromInterfaces(context.Background(), user, generic)
-			}
+			result, metadata, err := DeleteUserFromInterfaces(context.Background(), user, generic)
 			if err != nil {
 				if tc.err != nil {
 					diff := cmp.Diff(err.Error(), tc.err.Error())
@@ -392,7 +372,7 @@ func TestReadUsers(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, err := ReadUsers(ctx, []userProviders{{"", nil, nil, nil, &testImplementation}})
+			result, _, err := ReadUsers(ctx, []userProviders{{"", nil, nil, nil, &testImplementation}})
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {
@@ -440,14 +420,7 @@ func TestReadUsersFromInterfaces(t *testing.T) {
 				generic = []interface{}{&testImplementation}
 			}
 			expectedResult := users
-			var result []map[string]string
-			var err error
-			var metadata Metadata
-			if tc.withMetadata {
-				result, err = ReadUsersFromInterfaces(context.Background(), generic, &metadata)
-			} else {
-				result, err = ReadUsersFromInterfaces(context.Background(), generic)
-			}
+			result, metadata, err := ReadUsersFromInterfaces(context.Background(), generic)
 			if err != nil {
 				if tc.err != nil {
 					diff := cmp.Diff(err.Error(), tc.err.Error())

--- a/client.go
+++ b/client.go
@@ -21,6 +21,7 @@ type Client struct {
 	Auth     Auth
 	Logger   logr.Logger
 	Registry *registrar.Registry
+	metadata *bmc.Metadata
 }
 
 // Auth details for connecting to a BMC
@@ -91,10 +92,15 @@ func (c *Client) registerProviders() {
 	*/
 }
 
+// GetMetadata returns the metadata that is populated after each BMC function/method call
+func (c *Client) GetMetadata() bmc.Metadata {
+	return *c.metadata
+}
+
 // Open calls the OpenConnectionFromInterfaces library function
 // creates and returns a new Drivers with only implementations that were successfully opened
-func (c *Client) Open(ctx context.Context, metadata ...*bmc.Metadata) (reg registrar.Drivers, err error) {
-	ifs, err := bmc.OpenConnectionFromInterfaces(ctx, c.Registry.GetDriverInterfaces(), metadata...)
+func (c *Client) Open(ctx context.Context) (reg registrar.Drivers, err error) {
+	ifs, metadata, err := bmc.OpenConnectionFromInterfaces(ctx, c.Registry.GetDriverInterfaces())
 	if err != nil {
 		return nil, err
 	}
@@ -106,60 +112,62 @@ func (c *Client) Open(ctx context.Context, metadata ...*bmc.Metadata) (reg regis
 			}
 		}
 	}
+	c.metadata = &metadata
 	return reg, nil
 }
 
 // Close pass through to library function
-func (c *Client) Close(ctx context.Context, metadata ...*bmc.Metadata) (err error) {
-	return bmc.CloseConnectionFromInterfaces(ctx, c.Registry.GetDriverInterfaces(), metadata...)
+func (c *Client) Close(ctx context.Context) (err error) {
+	*c.metadata, err = bmc.CloseConnectionFromInterfaces(ctx, c.Registry.GetDriverInterfaces())
+	return err
 }
 
 // GetPowerState pass through to library function
-// if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
-func (c *Client) GetPowerState(ctx context.Context, metadata ...*bmc.Metadata) (state string, err error) {
-	return bmc.GetPowerStateFromInterfaces(ctx, c.Registry.GetDriverInterfaces(), metadata...)
+func (c *Client) GetPowerState(ctx context.Context) (state string, err error) {
+	state, *c.metadata, err = bmc.GetPowerStateFromInterfaces(ctx, c.Registry.GetDriverInterfaces())
+	return state, err
 }
 
 // SetPowerState pass through to library function
-// if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
-func (c *Client) SetPowerState(ctx context.Context, state string, metadata ...*bmc.Metadata) (ok bool, err error) {
-	return bmc.SetPowerStateFromInterfaces(ctx, state, c.Registry.GetDriverInterfaces(), metadata...)
+func (c *Client) SetPowerState(ctx context.Context, state string) (ok bool, err error) {
+	ok, *c.metadata, err = bmc.SetPowerStateFromInterfaces(ctx, state, c.Registry.GetDriverInterfaces())
+	return ok, err
 }
 
 // CreateUser pass through to library function
-// if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
-func (c *Client) CreateUser(ctx context.Context, user, pass, role string, metadata ...*bmc.Metadata) (ok bool, err error) {
-	return bmc.CreateUserFromInterfaces(ctx, user, pass, role, c.Registry.GetDriverInterfaces(), metadata...)
+func (c *Client) CreateUser(ctx context.Context, user, pass, role string) (ok bool, err error) {
+	ok, *c.metadata, err = bmc.CreateUserFromInterfaces(ctx, user, pass, role, c.Registry.GetDriverInterfaces())
+	return ok, err
 }
 
 // UpdateUser pass through to library function
-// if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
-func (c *Client) UpdateUser(ctx context.Context, user, pass, role string, metadata ...*bmc.Metadata) (ok bool, err error) {
-	return bmc.UpdateUserFromInterfaces(ctx, user, pass, role, c.Registry.GetDriverInterfaces(), metadata...)
+func (c *Client) UpdateUser(ctx context.Context, user, pass, role string) (ok bool, err error) {
+	ok, *c.metadata, err = bmc.UpdateUserFromInterfaces(ctx, user, pass, role, c.Registry.GetDriverInterfaces())
+	return ok, err
 }
 
 // DeleteUser pass through to library function
-// if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
-func (c *Client) DeleteUser(ctx context.Context, user string, metadata ...*bmc.Metadata) (ok bool, err error) {
-	return bmc.DeleteUserFromInterfaces(ctx, user, c.Registry.GetDriverInterfaces(), metadata...)
+func (c *Client) DeleteUser(ctx context.Context, user string) (ok bool, err error) {
+	ok, *c.metadata, err = bmc.DeleteUserFromInterfaces(ctx, user, c.Registry.GetDriverInterfaces())
+	return ok, err
 }
 
 // ReadUsers pass through to library function
-// if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
-func (c *Client) ReadUsers(ctx context.Context, metadata ...*bmc.Metadata) (users []map[string]string, err error) {
-	return bmc.ReadUsersFromInterfaces(ctx, c.Registry.GetDriverInterfaces(), metadata...)
+func (c *Client) ReadUsers(ctx context.Context) (users []map[string]string, err error) {
+	users, *c.metadata, err = bmc.ReadUsersFromInterfaces(ctx, c.Registry.GetDriverInterfaces())
+	return users, err
 }
 
 // SetBootDevice pass through to library function
-// if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
-func (c *Client) SetBootDevice(ctx context.Context, bootDevice string, setPersistent, efiBoot bool, metadata ...*bmc.Metadata) (ok bool, err error) {
-	return bmc.SetBootDeviceFromInterfaces(ctx, bootDevice, setPersistent, efiBoot, c.Registry.GetDriverInterfaces(), metadata...)
+func (c *Client) SetBootDevice(ctx context.Context, bootDevice string, setPersistent, efiBoot bool) (ok bool, err error) {
+	ok, *c.metadata, err = bmc.SetBootDeviceFromInterfaces(ctx, bootDevice, setPersistent, efiBoot, c.Registry.GetDriverInterfaces())
+	return ok, err
 }
 
 // ResetBMC pass through to library function
-// if a metadata is passed in, it will be updated to be the name of the provider that successfully executed
-func (c *Client) ResetBMC(ctx context.Context, resetType string, metadata ...*bmc.Metadata) (ok bool, err error) {
-	return bmc.ResetBMCFromInterfaces(ctx, resetType, c.Registry.GetDriverInterfaces(), metadata...)
+func (c *Client) ResetBMC(ctx context.Context, resetType string) (ok bool, err error) {
+	ok, *c.metadata, err = bmc.ResetBMCFromInterfaces(ctx, resetType, c.Registry.GetDriverInterfaces())
+	return ok, err
 }
 
 // GetBMCVersion pass through library function

--- a/client_test.go
+++ b/client_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bmc-toolbox/bmclib/bmc"
 	"github.com/bmc-toolbox/bmclib/logging"
 )
 
@@ -21,39 +20,36 @@ func TestBMC(t *testing.T) {
 	log := logging.DefaultLogger()
 	cl := NewClient(host, port, user, pass, WithLogger(log))
 	cl.Registry.Drivers = cl.Registry.FilterForCompatible(ctx)
-	var metadata bmc.Metadata
 	var err error
-	cl.Registry.Drivers, err = cl.Open(ctx, &metadata)
+	cl.Registry.Drivers, err = cl.Open(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cl.Close(ctx)
-	t.Logf("%+v", metadata)
+	t.Logf("metadata: %+v", cl.GetMetadata())
 
 	cl.Registry.Drivers = cl.Registry.PreferDriver("dummy")
-	state, err := cl.GetPowerState(ctx, &metadata)
+	state, err := cl.GetPowerState(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Log(state)
-	t.Logf("%+v", metadata)
+	t.Logf("metadata %+v", cl.GetMetadata())
 
 	cl.Registry.Drivers = cl.Registry.PreferDriver("ipmitool")
-	// if you pass in a the metadata as a pointer to any function
-	// it will be updated with details about the call. name of the provider
-	// that successfully execute and providers attempted.
-	state, err = cl.GetPowerState(ctx, &metadata)
+	state, err = cl.GetPowerState(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Log(state)
-	t.Logf("%+v", metadata)
+	t.Logf("metadata: %+v", cl.GetMetadata())
 
 	users, err := cl.ReadUsers(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Log(users)
+	t.Logf("metadata: %+v", cl.GetMetadata())
 
 	t.Fatal()
 }


### PR DESCRIPTION
Current:
```go
state, err := client.GetPowerState(ctx, &metadata)
if err != nil {
	panic(err)
}
fmt.Println(state)
fmt.Printf("metadata:  %+v\n", metadata)
```
Proposed:
```go
state, err := client.GetPowerState(ctx)
if err != nil {
	panic(err)
}
fmt.Println(state)
fmt.Printf("metadata: %+v\n", client.GetMetadata())
```
After using the metadata for a little, I don't like the
experience. Having to pass in metadata was not easily
understood and was trying to be too clever. This update
will make metadata available for all methods. the user just
has to call GetMetadata() to retrieve it.

Public API is affected as the client will no longer be able
to pass in the &metadata var. Seeing as we are not v1,
I feel comfortable proposing this change.

Signed-off-by: Jacob Weinstock <jakobweinstock@gmail.com>