### PR TITLE
Don't error on ipmitool power off when machine is already off:

### DIFF
--- a/internal/ipmi/ipmi.go
+++ b/internal/ipmi/ipmi.go
@@ -173,15 +173,6 @@ func (i *Ipmi) PowerOnForce(ctx context.Context) (status bool, err error) {
 
 // PowerOff power off the machine via bmc
 func (i *Ipmi) PowerOff(ctx context.Context) (status bool, err error) {
-	s, err := i.IsOn(ctx)
-	if err != nil {
-		return false, err
-	}
-
-	if !s {
-		return false, fmt.Errorf("server is already off")
-	}
-
 	output, err := i.run(ctx, []string{"chassis", "power", "off"})
 	if strings.Contains(output, "Chassis Power Control: Down/Off") {
 		return true, err


### PR DESCRIPTION
The current behavior in `internal/ipmitool` is to error if a request for a power-off is called against an already powered-off machine. I proposed we remove this behavior and if a request for a power-off (in `internal/ipmitool`) is called against an already powered-off machine we return success. This also mirrors `ipmitool` itself. It does not error out when an already-off machine calls power off against it.

* Checklist

- [x] Tests added
- [x] Similar commits squashed


- What does this PR implement/change/remove?

- The HW vendor this change applies to (if applicable)

- The HW model number, product name this change applies to (if applicable)

- The BMC firmware and/or BIOS versions that this change applies to (if applicable)

- What version of tooling - vendor specific or opensource does this change depend on (if applicable)

- Description for changelog/release notes
