### PR TITLE
[v0] dell redfish tasks 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@
     #enable:
     #  - fieldalignment
     check-shadowing: true
+    auto-fix: true
     settings:
       printf:
         funcs:
@@ -47,8 +48,6 @@
     extra-rules: true
     auto-fix: true
   wsl:
-    auto-fix: true
-  govet:
     auto-fix: true
   stylecheck:
     auto-fix: true

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/bmc-toolbox/bmclib
 go 1.17
 
 require (
+	github.com/bmc-toolbox/common v0.0.0-20220707135204-5368ecd5d175
 	github.com/bombsimon/logrusr/v2 v2.0.1
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.8

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
+github.com/bmc-toolbox/common v0.0.0-20220707135204-5368ecd5d175 h1:sBkvK0BfJqFEJ3OMNqmXc9iAutobuHhv3/QvAt+b2YU=
+github.com/bmc-toolbox/common v0.0.0-20220707135204-5368ecd5d175/go.mod h1:SY//n1PJjZfbFbmAsB6GvEKbc7UXz3d30s3kWxfJQ/c=
 github.com/bombsimon/logrusr/v2 v2.0.1 h1:1VgxVNQMCvjirZIYaT9JYn6sAVGVEcNtRE0y4mvaOAM=
 github.com/bombsimon/logrusr/v2 v2.0.1/go.mod h1:ByVAX+vHdLGAfdroiMg6q0zgq2FODY2lc5YJvzmOJio=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/providers/redfish/tasks.go
+++ b/providers/redfish/tasks.go
@@ -6,20 +6,24 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bmc-toolbox/bmclib/devices"
 	bmcliberrs "github.com/bmc-toolbox/bmclib/errors"
 	"github.com/pkg/errors"
 
 	rfcommon "github.com/stmcginnis/gofish/common"
 	rf "github.com/stmcginnis/gofish/redfish"
+
+	"github.com/bmc-toolbox/common"
 )
 
 // Dell specific redfish methods
 
 var (
 	componentSlugDellJobName = map[string]string{
-		devices.SlugBIOS: "Firmware Update: BIOS",
-		devices.SlugBMC:  "Firmware Update: iDRAC with Lifecycle Controller",
+		common.SlugBIOS:              "Firmware Update: BIOS",
+		common.SlugBMC:               "Firmware Update: iDRAC with Lifecycle Controller",
+		common.SlugNIC:               "Firmware Update: Network",
+		common.SlugDrive:             "Firmware Update: Serial ATA",
+		common.SlugStorageController: "Firmware Update: SAS RAID",
 	}
 )
 
@@ -57,7 +61,6 @@ func (c *Conn) getDellFirmwareInstallTaskScheduled(slug string) (*rf.Task, error
 
 	// filter to match the task Name based on the component slug
 	for _, task := range tasks {
-		// Firmware Update: BIOS
 		if task.Name == componentSlugDellJobName[strings.ToUpper(slug)] {
 			return task, nil
 		}
@@ -75,7 +78,6 @@ func (c *Conn) dellPurgeScheduledFirmwareInstallJob(slug string) error {
 
 	// filter to match the task Name based on the component slug
 	for _, task := range tasks {
-		// Firmware Update: BIOS
 		if task.Name == componentSlugDellJobName[strings.ToUpper(slug)] {
 			err = c.dellPurgeJob(task.ID)
 			if err != nil {


### PR DESCRIPTION
## What does this PR implement/change/remove?

This registers a few more Dell component update task names, these task names are used to identify firmware updates in progress.


same as https://github.com/bmc-toolbox/bmclib/pull/282, except for bmclib v0

