### PR TITLE
Redfish session fixes

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -9,6 +9,12 @@ var (
 	// ErrLoginFailed is returned when we fail to login to a bmc
 	ErrLoginFailed = errors.New("failed to login")
 
+	// ErrLogoutFailed is returned when we fail to logout from a bmc
+	ErrLogoutFailed = errors.New("failed to logout")
+
+	// ErrNotAuthenticated is returned when the session is not active.
+	ErrNotAuthenticated = errors.New("not authenticated")
+
 	// ErrNon200Response is returned when bmclib recieves an unexpected non-200 status code for a query
 	ErrNon200Response = errors.New("non-200 response returned for the endpoint")
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/jacobweinstock/registrar v0.4.6
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
-	github.com/stmcginnis/gofish v0.13.0
+	github.com/stmcginnis/gofish v0.13.1-0.20221107140645-5cc43fad050f
 	github.com/stretchr/testify v1.7.2
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	golang.org/x/net v0.0.0-20220615171555-694bf12d69de

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stmcginnis/gofish v0.13.0 h1:qq6q3yNt9vw7ZuJxiw87hq9+BdPLsuRQBwl+XoZSz60=
 github.com/stmcginnis/gofish v0.13.0/go.mod h1:BLDSFTp8pDlf/xDbLZa+F7f7eW0E/CHCboggsu8CznI=
+github.com/stmcginnis/gofish v0.13.1-0.20221107140645-5cc43fad050f h1:/nAm+3jDIM9pMfSlY2Lr0wCh4WFEhgbACuX9FpYAJ4k=
+github.com/stmcginnis/gofish v0.13.1-0.20221107140645-5cc43fad050f/go.mod h1:BLDSFTp8pDlf/xDbLZa+F7f7eW0E/CHCboggsu8CznI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -4,11 +4,6 @@ import (
 	"unicode"
 )
 
-var (
-	// EnvBmclibTestActive is set by tests to indicate a test is running for client methods to mock certain behaviour.
-	EnvBmclibTestActive = "false"
-)
-
 // IsntLetterOrNumber check if the give rune is not a letter nor a number
 func IsntLetterOrNumber(c rune) bool {
 	return !unicode.IsLetter(c) && !unicode.IsNumber(c)

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -4,6 +4,11 @@ import (
 	"unicode"
 )
 
+var (
+	// EnvBmclibTestActive is set by tests to indicate a test is running for client methods to mock certain behaviour.
+	EnvBmclibTestActive = "false"
+)
+
 // IsntLetterOrNumber check if the give rune is not a letter nor a number
 func IsntLetterOrNumber(c rune) bool {
 	return !unicode.IsLetter(c) && !unicode.IsNumber(c)

--- a/providers/redfish/firmware.go
+++ b/providers/redfish/firmware.go
@@ -32,9 +32,8 @@ func SupportedFirmwareApplyAtValues() []string {
 
 // FirmwareInstall uploads and initiates the firmware install process
 func (c *Conn) FirmwareInstall(ctx context.Context, component, applyAt string, forceInstall bool, reader io.Reader) (taskID string, err error) {
-	_, err = c.conn.GetSession()
-	if err != nil {
-		return taskID, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	if err := c.sessionActive(ctx); err != nil {
+		return "", err
 	}
 
 	// validate firmware update mechanism is supported
@@ -110,9 +109,8 @@ func (c *Conn) FirmwareInstall(ctx context.Context, component, applyAt string, f
 
 // FirmwareInstallStatus returns the status of the firmware install task queued
 func (c *Conn) FirmwareInstallStatus(ctx context.Context, installVersion, component, taskID string) (state string, err error) {
-	_, err = c.conn.GetSession()
-	if err != nil {
-		return taskID, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	if err := c.sessionActive(ctx); err != nil {
+		return "", err
 	}
 
 	vendor, _, err := c.DeviceVendorModel(ctx)

--- a/providers/redfish/firmware.go
+++ b/providers/redfish/firmware.go
@@ -32,6 +32,11 @@ func SupportedFirmwareApplyAtValues() []string {
 
 // FirmwareInstall uploads and initiates the firmware install process
 func (c *Conn) FirmwareInstall(ctx context.Context, component, applyAt string, forceInstall bool, reader io.Reader) (taskID string, err error) {
+	_, err = c.conn.GetSession()
+	if err != nil {
+		return taskID, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
 	// validate firmware update mechanism is supported
 	err = c.firmwareUpdateCompatible(ctx)
 	if err != nil {
@@ -105,6 +110,11 @@ func (c *Conn) FirmwareInstall(ctx context.Context, component, applyAt string, f
 
 // FirmwareInstallStatus returns the status of the firmware install task queued
 func (c *Conn) FirmwareInstallStatus(ctx context.Context, installVersion, component, taskID string) (state string, err error) {
+	_, err = c.conn.GetSession()
+	if err != nil {
+		return taskID, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
 	vendor, _, err := c.DeviceVendorModel(ctx)
 	if err != nil {
 		return state, errors.Wrap(err, "unable to determine device vendor, model attributes")

--- a/providers/redfish/firmware.go
+++ b/providers/redfish/firmware.go
@@ -284,9 +284,5 @@ func (c *Conn) purgeQueuedFirmwareInstallTask(ctx context.Context, component str
 		)
 	}
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/providers/redfish/firmware_test.go
+++ b/providers/redfish/firmware_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/bmc-toolbox/bmclib/v2/constants"
 	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
+	"github.com/bmc-toolbox/bmclib/v2/internal"
 	"github.com/bmc-toolbox/common"
 )
 
@@ -25,7 +25,7 @@ func multipartUpload(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -62,6 +62,9 @@ func Test_FirmwareInstall(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	os.Setenv(internal.EnvBmclibTestActive, "true")
+	defer os.Unsetenv(internal.EnvBmclibTestActive)
 
 	fh, err := os.Open(binPath)
 	if err != nil {

--- a/providers/redfish/firmware_test.go
+++ b/providers/redfish/firmware_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/bmc-toolbox/bmclib/v2/constants"
 	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
-	"github.com/bmc-toolbox/bmclib/v2/internal"
 	"github.com/bmc-toolbox/common"
 )
 
@@ -62,9 +61,6 @@ func Test_FirmwareInstall(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	os.Setenv(internal.EnvBmclibTestActive, "true")
-	defer os.Unsetenv(internal.EnvBmclibTestActive)
 
 	fh, err := os.Open(binPath)
 	if err != nil {

--- a/providers/redfish/inventory.go
+++ b/providers/redfish/inventory.go
@@ -46,6 +46,11 @@ type inventory struct {
 
 // DeviceVendorModel returns the device vendor and model attributes
 func (c *Conn) DeviceVendorModel(ctx context.Context) (vendor, model string, err error) {
+	_, err = c.conn.GetSession()
+	if err != nil {
+		return "", "", errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
 	systems, err := c.conn.Service.Systems()
 	if err != nil {
 		return vendor, model, err
@@ -63,6 +68,11 @@ func (c *Conn) DeviceVendorModel(ctx context.Context) (vendor, model string, err
 }
 
 func (c *Conn) Inventory(ctx context.Context) (device *common.Device, err error) {
+	_, err = c.conn.GetSession()
+	if err != nil {
+		return nil, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
 	// initialize inventory object
 	inv := &inventory{conn: c.conn}
 	// TODO: this can soft fail

--- a/providers/redfish/inventory.go
+++ b/providers/redfish/inventory.go
@@ -46,9 +46,8 @@ type inventory struct {
 
 // DeviceVendorModel returns the device vendor and model attributes
 func (c *Conn) DeviceVendorModel(ctx context.Context) (vendor, model string, err error) {
-	_, err = c.conn.GetSession()
-	if err != nil {
-		return "", "", errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	if err := c.sessionActive(ctx); err != nil {
+		return "", "", err
 	}
 
 	systems, err := c.conn.Service.Systems()
@@ -68,9 +67,8 @@ func (c *Conn) DeviceVendorModel(ctx context.Context) (vendor, model string, err
 }
 
 func (c *Conn) Inventory(ctx context.Context) (device *common.Device, err error) {
-	_, err = c.conn.GetSession()
-	if err != nil {
-		return nil, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	if err := c.sessionActive(ctx); err != nil {
+		return nil, err
 	}
 
 	// initialize inventory object

--- a/providers/redfish/inventory_collect.go
+++ b/providers/redfish/inventory_collect.go
@@ -274,6 +274,11 @@ func (i *inventory) collectStorageControllers(sys *redfish.ComputerSystem, devic
 				SpeedGbps: int64(controller.SpeedGbps),
 			}
 
+			// In some cases the storage controller model number is present in the Name field
+			if strings.TrimSpace(c.Model) == "" && strings.TrimSpace(controller.Name) != "" {
+				c.Model = controller.Name
+			}
+
 			// include additional firmware attributes from redfish firmware inventory
 			i.firmwareAttributes(c.Description, c.ID, c.Firmware)
 

--- a/providers/redfish/inventory_collect.go
+++ b/providers/redfish/inventory_collect.go
@@ -15,7 +15,7 @@ func (i *inventory) collectEnclosure(ch *redfish.Chassis, device *common.Device)
 	e := &common.Enclosure{
 		Common: common.Common{
 			Description: ch.Description,
-			Vendor:      ch.Manufacturer,
+			Vendor:      common.FormatVendorName(ch.Manufacturer),
 			Model:       ch.Model,
 			Status: &common.Status{
 				Health: string(ch.Status.Health),
@@ -51,7 +51,7 @@ func (i *inventory) collectPSUs(ch *redfish.Chassis, device *common.Device) (err
 		p := &common.PSU{
 			Common: common.Common{
 				Description: psu.Name,
-				Vendor:      psu.Manufacturer,
+				Vendor:      common.FormatVendorName(psu.Manufacturer),
 				Model:       psu.Model,
 				Serial:      psu.SerialNumber,
 
@@ -128,7 +128,7 @@ func (i *inventory) collectNICs(sys *redfish.ComputerSystem, device *common.Devi
 
 		n := &common.NIC{
 			Common: common.Common{
-				Vendor: adapter.Manufacturer,
+				Vendor: common.FormatVendorName(adapter.Manufacturer),
 				Model:  adapter.Model,
 				Serial: adapter.SerialNumber,
 				Status: &common.Status{
@@ -212,7 +212,7 @@ func (i *inventory) collectDrives(sys *redfish.ComputerSystem, device *common.De
 					ProductName: drive.Model,
 					Description: drive.Description,
 					Serial:      drive.SerialNumber,
-					Vendor:      drive.Manufacturer,
+					Vendor:      common.FormatVendorName(drive.Manufacturer),
 					Model:       drive.Model,
 					Firmware: &common.Firmware{
 						Installed: drive.Revision,
@@ -258,7 +258,7 @@ func (i *inventory) collectStorageControllers(sys *redfish.ComputerSystem, devic
 			c := &common.StorageController{
 				Common: common.Common{
 					Description: controller.Name,
-					Vendor:      controller.Manufacturer,
+					Vendor:      common.FormatVendorName(controller.Manufacturer),
 					Model:       controller.PartNumber,
 					Serial:      controller.SerialNumber,
 					Status: &common.Status{
@@ -306,7 +306,7 @@ func (i *inventory) collectCPUs(sys *redfish.ComputerSystem, device *common.Devi
 		device.CPUs = append(device.CPUs, &common.CPU{
 			Common: common.Common{
 				Description: proc.Description,
-				Vendor:      proc.Manufacturer,
+				Vendor:      common.FormatVendorName(proc.Manufacturer),
 				Model:       proc.Model,
 				Serial:      "",
 				Status: &common.Status{
@@ -340,7 +340,7 @@ func (i *inventory) collectDIMMs(sys *redfish.ComputerSystem, device *common.Dev
 		device.Memory = append(device.Memory, &common.Memory{
 			Common: common.Common{
 				Description: dimm.Description,
-				Vendor:      dimm.Manufacturer,
+				Vendor:      common.FormatVendorName(dimm.Manufacturer),
 				Model:       "",
 				Serial:      dimm.SerialNumber,
 				Status: &common.Status{
@@ -366,7 +366,7 @@ func (i *inventory) collectCPLDs(device *common.Device) (err error) {
 
 	cpld := &common.CPLD{
 		Common: common.Common{
-			Vendor:   device.Vendor,
+			Vendor:   common.FormatVendorName(device.Vendor),
 			Model:    device.Model,
 			Firmware: &common.Firmware{Metadata: make(map[string]string)},
 		},

--- a/providers/redfish/redfish.go
+++ b/providers/redfish/redfish.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
-	"github.com/bmc-toolbox/bmclib/v2/internal"
 	"github.com/bmc-toolbox/bmclib/v2/internal/httpclient"
 	"github.com/bmc-toolbox/bmclib/v2/providers"
 	"github.com/go-logr/logr"
@@ -160,11 +159,6 @@ func (c *Conn) Compatible(ctx context.Context) bool {
 }
 
 func (c *Conn) sessionActive(ctx context.Context) error {
-	// skip session active checks for tests
-	if os.Getenv(internal.EnvBmclibTestActive) == "true" {
-		return nil
-	}
-
 	if c.conn == nil {
 		return bmclibErrs.ErrNotAuthenticated
 	}

--- a/providers/redfish/redfish.go
+++ b/providers/redfish/redfish.go
@@ -155,6 +155,11 @@ func (c *Conn) Compatible(ctx context.Context) bool {
 
 // BmcReset powercycles the BMC
 func (c *Conn) BmcReset(ctx context.Context, resetType string) (ok bool, err error) {
+	_, err = c.conn.GetSession()
+	if err != nil {
+		return false, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
 	managers, err := c.conn.Service.Managers()
 	if err != nil {
 		return false, err
@@ -172,11 +177,21 @@ func (c *Conn) BmcReset(ctx context.Context, resetType string) (ok bool, err err
 
 // PowerStateGet gets the power state of a BMC machine
 func (c *Conn) PowerStateGet(ctx context.Context) (state string, err error) {
+	_, err = c.conn.GetSession()
+	if err != nil {
+		return "", errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
 	return c.status(ctx)
 }
 
 // PowerSet sets the power state of a BMC via redfish
 func (c *Conn) PowerSet(ctx context.Context, state string) (ok bool, err error) {
+	_, err = c.conn.GetSession()
+	if err != nil {
+		return false, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
 	switch strings.ToLower(state) {
 	case "on":
 		return c.on(ctx)

--- a/providers/redfish/redfish.go
+++ b/providers/redfish/redfish.go
@@ -122,7 +122,12 @@ func (c *Conn) Open(ctx context.Context) (err error) {
 
 // Close a connection to a BMC via redfish
 func (c *Conn) Close(ctx context.Context) error {
+	if c.conn == nil {
+		return nil
+	}
+
 	c.conn.Logout()
+
 	return nil
 }
 

--- a/providers/redfish/redfish.go
+++ b/providers/redfish/redfish.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
+	"github.com/bmc-toolbox/bmclib/v2/internal"
 	"github.com/bmc-toolbox/bmclib/v2/internal/httpclient"
 	"github.com/bmc-toolbox/bmclib/v2/providers"
 	"github.com/go-logr/logr"
@@ -154,6 +155,11 @@ func (c *Conn) Compatible(ctx context.Context) bool {
 }
 
 func (c *Conn) sessionActive(ctx context.Context) error {
+	// skip session active checks for tests
+	if os.Getenv(internal.EnvBmclibTestActive) == "true" {
+		return nil
+	}
+
 	if c.conn == nil {
 		return bmclibErrs.ErrNotAuthenticated
 	}

--- a/providers/redfish/redfish.go
+++ b/providers/redfish/redfish.go
@@ -116,10 +116,7 @@ func (c *Conn) Open(ctx context.Context) (err error) {
 	}
 
 	c.conn, err = gofish.ConnectContext(ctx, config)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // Close a connection to a BMC via redfish

--- a/providers/redfish/tasks.go
+++ b/providers/redfish/tasks.go
@@ -2,7 +2,7 @@ package redfish
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"strconv"
 	"strings"
 
@@ -137,7 +137,7 @@ func (c *Conn) dellJobs(state string) ([]*rf.Task, error) {
 		return nil, errors.New("dell jobs endpoint returned unexpected status code: " + strconv.Itoa(resp.StatusCode))
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/redfish/user.go
+++ b/providers/redfish/user.go
@@ -3,7 +3,6 @@ package redfish
 import (
 	"context"
 
-	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
 	"github.com/bmc-toolbox/bmclib/v2/internal"
 	"github.com/pkg/errors"
 	"github.com/stmcginnis/gofish/redfish"
@@ -20,9 +19,8 @@ var (
 
 // UserRead returns a list of enabled user accounts
 func (c *Conn) UserRead(ctx context.Context) (users []map[string]string, err error) {
-	_, err = c.conn.GetSession()
-	if err != nil {
-		return nil, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	if err := c.sessionActive(ctx); err != nil {
+		return nil, err
 	}
 
 	service, err := c.conn.Service.AccountService()
@@ -54,9 +52,8 @@ func (c *Conn) UserRead(ctx context.Context) (users []map[string]string, err err
 
 // UserUpdate updates a user password and role
 func (c *Conn) UserUpdate(ctx context.Context, user, pass, role string) (ok bool, err error) {
-	_, err = c.conn.GetSession()
-	if err != nil {
-		return false, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	if err := c.sessionActive(ctx); err != nil {
+		return false, err
 	}
 
 	service, err := c.conn.Service.AccountService()
@@ -104,9 +101,8 @@ func (c *Conn) UserCreate(ctx context.Context, user, pass, role string) (ok bool
 		return false, ErrUserPassParams
 	}
 
-	_, err = c.conn.GetSession()
-	if err != nil {
-		return false, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	if err := c.sessionActive(ctx); err != nil {
+		return false, err
 	}
 
 	service, err := c.conn.Service.AccountService()
@@ -156,9 +152,8 @@ func (c *Conn) UserDelete(ctx context.Context, user string) (ok bool, err error)
 		return false, ErrUserPassParams
 	}
 
-	_, err = c.conn.GetSession()
-	if err != nil {
-		return false, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	if err := c.sessionActive(ctx); err != nil {
+		return false, err
 	}
 
 	service, err := c.conn.Service.AccountService()

--- a/providers/redfish/user.go
+++ b/providers/redfish/user.go
@@ -3,6 +3,7 @@ package redfish
 import (
 	"context"
 
+	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
 	"github.com/bmc-toolbox/bmclib/v2/internal"
 	"github.com/pkg/errors"
 	"github.com/stmcginnis/gofish/redfish"
@@ -19,6 +20,11 @@ var (
 
 // UserRead returns a list of enabled user accounts
 func (c *Conn) UserRead(ctx context.Context) (users []map[string]string, err error) {
+	_, err = c.conn.GetSession()
+	if err != nil {
+		return nil, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
 	service, err := c.conn.Service.AccountService()
 	if err != nil {
 		return nil, err
@@ -48,6 +54,11 @@ func (c *Conn) UserRead(ctx context.Context) (users []map[string]string, err err
 
 // UserUpdate updates a user password and role
 func (c *Conn) UserUpdate(ctx context.Context, user, pass, role string) (ok bool, err error) {
+	_, err = c.conn.GetSession()
+	if err != nil {
+		return false, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
 	service, err := c.conn.Service.AccountService()
 	if err != nil {
 		return false, err
@@ -91,6 +102,11 @@ func (c *Conn) UserCreate(ctx context.Context, user, pass, role string) (ok bool
 
 	if user == "" || pass == "" {
 		return false, ErrUserPassParams
+	}
+
+	_, err = c.conn.GetSession()
+	if err != nil {
+		return false, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
 	}
 
 	service, err := c.conn.Service.AccountService()
@@ -138,6 +154,11 @@ func (c *Conn) UserCreate(ctx context.Context, user, pass, role string) (ok bool
 func (c *Conn) UserDelete(ctx context.Context, user string) (ok bool, err error) {
 	if user == "" {
 		return false, ErrUserPassParams
+	}
+
+	_, err = c.conn.GetSession()
+	if err != nil {
+		return false, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
 	}
 
 	service, err := c.conn.Service.AccountService()


### PR DESCRIPTION
## What does this PR implement/change/remove?

 - Fixes various superfluous nil error checks and remove calls to deprecated ioutil package.
 - Adds a check to ensure a Redfish session is active, this prevents the clients from seeing panics (see paste below)
   when a redfish session was closed or was not previously created.
 - A few inventory fixes.

Related: https://github.com/stmcginnis/gofish/pull/214

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x17b78fc]

goroutine 30 [running]:
github.com/bmc-toolbox/bmclib/v2/providers/redfish.(*Conn).status(0x17cb315?, {0xc0002f6470?, 0x0?})
        /go/pkg/mod/github.com/bmc-toolbox/bmclib/v2@v2.0.0/providers/redfish/redfish.go:236 +0x1c
github.com/bmc-toolbox/bmclib/v2/providers/redfish.(*Conn).PowerStateGet(0x18768c0?, {0x1b4ac18?, 0xc000433f80?})
        /go/pkg/mod/github.com/bmc-toolbox/bmclib/v2@v2.0.0/providers/redfish/redfish.go:178 +0x25
github.com/bmc-toolbox/bmclib/v2/bmc.getPowerState({0x1b4ac18, 0xc000433f80}, {0xc0003fa990?, 0x0?, 0x0?})
        /go/pkg/mod/github.com/bmc-toolbox/bmclib/v2@v2.0.0/bmc/power.go:102 +0x28d
github.com/bmc-toolbox/bmclib/v2/bmc.GetPowerStateFromInterfaces({0x1b4ac18?, 0xc000433f80?}, {0xc0002f6460?, 0x1?, 0x1?})
        /go/pkg/mod/github.com/bmc-toolbox/bmclib/v2@v2.0.0/bmc/power.go:131 +0x1c5
github.com/bmc-toolbox/bmclib/v2.(*Client).GetPowerState(0xc000196e10, {0x1b4ac18, 0xc000433f80})
        /go/pkg/mod/github.com/bmc-toolbox/bmclib/v2@v2.0.0/client.go:178 +0x1e7
```