### PR TITLE
Differentiate provider errors:

### DIFF
--- a/bmc/boot_device.go
+++ b/bmc/boot_device.go
@@ -2,10 +2,10 @@ package bmc
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
 )
 
 // BootDeviceSetter sets the next boot device for a machine
@@ -36,11 +36,11 @@ Loop:
 			metadataLocal.ProvidersAttempted = append(metadataLocal.ProvidersAttempted, elem.name)
 			ok, setErr := elem.bootDeviceSetter.BootDeviceSet(ctx, bootDevice, setPersistent, efiBoot)
 			if setErr != nil {
-				err = multierror.Append(err, setErr)
+				err = multierror.Append(err, errors.WithMessagef(setErr, "provider: %v", elem.name))
 				continue
 			}
 			if !ok {
-				err = multierror.Append(err, errors.New("failed to set boot device"))
+				err = multierror.Append(err, fmt.Errorf("provider: %v, failed to set boot device", elem.name))
 				continue
 			}
 			metadataLocal.SuccessfulProvider = elem.name

--- a/bmc/boot_device_test.go
+++ b/bmc/boot_device_test.go
@@ -39,8 +39,8 @@ func TestSetBootDevice(t *testing.T) {
 		ctxTimeout   time.Duration
 	}{
 		"success":               {bootDevice: "pxe", want: true},
-		"not ok return":         {bootDevice: "pxe", want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("failed to set boot device"), errors.New("failed to set boot device")}}},
-		"error":                 {bootDevice: "pxe", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("boot device set failed"), errors.New("failed to set boot device")}}},
+		"not ok return":         {bootDevice: "pxe", want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider, failed to set boot device"), errors.New("failed to set boot device")}}},
+		"error":                 {bootDevice: "pxe", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider: boot device set failed"), errors.New("failed to set boot device")}}},
 		"error context timeout": {bootDevice: "pxe", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to set boot device")}}, ctxTimeout: time.Nanosecond * 1},
 	}
 
@@ -53,7 +53,7 @@ func TestSetBootDevice(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, _, err := SetBootDevice(ctx, tc.bootDevice, false, false, []bootDeviceProviders{{"", &testImplementation}})
+			result, _, err := SetBootDevice(ctx, tc.bootDevice, false, false, []bootDeviceProviders{{"test provider", &testImplementation}})
 			if err != nil {
 				if tc.err != nil {
 					diff := cmp.Diff(err.Error(), tc.err.Error())

--- a/bmc/connection.go
+++ b/bmc/connection.go
@@ -2,10 +2,10 @@ package bmc
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
 )
 
 // Opener interface for opening a connection to a BMC
@@ -46,7 +46,7 @@ Loop:
 			metadataLocal.ProvidersAttempted = append(metadataLocal.ProvidersAttempted, providerName)
 			er := p.Open(ctx)
 			if er != nil {
-				err = multierror.Append(err, er)
+				err = multierror.Append(err, errors.WithMessagef(er, "provider: %v", providerName))
 				continue
 			}
 			opened = append(opened, elem)
@@ -77,9 +77,9 @@ Loop:
 			break Loop
 		default:
 			metadataLocal.ProvidersAttempted = append(metadataLocal.ProvidersAttempted, elem.name)
-			openErr := elem.closer.Close(ctx)
-			if openErr != nil {
-				err = multierror.Append(err, openErr)
+			closeErr := elem.closer.Close(ctx)
+			if closeErr != nil {
+				err = multierror.Append(err, errors.WithMessagef(closeErr, "provider: %v", elem.name))
 				continue
 			}
 			connClosed = true

--- a/bmc/connection_test.go
+++ b/bmc/connection_test.go
@@ -43,7 +43,7 @@ func TestOpenConnectionFromInterfaces(t *testing.T) {
 		"success":                  {},
 		"success with metadata":    {withMetadata: true},
 		"error context deadline":   {err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("no Opener implementations found")}}, ctxTimeout: time.Nanosecond * 1},
-		"error failed open":        {makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("open connection failed"), errors.New("no Opener implementations found")}}},
+		"error failed open":        {makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider: open connection failed"), errors.New("no Opener implementations found")}}},
 		"no implementations found": {badImplementation: true, err: &multierror.Error{Errors: []error{errors.New("not a Opener implementation: *struct {}"), errors.New("no Opener implementations found")}}},
 	}
 
@@ -94,7 +94,7 @@ func TestCloseConnection(t *testing.T) {
 	}{
 		"success":                {},
 		"error context deadline": {err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to close connection")}}, ctxTimeout: time.Nanosecond * 1},
-		"error":                  {makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("close connection failed"), errors.New("failed to close connection")}}},
+		"error":                  {makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider: close connection failed"), errors.New("failed to close connection")}}},
 	}
 
 	for name, tc := range testCases {
@@ -105,7 +105,7 @@ func TestCloseConnection(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			_, err := CloseConnection(ctx, []connectionProviders{{"", &testImplementation}})
+			_, err := CloseConnection(ctx, []connectionProviders{{"test provider", &testImplementation}})
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {

--- a/bmc/power.go
+++ b/bmc/power.go
@@ -2,10 +2,10 @@ package bmc
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
 )
 
 // PowerSetter sets the power state of a BMC
@@ -53,11 +53,11 @@ Loop:
 			metadataLocal.ProvidersAttempted = append(metadataLocal.ProvidersAttempted, elem.name)
 			ok, setErr := elem.powerSetter.PowerSet(ctx, state)
 			if setErr != nil {
-				err = multierror.Append(err, setErr)
+				err = multierror.Append(err, errors.WithMessagef(setErr, "provider: %v", elem.name))
 				continue
 			}
 			if !ok {
-				err = multierror.Append(err, errors.New("failed to set power state"))
+				err = multierror.Append(err, fmt.Errorf("provider: %v, failed to set power state", elem.name))
 				continue
 			}
 			metadataLocal.SuccessfulProvider = elem.name
@@ -104,7 +104,7 @@ Loop:
 			metadata.ProvidersAttempted = append(metadata.ProvidersAttempted, elem.name)
 			state, stateErr := elem.powerStateGetter.PowerStateGet(ctx)
 			if stateErr != nil {
-				err = multierror.Append(err, stateErr)
+				err = multierror.Append(err, errors.WithMessagef(stateErr, "provider: %v", elem.name))
 				continue
 			}
 			metadata.SuccessfulProvider = elem.name

--- a/bmc/power_test.go
+++ b/bmc/power_test.go
@@ -46,8 +46,8 @@ func TestSetPowerState(t *testing.T) {
 		ctxTimeout   time.Duration
 	}{
 		"success":               {state: "off", want: true},
-		"not ok return":         {state: "off", want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("failed to set power state"), errors.New("failed to set power state")}}},
-		"error":                 {state: "off", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("power set failed"), errors.New("failed to set power state")}}},
+		"not ok return":         {state: "off", want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider, failed to set power state"), errors.New("failed to set power state")}}},
+		"error":                 {state: "off", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider: power set failed"), errors.New("failed to set power state")}}},
 		"error context timeout": {state: "off", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to set power state")}}, ctxTimeout: time.Nanosecond * 1},
 	}
 
@@ -60,7 +60,7 @@ func TestSetPowerState(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, _, err := SetPowerState(ctx, tc.state, []powerProviders{{"", nil, &testImplementation}})
+			result, _, err := SetPowerState(ctx, tc.state, []powerProviders{{"test provider", nil, &testImplementation}})
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {
@@ -133,7 +133,7 @@ func TestGetPowerState(t *testing.T) {
 		ctxTimeout time.Duration
 	}{
 		"success":              {state: "on", err: nil},
-		"failure":              {state: "on", makeFail: true, err: &multierror.Error{Errors: []error{errors.New("power state get failed"), errors.New("failed to get power state")}}},
+		"failure":              {state: "on", makeFail: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider: power state get failed"), errors.New("failed to get power state")}}},
 		"fail context timeout": {state: "on", makeFail: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to get power state")}}, ctxTimeout: time.Nanosecond * 1},
 	}
 
@@ -146,7 +146,7 @@ func TestGetPowerState(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, _, err := GetPowerState(ctx, []powerProviders{{"", &testImplementation, nil}})
+			result, _, err := GetPowerState(ctx, []powerProviders{{"test provider", &testImplementation, nil}})
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {

--- a/bmc/reset.go
+++ b/bmc/reset.go
@@ -2,10 +2,10 @@ package bmc
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
 )
 
 // BMCResetter for resetting a BMC.
@@ -38,11 +38,11 @@ Loop:
 			metadataLocal.ProvidersAttempted = append(metadataLocal.ProvidersAttempted, elem.name)
 			ok, setErr := elem.bmcResetter.BmcReset(ctx, resetType)
 			if setErr != nil {
-				err = multierror.Append(err, setErr)
+				err = multierror.Append(err, errors.WithMessagef(setErr, "provider: %v", elem.name))
 				continue
 			}
 			if !ok {
-				err = multierror.Append(err, errors.New("failed to reset BMC"))
+				err = multierror.Append(err, fmt.Errorf("provider: %v, failed to reset BMC", elem.name))
 				continue
 			}
 			metadataLocal.SuccessfulProvider = elem.name

--- a/bmc/reset_test.go
+++ b/bmc/reset_test.go
@@ -39,8 +39,8 @@ func TestResetBMC(t *testing.T) {
 		ctxTimeout   time.Duration
 	}{
 		"success":               {resetType: "cold", want: true},
-		"not ok return":         {resetType: "warm", want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("failed to reset BMC"), errors.New("failed to reset BMC")}}},
-		"error":                 {resetType: "cold", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("bmc reset failed"), errors.New("failed to reset BMC")}}},
+		"not ok return":         {resetType: "warm", want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider, failed to reset BMC"), errors.New("failed to reset BMC")}}},
+		"error":                 {resetType: "cold", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider: bmc reset failed"), errors.New("failed to reset BMC")}}},
 		"error context timeout": {resetType: "cold", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to reset BMC")}}, ctxTimeout: time.Nanosecond * 1},
 	}
 
@@ -53,7 +53,7 @@ func TestResetBMC(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, _, err := ResetBMC(ctx, tc.resetType, []bmcProviders{{"", &testImplementation}})
+			result, _, err := ResetBMC(ctx, tc.resetType, []bmcProviders{{"test provider", &testImplementation}})
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {


### PR DESCRIPTION
Right now, errors from providers are captured in a slice
but it is difficult to know which error was for which provider.
This will prefix errors with a provider name.

3 errors occurred:
  * provider: ipmitool: requested state type unknown
  * provider: goipmi: requested state type unknown
  * failed to set power state

