### PR TITLE
Chassis with single OA takes more than 60 seconds

### DIFF
--- a/discover/probe.go
+++ b/discover/probe.go
@@ -97,7 +97,7 @@ func (p *Probe) hpIlo(ctx context.Context, log logr.Logger) (bmcConnection inter
 }
 
 func (p *Probe) hpC7000(ctx context.Context, log logr.Logger) (bmcConnection interface{}, err error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(time.Second*60))
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(time.Second*120))
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://%s/xmldata?item=all", p.host), nil)


### PR DESCRIPTION
## What does this PR implement/change/remove?

Currenlty we have noticed that hpC7000s that have only one OA takes more than 60s seconds to generate the XML Data via https://<Ip>/xmldata?item=all. Increasing the timeout to 120 seconds to accomodate such chassis. Other "healthy chassis" scan will not be affected by this change as it will return success as soon as the XML is generated. 

It might however cause dead chassis to create a delay, which I assume is tolerable damage in return of saving half alive chanssis :) 


### Checklist
- [ NA] Tests added
- [ Y] Similar commits squashed

### The HW vendor this change applies to (if applicable)
HP
### The HW model number, product name this change applies to (if applicable)
HPC7000
### The BMC firmware and/or BIOS versions that this change applies to (if applicable)
N/A
### What version of tooling - vendor specific or opensource does this change depend on (if applicable)
vendor specific
## Description for changelog/release notes

```
```
