### PR TITLE
Update Client.Open method:

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -21,7 +21,7 @@ func TestBMC(t *testing.T) {
 	cl := NewClient(host, port, user, pass, WithLogger(log))
 	cl.Registry.Drivers = cl.Registry.FilterForCompatible(ctx)
 	var err error
-	cl.Registry.Drivers, err = cl.Open(ctx)
+	err = cl.Open(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/examples/v1/main.go
+++ b/examples/v1/main.go
@@ -31,7 +31,7 @@ func main() {
 	var err error
 
 	cl := bmclib.NewClient(host, port, user, pass, bmclib.WithLogger(logger))
-	cl.Registry.Drivers, err = cl.Open(ctx)
+	err = cl.Open(ctx)
 	if err != nil {
 		log.Fatal(err, "bmc login failed")
 	}


### PR DESCRIPTION
The UX feels unnecessarily verbose/explicit. Most other
libraries that have open/close methods just return an error.
These libraries dont return multiple implementation but with
the ability to get metadata for each Client.X call I dont
think we need to worry about making it that explicit that
we've modified the providers. Open for discussion here, but
putting this in as a PR regardless.

Signed-off-by: Jacob Weinstock <jakobweinstock@gmail.com>