### PR TITLE
redfish/dell tasks: register task names for NIC, Drive, controllers

### DIFF
--- a/providers/redfish/tasks.go
+++ b/providers/redfish/tasks.go
@@ -18,8 +18,11 @@ import (
 
 var (
 	componentSlugDellJobName = map[string]string{
-		common.SlugBIOS: "Firmware Update: BIOS",
-		common.SlugBMC:  "Firmware Update: iDRAC with Lifecycle Controller",
+		common.SlugBIOS:              "Firmware Update: BIOS",
+		common.SlugBMC:               "Firmware Update: iDRAC with Lifecycle Controller",
+		common.SlugNIC:               "Firmware Update: Network",
+		common.SlugDrive:             "Firmware Update: Serial ATA",
+		common.SlugStorageController: "Firmware Update: SAS RAID",
 	}
 )
 
@@ -57,7 +60,6 @@ func (c *Conn) getDellFirmwareInstallTaskScheduled(slug string) (*rf.Task, error
 
 	// filter to match the task Name based on the component slug
 	for _, task := range tasks {
-		// Firmware Update: BIOS
 		if task.Name == componentSlugDellJobName[strings.ToUpper(slug)] {
 			return task, nil
 		}
@@ -75,7 +77,6 @@ func (c *Conn) dellPurgeScheduledFirmwareInstallJob(slug string) error {
 
 	// filter to match the task Name based on the component slug
 	for _, task := range tasks {
-		// Firmware Update: BIOS
 		if task.Name == componentSlugDellJobName[strings.ToUpper(slug)] {
 			err = c.dellPurgeJob(task.ID)
 			if err != nil {


### PR DESCRIPTION
## What does this PR implement/change/remove?

This registers a few more Dell component update task names, these task names are used to identify firmware updates in progress.

### The HW vendor this change applies to (if applicable)

- Dell
