### PR TITLE
Update default logging for Client:

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/bmc-toolbox/bmclib/bmc"
-	"github.com/bmc-toolbox/bmclib/logging"
 	"github.com/bmc-toolbox/bmclib/providers/asrockrack"
 	"github.com/bmc-toolbox/bmclib/providers/dell/idrac9"
 	"github.com/bmc-toolbox/bmclib/providers/goipmi"
@@ -51,7 +50,7 @@ func WithRegistry(registry *registrar.Registry) Option {
 // NewClient returns a new Client struct
 func NewClient(host, port, user, pass string, opts ...Option) *Client {
 	var defaultClient = &Client{
-		Logger:   logging.DefaultLogger(),
+		Logger:   logr.Discard(),
 		Registry: registrar.NewRegistry(),
 	}
 


### PR DESCRIPTION
If a user doesn't provide a logger our current default logger will still log. This feels like the wrong user experience. If a client doesn't pass in a logger we shouldn't log either. This makes that happen. This only affects the new interfaces and users that use `bmc.NewClient`
