### PR TITLE
implement Provider interface

### DIFF
--- a/providers/dell/idrac9/idrac.go
+++ b/providers/dell/idrac9/idrac.go
@@ -43,6 +43,10 @@ var (
 	}
 )
 
+func (c *Conn) Name() string {
+	return ProviderName
+}
+
 func (c *Conn) Open(ctx context.Context) error {
 	idrac := &IDrac9{ip: c.Host, username: c.User, password: c.Pass, log: c.Log}
 	err := idrac.httpLogin()


### PR DESCRIPTION
implement Provider interface. this means `Client.GetMetadata` will have the provider-defined name instead of the provider's type.