### PR TITLE
Initial HP SNMP support

### DIFF
--- a/cfgresources/cfgresources.go
+++ b/cfgresources/cfgresources.go
@@ -184,6 +184,7 @@ type Network struct {
 	DNSFromDHCP    bool   `yaml:"dnsFromDhcp"`
 	SSHEnable      bool   `yaml:"sshEnable"`
 	SSHPort        int    `yaml:"sshPort"`
+	SNMPEnable     bool   `yaml:"snmpEnable"`
 	SolEnable      bool   `yaml:"solEnable"` // SerialOverLan
 	IpmiEnable     bool   `yaml:"ipmiEnable"`
 	DhcpEnable     bool   `yaml:"dhcpEnable"`

--- a/providers/hp/ilo/configure.go
+++ b/providers/hp/ilo/configure.go
@@ -341,7 +341,7 @@ func (i *Ilo) Ntp(cfg *cfgresources.Ntp) (err error) {
 
 	// ideally ilo5 ilo4 should be split up into its own device
 	// instead of depending on HardwareType.
-	if i.HardwareType() == "ilo5" {
+	if i.HardwareType() == Ilo5 {
 		timezones = TimezonesIlo5
 	} else {
 		timezones = TimezonesIlo4

--- a/providers/hp/ilo/helpers.go
+++ b/providers/hp/ilo/helpers.go
@@ -79,6 +79,50 @@ func (i *Ilo) cmpNetworkIPv4Settings(cfg *cfgresources.Network) (NetworkIPv4, bo
 	return currentConfig, true, nil
 }
 
+func setSnmpSettings(hardwareType string, snmpEnable bool) *SNMPSettings {
+	snmpSettings := new(SNMPSettings)
+	snmpSettings.SnmpPort = 161 // TODO: Change this to something user-configurable
+	snmpSettings.TrapPort = 162 // TODO: Change this to something user-configurable
+
+	switch hardwareType {
+	case Ilo4:
+		snmpDisable := new(int)
+		if snmpEnable {
+			*snmpDisable = 0
+		} else {
+			*snmpDisable = 1
+		}
+		snmpSettings.SnmpExternalDisableIlo4 = snmpDisable
+	case Ilo5:
+		snmpEnabled := new(int)
+		if snmpEnable {
+			*snmpEnabled = 1
+		} else {
+			*snmpEnabled = 0
+		}
+		snmpSettings.SnmpExternalEnabledIlo5 = snmpEnabled
+	}
+
+	return snmpSettings
+
+}
+
+func isUpdateRequiredSNMPIlo4(snmpEnable bool, bmcSettings SNMPSettings) bool {
+	if (snmpEnable && *bmcSettings.SnmpExternalDisableIlo4 == 1) ||
+		(!snmpEnable && *bmcSettings.SnmpExternalDisableIlo4 == 0) {
+		return true // means the current settings applied on the BMC and the declared configuration are different
+	}
+	return false // settings are equal, update not required
+}
+
+func isUpdateRequiredSNMPIlo5(snmpEnable bool, bmcSettings SNMPSettings) bool {
+	if (snmpEnable && *bmcSettings.SnmpExternalEnabledIlo5 == 0) ||
+		(!snmpEnable && *bmcSettings.SnmpExternalEnabledIlo5 == 1) {
+		return true // means the current settings applied on the BMC and the declared configuration are different
+	}
+	return false //settings are equal, update not required
+}
+
 // compares the current AccessSettings struct field values
 // with the given Network configuration resource,
 // returning an updated AccessSettings struct if an update is required.
@@ -139,13 +183,12 @@ func (i *Ilo) cmpAccessSettings(cfg *cfgresources.Network) (AccessSettings, bool
 		}
 		// Comparing SNMP settings for iLO 4 and iLO5
 		switch i.HardwareType() {
-		case "ilo4":
-			if (cfg.SNMPEnable && *currentConfig.SNMPSettings.SnmpExternalDisableIlo4 == 1) || (!cfg.SNMPEnable && *currentConfig.SNMPSettings.SnmpExternalDisableIlo4 == 0) {
+		case Ilo4:
+			if isUpdateRequiredSNMPIlo4(cfg.SNMPEnable, currentConfig.SNMPSettings) {
 				return false
 			}
-		case "ilo5":
-			if (cfg.SNMPEnable && *currentConfig.SNMPSettings.SnmpExternalEnabledIlo5 == 0) ||
-				(!cfg.SNMPEnable && *currentConfig.SNMPSettings.SnmpExternalEnabledIlo5 == 1) {
+		case Ilo5:
+			if isUpdateRequiredSNMPIlo5(cfg.SNMPEnable, currentConfig.SNMPSettings) {
 				return false
 			}
 		}
@@ -160,28 +203,7 @@ func (i *Ilo) cmpAccessSettings(cfg *cfgresources.Network) (AccessSettings, bool
 	currentConfig.IpmiPort = cfg.IpmiPort
 	currentConfig.SSHStatus = sshEnable
 	currentConfig.SSHPort = cfg.SSHPort
-	snmpSettings := new(SNMPSettings)
-	snmpSettings.SnmpPort = 161 // TODO: Change this to something user-configurable
-	snmpSettings.TrapPort = 162 // TODO: Change this to something user-configurable
-	switch i.HardwareType() {
-	case "ilo4":
-		snmpDisable := new(int)
-		if cfg.SNMPEnable {
-			*snmpDisable = 0
-		} else {
-			*snmpDisable = 1
-		}
-		snmpSettings.SnmpExternalDisableIlo4 = snmpDisable
-	case "ilo5":
-		snmpEnabled := new(int)
-		if cfg.SNMPEnable {
-			*snmpEnabled = 1
-		} else {
-			*snmpEnabled = 0
-		}
-		snmpSettings.SnmpExternalEnabledIlo5 = snmpEnabled
-	}
-	currentConfig.SNMPSettings = *snmpSettings
+	currentConfig.SNMPSettings = *setSnmpSettings(i.HardwareType(), cfg.SNMPEnable)
 	currentConfig.RemoteConsolePort = cfg.KVMConsolePort
 	currentConfig.VirtualMediaPort = cfg.KVMMediaPort
 	currentConfig.IpmiLanStatus = ipmiEnable

--- a/providers/hp/ilo/model.go
+++ b/providers/hp/ilo/model.go
@@ -138,41 +138,42 @@ type certImport struct {
 // AccessSettings declares BMC network service ports
 // Updating these params requires the BMC to be reset.
 type AccessSettings struct {
-	SSHStatus                    int           `json:"ssh_status"`
-	SSHPort                      int           `json:"ssh_port"`
-	HTTPPort                     int           `json:"http_port"`
-	HTTPSPort                    int           `json:"https_port"`
-	RemoteConsolePort            int           `json:"remote_console_port"`
-	VirtualMediaPort             int           `json:"virtual_media_port"`
-	IpmiLanStatus                int           `json:"ipmi_lan_status"`
-	IpmiPort                     int           `json:"ipmi_port"`
-	SNMPSettings                 *SNMPSettings `json:"snmp_settings"`
-	SessionTimeout               int           `json:"session_timeout"`
-	IloFunctEnabled              int           `json:"ilo_funct_enabled"`
-	IloFunctRequired             int           `json:"ilo_funct_required"`
-	RbsuEnabled                  int           `json:"rbsu_enabled"`
-	F8LoginRequired              int           `json:"f8_login_required"`
-	RbsuPostIP                   int           `json:"rbsu_post_ip"`
-	SerialCliStatus              int           `json:"serial_cli_status"`
-	SystemNoUart                 int           `json:"system_no_uart"`
-	SerialCliSpeed               int           `json:"serial_cli_speed"`
-	VspLogging                   int           `json:"vsp_logging"`
-	AuthenticationFailureLogging int           `json:"authentication_failure_logging"`
-	MinPassword                  int           `json:"min_password"`
-	AuthFailureDelayTime         int           `json:"auth_failure_delay_time"`
-	AuthNodelayFailures          int           `json:"auth_nodelay_failures"`
-	ServerName                   string        `json:"server_name"`
-	ServerFqdn                   string        `json:"server_fqdn"`
-	DefaultLang                  string        `json:"default_lang"`
-	SessionKey                   string        `json:"session_key"`
-	Method                       string        `json:"method"`
+	SSHStatus                    int          `json:"ssh_status"`
+	SSHPort                      int          `json:"ssh_port"`
+	HTTPPort                     int          `json:"http_port"`
+	HTTPSPort                    int          `json:"https_port"`
+	RemoteConsolePort            int          `json:"remote_console_port"`
+	VirtualMediaPort             int          `json:"virtual_media_port"`
+	IpmiLanStatus                int          `json:"ipmi_lan_status"`
+	IpmiPort                     int          `json:"ipmi_port"`
+	SNMPSettings                 SNMPSettings `json:"snmp_settings"`
+	SessionTimeout               int          `json:"session_timeout"`
+	IloFunctEnabled              int          `json:"ilo_funct_enabled"`
+	IloFunctRequired             int          `json:"ilo_funct_required"`
+	RbsuEnabled                  int          `json:"rbsu_enabled"`
+	F8LoginRequired              int          `json:"f8_login_required"`
+	RbsuPostIP                   int          `json:"rbsu_post_ip"`
+	SerialCliStatus              int          `json:"serial_cli_status"`
+	SystemNoUart                 int          `json:"system_no_uart"`
+	SerialCliSpeed               int          `json:"serial_cli_speed"`
+	VspLogging                   int          `json:"vsp_logging"`
+	AuthenticationFailureLogging int          `json:"authentication_failure_logging"`
+	MinPassword                  int          `json:"min_password"`
+	AuthFailureDelayTime         int          `json:"auth_failure_delay_time"`
+	AuthNodelayFailures          int          `json:"auth_nodelay_failures"`
+	ServerName                   string       `json:"server_name"`
+	ServerFqdn                   string       `json:"server_fqdn"`
+	DefaultLang                  string       `json:"default_lang"`
+	SessionKey                   string       `json:"session_key"`
+	Method                       string       `json:"method"`
 }
 
 // SNMPSettings declares BMC SNMP params
 type SNMPSettings struct {
-	SnmpPort            int `json:"snmp_port"`
-	TrapPort            int `json:"trap_port"`
-	SnmpExternalDisable int `json:"snmp_external_disable"`
+	SnmpPort                int  `json:"snmp_port"`
+	TrapPort                int  `json:"trap_port"`
+	SnmpExternalDisableIlo4 *int `json:"snmp_external_disable,omitempty"` // this is iLO4
+	SnmpExternalEnabledIlo5 *int `json:"snmp_external_enabled,omitempty"` // this is iLO5
 }
 
 // NetworkIPv4 sets IPv4 network settings


### PR DESCRIPTION
## What does this PR implement/change/remove?

### Checklist
- [ ] Tests added
- [x] Similar commits squashed

### The HW vendor this change applies to (if applicable)

HP

### The HW model number, product name this change applies to (if applicable)

-

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

iLO4 and 5

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

-

## Description for changelog/release notes

```
Added initial SNMP support to enable and disable SNMP.
New configuration setting added to indicate enabling or disabling SNMP. Sample config available on [bmcbutler](https://github.com/bmc-toolbox/bmcbutler/blob/2073ba74749452ffa50e607fa193713541cb9ab1/samples/cfg/configuration.yml)
```
