### PR TITLE
HP Certificate Upload via redfish endpoint

### DIFF
--- a/providers/hp/ilo/configure.go
+++ b/providers/hp/ilo/configure.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/bmc-toolbox/bmclib/cfgresources"
 	"github.com/bmc-toolbox/bmclib/devices"

--- a/providers/hp/ilo/configure.go
+++ b/providers/hp/ilo/configure.go
@@ -718,18 +718,17 @@ func (i *Ilo) GenerateCSR(cert *cfgresources.HTTPSCertAttributes) ([]byte, error
 // UploadHTTPSCert implements the Configure interface.
 // return true if the bmc requires a reset.
 func (i *Ilo) UploadHTTPSCert(cert []byte, certFileName string, key []byte, keyFileName string) (bool, error) {
-	certPayload := &certImport{
-		Method:          "import_certificate",
-		CertificateData: string(cert),
-		SessionKey:      i.sessionKey,
+	type RedfishCertificatePayload struct {
+		Certificate string `json:"Certificate"`
 	}
+	endpoint := "redfish/v1/Managers/1/SecurityService/HttpsCert/Actions/HpeHttpsCert.ImportCertificate/"
+	certPayload := RedfishCertificatePayload{string(cert)}
 
 	payload, err := json.Marshal(certPayload)
 	if err != nil {
 		return false, err
 	}
 
-	endpoint := "json/certificate"
 	statusCode, _, err := i.post(endpoint, payload)
 	if err != nil {
 		return false, err

--- a/providers/hp/ilo/ilo.go
+++ b/providers/hp/ilo/ilo.go
@@ -201,6 +201,9 @@ func (i *Ilo) post(endpoint string, data []byte) (statusCode int, body []byte, e
 	for _, cookie := range i.httpClient.Jar.Cookies(u) {
 		if cookie.Name == "sessionKey" {
 			req.AddCookie(cookie)
+			if strings.Contains(u.String(), "redfish") {
+				req.Header.Add("X-Auth-Token", cookie.Value)
+			}
 		}
 	}
 


### PR DESCRIPTION
## What does this PR implement/change/remove?

Starting from ILO 5 2.55 Support import of SSL certificate which is more than 20KB is allowed via redfish endpoints 
https://support.hpe.com/connect/s/softwaredetails?softwareId=MTX_5db4ea82a110436daf58edbc61&language=en_US&tab=revisionHistory 

### The HW vendor this change applies to

HPE


### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

HPE ILO 5 v2.55 and higher


## Description for changelog/release notes

```
```
