### PR TITLE
providers/ipmitool: Open() should attempt to connect

### DIFF
--- a/providers/ipmitool/ipmitool.go
+++ b/providers/ipmitool/ipmitool.go
@@ -42,7 +42,16 @@ type Conn struct {
 // Open a connection to a BMC
 func (c *Conn) Open(ctx context.Context) (err error) {
 	c.con, err = ipmi.New(c.User, c.Pass, c.Host+":"+c.Port)
-	return err
+	if err != nil {
+		return err
+	}
+
+	_, err = c.con.PowerState(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Close a connection to a BMC


### PR DESCRIPTION

## What does this PR implement/change/remove?

This keeps the `Open` behaviour consistent with the other providers,
such that the provider is excluded if Open() fails.

### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

## Description for changelog/release notes

