### PR TITLE
Fix panic for nil metadata:

### DIFF
--- a/client.go
+++ b/client.go
@@ -100,7 +100,10 @@ func (c *Client) registerProviders() {
 
 // GetMetadata returns the metadata that is populated after each BMC function/method call
 func (c *Client) GetMetadata() bmc.Metadata {
-	return *c.metadata
+	if c.metadata != nil {
+		return *c.metadata
+	}
+	return bmc.Metadata{}
 }
 
 // setMetadata wraps setting metadata with a mutex for cases where users are


### PR DESCRIPTION
This fixes a poor user experience of panicking on calls to metadata if the metadata is nil.
