### PR TITLE
redfish/firmware: downloaded is another firmware install state returned by idracs

### DIFF
--- a/providers/redfish/firmware.go
+++ b/providers/redfish/firmware.go
@@ -132,7 +132,7 @@ func (c *Conn) FirmwareInstallStatus(ctx context.Context, installVersion, compon
 
 	// so much for standards...
 	switch state {
-	case "starting", "downloading":
+	case "starting", "downloading", "downloaded":
 		return devices.FirmwareInstallInitializing, nil
 	case "running", "stopping", "cancelling", "scheduling":
 		return devices.FirmwareInstallRunning, nil


### PR DESCRIPTION
## What does this PR implement/change/remove?

Includes the `downloaded` state for firmware install.