### PR TITLE
Set verbose output to golangci-lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,10 +17,10 @@ jobs:
         go-version: '1.16'
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3
       with:
-        args: --config .golangci.yml --timeout=5m
-        version: v1.41.0
+        args: -v --config .golangci.yml --timeout=5m
+        version: latest
 
     - name: goimports
       run: go get golang.org/x/tools/cmd/goimports && make goimports-check


### PR DESCRIPTION
Signed-off-by: Micah Hausler <mhausler@amazon.com>

* Checklist
  - [x] Tests added
  - [x] Similar commits squashed


- What does this PR implement/change/remove?
  Enables verbose output for failing golangci-lint
