### PR TITLE
errors: less verbose compatibility check errors

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -116,6 +116,9 @@ var (
 
 	// ErrProviderImplementation is returned when theres an error in the BMC provider implementation
 	ErrProviderImplementation = errors.New("error in provider implementation")
+
+	// ErrCompatibilityCheck is returned when the compatibility probe failed to complete successfully.
+	ErrCompatibilityCheck = errors.New("compatibility check failed")
 )
 
 type ErrUnsupportedHardware struct {

--- a/providers/ipmitool/ipmitool.go
+++ b/providers/ipmitool/ipmitool.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"strings"
 
+	bmclibErrs "github.com/bmc-toolbox/bmclib/errors"
+
 	"github.com/bmc-toolbox/bmclib/internal/ipmi"
 	"github.com/bmc-toolbox/bmclib/providers"
 	"github.com/go-logr/logr"
@@ -63,14 +65,23 @@ func (c *Conn) Close(ctx context.Context) (err error) {
 func (c *Conn) Compatible(ctx context.Context) bool {
 	err := c.Open(ctx)
 	if err != nil {
-		c.Log.V(0).Error(err, "error checking compatibility opening connection")
+		c.Log.V(2).WithValues(
+			"provider",
+			c.Name(),
+		).Info("warn", bmclibErrs.ErrCompatibilityCheck.Error(), err.Error())
+
 		return false
 	}
 	defer c.Close(ctx)
+
 	_, err = c.con.PowerState(ctx)
 	if err != nil {
-		c.Log.V(0).Error(err, "error checking compatibility through power status")
+		c.Log.V(2).WithValues(
+			"provider",
+			c.Name(),
+		).Info("warn", bmclibErrs.ErrCompatibilityCheck.Error(), err.Error())
 	}
+
 	return err == nil
 }
 

--- a/providers/ipmitool/ipmitool.go
+++ b/providers/ipmitool/ipmitool.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	bmclibErrs "github.com/bmc-toolbox/bmclib/errors"
-
 	"github.com/bmc-toolbox/bmclib/internal/ipmi"
 	"github.com/bmc-toolbox/bmclib/providers"
 	"github.com/go-logr/logr"

--- a/providers/redfish/redfish.go
+++ b/providers/redfish/redfish.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	bmclibErrs "github.com/bmc-toolbox/bmclib/errors"
 	"github.com/bmc-toolbox/bmclib/internal/httpclient"
 	"github.com/bmc-toolbox/bmclib/providers"
 	"github.com/go-logr/logr"
@@ -135,14 +136,23 @@ func (c *Conn) Name() string {
 func (c *Conn) Compatible(ctx context.Context) bool {
 	err := c.Open(ctx)
 	if err != nil {
-		c.Log.V(0).Error(err, "error checking compatibility: open connection failed")
+		c.Log.V(2).WithValues(
+			"provider",
+			c.Name(),
+		).Info("warn", bmclibErrs.ErrCompatibilityCheck.Error(), err.Error())
+
 		return false
 	}
 	defer c.Close(ctx)
+
 	_, err = c.PowerStateGet(ctx)
 	if err != nil {
-		c.Log.V(0).Error(err, "error checking compatibility: power state get failed")
+		c.Log.V(2).WithValues(
+			"provider",
+			c.Name(),
+		).Info("warn", bmclibErrs.ErrCompatibilityCheck.Error(), err.Error())
 	}
+
 	return err == nil
 }
 


### PR DESCRIPTION
## What does this PR implement/change/remove?

compatibility check logs to log only when debug/trace logging is
enabled, a lot of compatibility checks are performed for each
connection.
