### PR TITLE
Redfish refactor

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,8 +11,9 @@ import (
 
 	"github.com/bmc-toolbox/bmclib/v2/bmc"
 	"github.com/bmc-toolbox/bmclib/v2/internal/httpclient"
-	"github.com/bmc-toolbox/bmclib/v2/providers/intelamt"
+	"github.com/bmc-toolbox/bmclib/v2/internal/redfishwrapper"
 	"github.com/bmc-toolbox/bmclib/v2/providers/asrockrack"
+	"github.com/bmc-toolbox/bmclib/v2/providers/intelamt"
 	"github.com/bmc-toolbox/bmclib/v2/providers/ipmitool"
 	"github.com/bmc-toolbox/bmclib/v2/providers/redfish"
 	"github.com/bmc-toolbox/common"
@@ -109,7 +110,7 @@ func (c *Client) registerProviders() {
 	c.Registry.Register(asrockrack.ProviderName, asrockrack.ProviderProtocol, asrockrack.Features, nil, driverAsrockrack)
 
 	// register gofish provider
-	driverGoFish := redfish.New(c.Auth.Host, c.Auth.Port, c.Auth.User, c.Auth.Pass, c.Logger, redfish.WithHTTPClient(c.httpClient))
+	driverGoFish := redfish.New(c.Auth.Host, c.Auth.Port, c.Auth.User, c.Auth.Pass, c.Logger, redfishwrapper.WithHTTPClient(c.httpClient))
 	c.Registry.Register(redfish.ProviderName, redfish.ProviderProtocol, redfish.Features, nil, driverGoFish)
 
 	// register AMT provider

--- a/internal/redfishwrapper/client.go
+++ b/internal/redfishwrapper/client.go
@@ -1,0 +1,141 @@
+package redfishwrapper
+
+import (
+	"context"
+	"crypto/x509"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
+	"github.com/bmc-toolbox/bmclib/v2/internal/httpclient"
+	"github.com/pkg/errors"
+	"github.com/stmcginnis/gofish"
+)
+
+// Client is a redfishwrapper client which wraps the gofish client.
+type Client struct {
+	host                 string
+	port                 string
+	user                 string
+	pass                 string
+	client               *gofish.APIClient
+	httpClient           *http.Client
+	httpClientSetupFuncs []func(*http.Client)
+}
+
+// Option is a function applied to a *Conn
+type Option func(*Client)
+
+// WithHTTPClient returns an option that sets an HTTP client for the connecion
+func WithHTTPClient(cli *http.Client) Option {
+	return func(c *Client) {
+		c.httpClient = cli
+	}
+}
+
+// WithSecureTLS returns an option that enables secure TLS with an optional cert pool.
+func WithSecureTLS(rootCAs *x509.CertPool) Option {
+	return func(c *Client) {
+		c.httpClientSetupFuncs = append(c.httpClientSetupFuncs, httpclient.SecureTLSOption(rootCAs))
+	}
+}
+
+// NewClient returns a redfishwrapper client
+func NewClient(host, port, user, pass string, opts ...Option) *Client {
+	if !strings.HasPrefix(host, "https://") && !strings.HasPrefix(host, "http://") {
+		host = "https://" + host
+	}
+
+	client := &Client{
+		host: host,
+		port: port,
+		user: user,
+		pass: pass,
+	}
+
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	return client
+}
+
+// Open sets up a new redfish session.
+func (c *Client) Open(ctx context.Context) error {
+	config := gofish.ClientConfig{
+		Endpoint:   c.host,
+		Username:   c.user,
+		Password:   c.pass,
+		Insecure:   true,
+		HTTPClient: c.httpClient,
+	}
+
+	if config.HTTPClient == nil {
+		var err error
+		config.HTTPClient, err = httpclient.Build(c.httpClientSetupFuncs...)
+		if err != nil {
+			return err
+		}
+	} else {
+		for _, setupFunc := range c.httpClientSetupFuncs {
+			setupFunc(config.HTTPClient)
+		}
+	}
+
+	debug := os.Getenv("DEBUG_BMCLIB")
+	if debug == "true" {
+		config.DumpWriter = os.Stdout
+	}
+
+	var err error
+	c.client, err = gofish.ConnectContext(ctx, config)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Close closes the redfish session.
+func (c *Client) Close(ctx context.Context) error {
+	if c == nil || c.client.Service == nil {
+		return nil
+	}
+
+	c.client.Logout()
+
+	return nil
+}
+
+// SessionActive returns an error if a redfish session is not active.
+func (c *Client) SessionActive() error {
+	if c.client == nil || c.client.Service == nil {
+		return bmclibErrs.ErrNotAuthenticated
+	}
+
+	_, err := c.client.GetSession()
+	if err != nil {
+		return errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
+	return nil
+}
+
+// RunRawRequestWithHeaders wraps the gofish client method RunRawRequestWithHeaders
+func (c *Client) RunRawRequestWithHeaders(method, url string, payloadBuffer io.ReadSeeker, contentType string, customHeaders map[string]string) (*http.Response, error) {
+	if err := c.SessionActive(); err != nil {
+		return nil, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
+	return c.client.RunRawRequestWithHeaders(method, url, payloadBuffer, contentType, customHeaders)
+}
+
+func (c *Client) Delete(url string) (*http.Response, error) {
+	return c.client.Delete(url)
+}
+
+func (c *Client) Get(url string) (*http.Response, error) {
+	return c.client.Get(url)
+}

--- a/internal/redfishwrapper/power.go
+++ b/internal/redfishwrapper/power.go
@@ -1,0 +1,191 @@
+package redfishwrapper
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
+	"github.com/pkg/errors"
+	rf "github.com/stmcginnis/gofish/redfish"
+)
+
+// BmcReset powercycles the BMC.
+func (c *Client) BmcReset(ctx context.Context, resetType string) (ok bool, err error) {
+	if err := c.SessionActive(); err != nil {
+		return false, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
+	managers, err := c.client.Service.Managers()
+	if err != nil {
+		return false, err
+	}
+
+	for _, manager := range managers {
+		err = manager.Reset(rf.ResetType(resetType))
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+// SystemPowerOn powers on the system.
+func (c *Client) SystemPowerOn(ctx context.Context) (ok bool, err error) {
+	if err := c.SessionActive(); err != nil {
+		return false, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
+	service := c.client.Service
+	ss, err := service.Systems()
+	if err != nil {
+		return false, err
+	}
+
+	for _, system := range ss {
+		if system.PowerState == rf.OnPowerState {
+			break
+		}
+		err = system.Reset(rf.OnResetType)
+		if err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+// SystemPowerOff powers off the system.
+func (c *Client) SystemPowerOff(ctx context.Context) (ok bool, err error) {
+	if err := c.SessionActive(); err != nil {
+		return false, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
+	service := c.client.Service
+	ss, err := service.Systems()
+	if err != nil {
+		return false, err
+	}
+
+	for _, system := range ss {
+		if system.PowerState == rf.OffPowerState {
+			break
+		}
+		err = system.Reset(rf.GracefulShutdownResetType)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return false, nil
+}
+
+// SystemReset power cycles the system.
+func (c *Client) SystemReset(ctx context.Context) (ok bool, err error) {
+	if err := c.SessionActive(); err != nil {
+		return false, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
+	service := c.client.Service
+	ss, err := service.Systems()
+	if err != nil {
+		return false, err
+	}
+
+	for _, system := range ss {
+		err = system.Reset(rf.PowerCycleResetType)
+		if err != nil {
+
+			_, _ = c.SystemPowerOff(ctx)
+
+			for wait := 1; wait < 10; wait++ {
+				status, _ := c.SystemPowerStatus(ctx)
+				if status == "off" {
+					break
+				}
+				time.Sleep(1 * time.Second)
+			}
+
+			_, errMsg := c.SystemPowerOn(ctx)
+
+			return true, errMsg
+		}
+	}
+	return true, nil
+}
+
+// SystemPowerCycle power cycles the system.
+func (c *Client) SystemPowerCycle(ctx context.Context) (ok bool, err error) {
+	if err := c.SessionActive(); err != nil {
+		return false, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
+	service := c.client.Service
+	ss, err := service.Systems()
+	if err != nil {
+		return false, err
+	}
+
+	res, err := c.SystemPowerStatus(ctx)
+	if err != nil {
+		return false, fmt.Errorf("power cycle failed: unable to get current state")
+	}
+
+	if strings.ToLower(res) == "off" {
+		return false, fmt.Errorf("power cycle failed: Command not supported in present state: %v", res)
+	}
+
+	for _, system := range ss {
+		err = system.Reset(rf.ForceRestartResetType)
+		if err != nil {
+			return false, errors.WithMessage(err, "power cycle failed")
+		}
+	}
+
+	return true, nil
+}
+
+// SystemPowerStatus returns the system power state.
+func (c *Client) SystemPowerStatus(ctx context.Context) (result string, err error) {
+	if err := c.SessionActive(); err != nil {
+		return result, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
+	service := c.client.Service
+	ss, err := service.Systems()
+	if err != nil {
+		return "", err
+	}
+
+	for _, system := range ss {
+		return string(system.PowerState), nil
+	}
+
+	return "", errors.New("unable to retrieve status")
+}
+
+// SystemForceOff powers off the system, without waiting for the OS to shutdown.
+func (c *Client) SystemForceOff(ctx context.Context) (ok bool, err error) {
+	if err := c.SessionActive(); err != nil {
+		return false, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
+	service := c.client.Service
+	ss, err := service.Systems()
+	if err != nil {
+		return false, err
+	}
+
+	for _, system := range ss {
+		if system.PowerState == rf.OffPowerState {
+			break
+		}
+		err = system.Reset(rf.ForceOffResetType)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}

--- a/internal/redfishwrapper/power.go
+++ b/internal/redfishwrapper/power.go
@@ -11,8 +11,8 @@ import (
 	rf "github.com/stmcginnis/gofish/redfish"
 )
 
-// BmcReset powercycles the BMC.
-func (c *Client) BmcReset(ctx context.Context, resetType string) (ok bool, err error) {
+// BMCReset powercycles the BMC.
+func (c *Client) BMCReset(ctx context.Context, resetType string) (ok bool, err error) {
 	if err := c.SessionActive(); err != nil {
 		return false, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
 	}

--- a/internal/redfishwrapper/system.go
+++ b/internal/redfishwrapper/system.go
@@ -1,0 +1,57 @@
+package redfishwrapper
+
+import (
+	"context"
+
+	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
+
+	"github.com/pkg/errors"
+	gofishrf "github.com/stmcginnis/gofish/redfish"
+)
+
+// The methods here should be a thin wrapper so as to only guard the client from authentication failures.
+
+// AccountService gets the Redfish AccountService.d
+func (c *Client) AccountService() (*gofishrf.AccountService, error) {
+	if err := c.SessionActive(); err != nil {
+		return nil, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
+	return c.client.Service.AccountService()
+}
+
+// UpdateService gets the update service instance.
+func (c *Client) UpdateService() (*gofishrf.UpdateService, error) {
+	if err := c.SessionActive(); err != nil {
+		return nil, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
+	return c.client.Service.UpdateService()
+}
+
+// Systems get the system instances from the service.
+func (c *Client) Systems() ([]*gofishrf.ComputerSystem, error) {
+	if err := c.SessionActive(); err != nil {
+		return nil, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
+	return c.client.Service.Systems()
+}
+
+// Managers gets the manager instances of this service.
+func (c *Client) Managers(ctx context.Context) ([]*gofishrf.Manager, error) {
+	if err := c.SessionActive(); err != nil {
+		return nil, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
+	return c.client.Service.Managers()
+}
+
+// Chassis gets the chassis instances managed by this service.
+func (c *Client) Chassis(ctx context.Context) ([]*gofishrf.Chassis, error) {
+	if err := c.SessionActive(); err != nil {
+		return nil, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
+	return c.client.Service.Chassis()
+}

--- a/providers/asrockrack/helpers.go
+++ b/providers/asrockrack/helpers.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/http/httputil"
@@ -105,8 +104,8 @@ type preserveConfig struct {
 }
 
 // Firmware flash progress
-//{ "id": 1, "action": "Flashing...", "progress": "12% done         ", "state": 0 }
-//{ "id": 1, "action": "Flashing...", "progress": "100% done", "state": 0 }
+// { "id": 1, "action": "Flashing...", "progress": "12% done         ", "state": 0 }
+// { "id": 1, "action": "Flashing...", "progress": "100% done", "state": 0 }
 type upgradeProgress struct {
 	ID       int    `json:"id,omitempty"`
 	Action   string `json:"action,omitempty"`
@@ -441,7 +440,7 @@ func (a *ASRockRack) sensors(ctx context.Context) ([]*sensor, error) {
 }
 
 // Set the BIOS upgrade configuration
-//  - preserve current configuration
+//   - preserve current configuration
 func (a *ASRockRack) biosUpgradeConfiguration(ctx context.Context) error {
 	endpoint := "api/asrr/maintenance/BIOS/configuration"
 
@@ -463,12 +462,7 @@ func (a *ASRockRack) biosUpgradeConfiguration(ctx context.Context) error {
 	}
 
 	f := &firmwareInfo{}
-	err = json.Unmarshal(resp, f)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return json.Unmarshal(resp, f)
 }
 
 // Run BIOS upgrade
@@ -493,12 +487,7 @@ func (a *ASRockRack) upgradeBIOS(ctx context.Context) error {
 	}
 
 	f := &firmwareInfo{}
-	err = json.Unmarshal(resp, f)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return json.Unmarshal(resp, f)
 }
 
 // Returns the chassis status object which includes the power state
@@ -560,13 +549,10 @@ func (a *ASRockRack) httpsLogout(ctx context.Context) error {
 		return fmt.Errorf("Error logging out: " + err.Error())
 	}
 
-	if err != nil {
-		return fmt.Errorf("Error logging out: " + err.Error())
-	}
-
 	if statusCode != http.StatusOK {
 		return fmt.Errorf("non 200 response at https logout: %d", statusCode)
 	}
+
 	return nil
 }
 
@@ -614,7 +600,7 @@ func (a *ASRockRack) queryHTTPS(ctx context.Context, endpoint, method string, pa
 		a.log.V(3).Info("trace", "responseDump", string(respDump))
 	}
 
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return body, 0, err
 	}

--- a/providers/asrockrack/mock_test.go
+++ b/providers/asrockrack/mock_test.go
@@ -3,7 +3,7 @@ package asrockrack
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -71,7 +71,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-/////////////// mock bmc service ///////////////////////////
+// ///////////// mock bmc service ///////////////////////////
 func mockASRockBMC() *httptest.Server {
 	handler := http.NewServeMux()
 	handler.HandleFunc("/", index)
@@ -270,7 +270,7 @@ func sensorsinfo(w http.ResponseWriter, r *http.Request) {
 			log.Fatal(err)
 		}
 
-		b, err := ioutil.ReadAll(fh)
+		b, err := io.ReadAll(fh)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -296,7 +296,7 @@ func session(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "POST":
 		// login to BMC
-		b, _ := ioutil.ReadAll(r.Body)
+		b, _ := io.ReadAll(r.Body)
 		if string(b) == string(loginPayload) {
 			// login request needs to be of the right content-typ
 			if r.Header.Get("Content-Type") != "application/x-www-form-urlencoded" {

--- a/providers/ipmitool/ipmitool_test.go
+++ b/providers/ipmitool/ipmitool_test.go
@@ -3,7 +3,6 @@ package ipmitool
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,7 +16,7 @@ func TestMain(m *testing.M) {
 	var tempDir string
 	_, err := exec.LookPath("ipmitool")
 	if err != nil {
-		tempDir, err = ioutil.TempDir("/tmp", "")
+		tempDir, err = os.MkdirTemp("/tmp", "")
 		if err != nil {
 			os.Exit(2)
 		}
@@ -25,7 +24,7 @@ func TestMain(m *testing.M) {
 		os.Setenv("PATH", path)
 		fmt.Println(os.Getenv("PATH"))
 		f := filepath.Join(tempDir, "ipmitool")
-		err = ioutil.WriteFile(f, []byte{}, 0755)
+		err = os.WriteFile(f, []byte{}, 0755)
 		if err != nil {
 			os.RemoveAll(tempDir)
 			os.Exit(3)

--- a/providers/redfish/inventory_collect.go
+++ b/providers/redfish/inventory_collect.go
@@ -4,14 +4,13 @@ import (
 	"strings"
 
 	"github.com/bmc-toolbox/common"
-	"github.com/stmcginnis/gofish/redfish"
+	gofishrf "github.com/stmcginnis/gofish/redfish"
 )
 
 // defines various inventory collection helper methods
 
 // collectEnclosure collects Enclosure information
-func (i *inventory) collectEnclosure(ch *redfish.Chassis, device *common.Device) (err error) {
-
+func (i *inventory) collectEnclosure(ch *gofishrf.Chassis, device *common.Device) (err error) {
 	e := &common.Enclosure{
 		Common: common.Common{
 			Description: ch.Description,
@@ -37,7 +36,7 @@ func (i *inventory) collectEnclosure(ch *redfish.Chassis, device *common.Device)
 }
 
 // collectPSUs collects Power Supply Unit component information
-func (i *inventory) collectPSUs(ch *redfish.Chassis, device *common.Device) (err error) {
+func (i *inventory) collectPSUs(ch *gofishrf.Chassis, device *common.Device) (err error) {
 	power, err := ch.Power()
 	if err != nil {
 		return err
@@ -78,9 +77,8 @@ func (i *inventory) collectPSUs(ch *redfish.Chassis, device *common.Device) (err
 }
 
 // collectTPMs collects Trusted Platform Module component information
-func (i *inventory) collectTPMs(sys *redfish.ComputerSystem, device *common.Device) (err error) {
+func (i *inventory) collectTPMs(sys *gofishrf.ComputerSystem, device *common.Device) (err error) {
 	for _, module := range sys.TrustedModules {
-
 		tpm := &common.TPM{
 			Common: common.Common{
 				Firmware: &common.Firmware{
@@ -105,7 +103,7 @@ func (i *inventory) collectTPMs(sys *redfish.ComputerSystem, device *common.Devi
 }
 
 // collectNICs collects network interface component information
-func (i *inventory) collectNICs(sys *redfish.ComputerSystem, device *common.Device) (err error) {
+func (i *inventory) collectNICs(sys *gofishrf.ComputerSystem, device *common.Device) (err error) {
 	// collect network interface information
 	nics, err := sys.NetworkInterfaces()
 	if err != nil {
@@ -168,7 +166,7 @@ func (i *inventory) collectNICs(sys *redfish.ComputerSystem, device *common.Devi
 	return nil
 }
 
-func (i *inventory) collectBIOS(sys *redfish.ComputerSystem, device *common.Device) (err error) {
+func (i *inventory) collectBIOS(sys *gofishrf.ComputerSystem, device *common.Device) (err error) {
 	bios, err := sys.Bios()
 	if err != nil {
 		return err
@@ -190,7 +188,7 @@ func (i *inventory) collectBIOS(sys *redfish.ComputerSystem, device *common.Devi
 }
 
 // collectDrives collects drive component information
-func (i *inventory) collectDrives(sys *redfish.ComputerSystem, device *common.Device) (err error) {
+func (i *inventory) collectDrives(sys *gofishrf.ComputerSystem, device *common.Device) (err error) {
 	storage, err := sys.Storage()
 	if err != nil {
 		return err
@@ -246,7 +244,7 @@ func (i *inventory) collectDrives(sys *redfish.ComputerSystem, device *common.De
 }
 
 // collectStorageControllers populates the device with Storage controller component attributes
-func (i *inventory) collectStorageControllers(sys *redfish.ComputerSystem, device *common.Device) (err error) {
+func (i *inventory) collectStorageControllers(sys *gofishrf.ComputerSystem, device *common.Device) (err error) {
 	storage, err := sys.Storage()
 	if err != nil {
 		return err
@@ -291,7 +289,7 @@ func (i *inventory) collectStorageControllers(sys *redfish.ComputerSystem, devic
 }
 
 // collectCPUs populates the device with CPU component attributes
-func (i *inventory) collectCPUs(sys *redfish.ComputerSystem, device *common.Device) (err error) {
+func (i *inventory) collectCPUs(sys *gofishrf.ComputerSystem, device *common.Device) (err error) {
 	procs, err := sys.Processors()
 	if err != nil {
 		return err
@@ -330,7 +328,7 @@ func (i *inventory) collectCPUs(sys *redfish.ComputerSystem, device *common.Devi
 }
 
 // collectDIMMs populates the device with memory component attributes
-func (i *inventory) collectDIMMs(sys *redfish.ComputerSystem, device *common.Device) (err error) {
+func (i *inventory) collectDIMMs(sys *gofishrf.ComputerSystem, device *common.Device) (err error) {
 	dimms, err := sys.Memory()
 	if err != nil {
 		return err

--- a/providers/redfish/main_test.go
+++ b/providers/redfish/main_test.go
@@ -3,7 +3,6 @@ package redfish
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -26,7 +25,6 @@ var (
 
 // jsonResponse returns the fixture json response for a request URI
 func jsonResponse(endpoint string) []byte {
-
 	jsonResponsesMap := map[string]string{
 		"/redfish/v1/":              fixturesDir + "/v1/serviceroot.json",
 		"/redfish/v1/UpdateService": fixturesDir + "/v1/updateservice.json",
@@ -44,7 +42,7 @@ func jsonResponse(endpoint string) []byte {
 
 	defer fh.Close()
 
-	b, err := ioutil.ReadAll(fh)
+	b, err := io.ReadAll(fh)
 	if err != nil {
 		log.Fatalf("%s, failed to read fixture: %s for endpoint: %s", err.Error(), jsonResponsesMap[endpoint], endpoint)
 	}
@@ -66,13 +64,11 @@ func TestMain(m *testing.M) {
 
 	mockBMCHost, _ = url.Parse(mockServer.URL)
 
-	mockClient = &Conn{Host: mockBMCHost.String(), User: "foo", Pass: "bar"}
+	mockClient = New(mockBMCHost.String(), "", "foo", "bar", logr.Discard())
 	err := mockClient.Open(context.TODO())
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	mockClient.Log = logr.Discard()
 
 	os.Exit(m.Run())
 }

--- a/providers/redfish/redfish.go
+++ b/providers/redfish/redfish.go
@@ -2,21 +2,15 @@ package redfish
 
 import (
 	"context"
-	"crypto/x509"
-	"fmt"
-	"net/http"
-	"os"
 	"strings"
-	"time"
 
-	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
-	"github.com/bmc-toolbox/bmclib/v2/internal/httpclient"
+	"github.com/bmc-toolbox/bmclib/v2/internal/redfishwrapper"
 	"github.com/bmc-toolbox/bmclib/v2/providers"
 	"github.com/go-logr/logr"
 	"github.com/jacobweinstock/registrar"
 	"github.com/pkg/errors"
-	"github.com/stmcginnis/gofish"
-	rf "github.com/stmcginnis/gofish/redfish"
+
+	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
 )
 
 const (
@@ -43,93 +37,29 @@ var (
 
 // Conn details for redfish client
 type Conn struct {
-	Host                 string
-	Port                 string
-	User                 string
-	Pass                 string
-	conn                 *gofish.APIClient
-	Log                  logr.Logger
-	httpClient           *http.Client
-	httpClientSetupFuncs []func(*http.Client)
+	redfishwrapper *redfishwrapper.Client
+	Log            logr.Logger
 }
 
-// Option is a function applied to a *Conn
-type Option func(*Conn)
-
-// WithHTTPClient returns an option that sets an HTTP client for the connecion
-func WithHTTPClient(cli *http.Client) Option {
-	return func(c *Conn) {
-		c.httpClient = cli
+// New returns connection with a redfish client initialized
+func New(host, port, user, pass string, log logr.Logger, opts ...redfishwrapper.Option) *Conn {
+	return &Conn{
+		Log:            log,
+		redfishwrapper: redfishwrapper.NewClient(host, port, user, pass, opts...),
 	}
-}
-
-// WithSecureTLS returns an option that enables secure TLS with an optional cert pool.
-func WithSecureTLS(rootCAs *x509.CertPool) Option {
-	return func(c *Conn) {
-		c.httpClientSetupFuncs = append(c.httpClientSetupFuncs, httpclient.SecureTLSOption(rootCAs))
-	}
-}
-
-// New returns a redfish *Conn
-func New(host, port, user, pass string, log logr.Logger, opts ...Option) *Conn {
-	conn := &Conn{
-		Host: host,
-		Port: port,
-		User: user,
-		Pass: pass,
-		Log:  log,
-	}
-	for _, opt := range opts {
-		opt(conn)
-	}
-	return conn
 }
 
 // Open a connection to a BMC via redfish
 func (c *Conn) Open(ctx context.Context) (err error) {
-	if !strings.HasPrefix(c.Host, "https://") && !strings.HasPrefix(c.Host, "http://") {
-		c.Host = "https://" + c.Host
-	}
-
-	config := gofish.ClientConfig{
-		Endpoint:   c.Host,
-		Username:   c.User,
-		Password:   c.Pass,
-		Insecure:   true,
-		HTTPClient: c.httpClient,
-	}
-
-	if config.HTTPClient == nil {
-		config.HTTPClient, err = httpclient.Build(c.httpClientSetupFuncs...)
-		if err != nil {
-			return err
-		}
-	} else {
-		for _, setupFunc := range c.httpClientSetupFuncs {
-			setupFunc(config.HTTPClient)
-		}
-	}
-
-	debug := os.Getenv("DEBUG_BMCLIB")
-	if debug == "true" {
-		config.DumpWriter = os.Stdout
-	}
-
-	c.conn, err = gofish.ConnectContext(ctx, config)
-	return err
+	return c.redfishwrapper.Open(ctx)
 }
 
 // Close a connection to a BMC via redfish
 func (c *Conn) Close(ctx context.Context) error {
-	if c.conn == nil {
-		return nil
-	}
-
-	c.conn.Logout()
-
-	return nil
+	return c.redfishwrapper.Close(ctx)
 }
 
+// Name returns the client provider name.
 func (c *Conn) Name() string {
 	return ProviderName
 }
@@ -158,181 +88,48 @@ func (c *Conn) Compatible(ctx context.Context) bool {
 	return err == nil
 }
 
-func (c *Conn) sessionActive(ctx context.Context) error {
-	if c.conn == nil {
-		return bmclibErrs.ErrNotAuthenticated
-	}
-
-	_, err := c.conn.GetSession()
+// DeviceVendorModel returns the device manufacturer and model attributes
+func (c *Conn) DeviceVendorModel(ctx context.Context) (vendor, model string, err error) {
+	systems, err := c.redfishwrapper.Systems()
 	if err != nil {
-		return errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+		return "", "", err
 	}
 
-	return nil
+	for _, sys := range systems {
+		if !compatibleOdataID(sys.ODataID, systemsOdataIDs) {
+			continue
+		}
+
+		return sys.Manufacturer, sys.Model, nil
+	}
+
+	return vendor, model, bmclibErrs.ErrRedfishSystemOdataID
 }
 
-// BmcReset powercycles the BMC
+// BmcReset power cycles the BMC
 func (c *Conn) BmcReset(ctx context.Context, resetType string) (ok bool, err error) {
-	if err := c.sessionActive(ctx); err != nil {
-		return false, err
-	}
-
-	managers, err := c.conn.Service.Managers()
-	if err != nil {
-		return false, err
-	}
-
-	for _, manager := range managers {
-		err = manager.Reset(rf.ResetType(resetType))
-		if err != nil {
-			return false, err
-		}
-	}
-
-	return true, nil
+	return c.redfishwrapper.BmcReset(ctx, resetType)
 }
 
 // PowerStateGet gets the power state of a BMC machine
 func (c *Conn) PowerStateGet(ctx context.Context) (state string, err error) {
-	if err := c.sessionActive(ctx); err != nil {
-		return "", err
-	}
-
-	return c.status(ctx)
+	return c.redfishwrapper.SystemPowerStatus(ctx)
 }
 
-// PowerSet sets the power state of a BMC via redfish
+// PowerSet sets the power state of a server
 func (c *Conn) PowerSet(ctx context.Context, state string) (ok bool, err error) {
-	if err := c.sessionActive(ctx); err != nil {
-		return false, err
-	}
-
 	switch strings.ToLower(state) {
 	case "on":
-		return c.on(ctx)
+		return c.redfishwrapper.SystemPowerOn(ctx)
 	case "off":
-		return c.hardoff(ctx)
+		return c.redfishwrapper.SystemForceOff(ctx)
 	case "soft":
-		return c.off(ctx)
+		return c.redfishwrapper.SystemPowerOff(ctx)
 	case "reset":
-		return c.reset(ctx)
+		return c.redfishwrapper.SystemReset(ctx)
 	case "cycle":
-		return c.cycle(ctx)
+		return c.redfishwrapper.SystemPowerCycle(ctx)
 	default:
 		return false, errors.New("unknown power action")
 	}
-}
-
-func (c *Conn) on(ctx context.Context) (ok bool, err error) {
-	service := c.conn.Service
-	ss, err := service.Systems()
-	if err != nil {
-		return false, err
-	}
-	for _, system := range ss {
-		if system.PowerState == rf.OnPowerState {
-			break
-		}
-		err = system.Reset(rf.OnResetType)
-		if err != nil {
-			return false, err
-		}
-	}
-	return true, nil
-}
-
-func (c *Conn) off(ctx context.Context) (ok bool, err error) {
-	service := c.conn.Service
-	ss, err := service.Systems()
-	if err != nil {
-		return false, err
-	}
-	for _, system := range ss {
-		if system.PowerState == rf.OffPowerState {
-			break
-		}
-		err = system.Reset(rf.GracefulShutdownResetType)
-		if err != nil {
-			return false, err
-		}
-	}
-	return false, nil
-}
-
-func (c *Conn) status(ctx context.Context) (result string, err error) {
-	service := c.conn.Service
-	ss, err := service.Systems()
-	if err != nil {
-		return "", err
-	}
-	for _, system := range ss {
-		return string(system.PowerState), nil
-	}
-	return "", errors.New("unable to retrieve status")
-}
-
-func (c *Conn) reset(ctx context.Context) (ok bool, err error) {
-	service := c.conn.Service
-	ss, err := service.Systems()
-	if err != nil {
-		return false, err
-	}
-	for _, system := range ss {
-		err = system.Reset(rf.PowerCycleResetType)
-		if err != nil {
-			c.Log.V(1).Info("warning", "msg", err.Error())
-			_, _ = c.off(ctx)
-			for wait := 1; wait < 10; wait++ {
-				status, _ := c.status(ctx)
-				if status == "off" {
-					break
-				}
-				time.Sleep(1 * time.Second)
-			}
-			_, errMsg := c.on(ctx)
-			return true, errMsg
-		}
-	}
-	return true, nil
-}
-
-func (r *Conn) hardoff(ctx context.Context) (ok bool, err error) {
-	service := r.conn.Service
-	ss, err := service.Systems()
-	if err != nil {
-		return false, err
-	}
-	for _, system := range ss {
-		if system.PowerState == rf.OffPowerState {
-			break
-		}
-		err = system.Reset(rf.ForceOffResetType)
-		if err != nil {
-			return false, err
-		}
-	}
-	return true, nil
-}
-
-func (r *Conn) cycle(ctx context.Context) (ok bool, err error) {
-	service := r.conn.Service
-	ss, err := service.Systems()
-	if err != nil {
-		return false, err
-	}
-	res, err := r.status(ctx)
-	if err != nil {
-		return false, fmt.Errorf("power cycle failed: unable to get current state")
-	}
-	if strings.ToLower(res) == "off" {
-		return false, fmt.Errorf("power cycle failed: Command not supported in present state: %v", res)
-	}
-
-	for _, system := range ss {
-		err = system.Reset(rf.ForceRestartResetType)
-		if err != nil {
-			return false, errors.WithMessage(err, "power cycle failed")
-		}
-	}
-	return true, nil
 }

--- a/providers/redfish/redfish.go
+++ b/providers/redfish/redfish.go
@@ -108,7 +108,7 @@ func (c *Conn) DeviceVendorModel(ctx context.Context) (vendor, model string, err
 
 // BmcReset power cycles the BMC
 func (c *Conn) BmcReset(ctx context.Context, resetType string) (ok bool, err error) {
-	return c.redfishwrapper.BmcReset(ctx, resetType)
+	return c.redfishwrapper.BMCReset(ctx, resetType)
 }
 
 // PowerStateGet gets the power state of a BMC machine

--- a/providers/redfish/user.go
+++ b/providers/redfish/user.go
@@ -19,11 +19,7 @@ var (
 
 // UserRead returns a list of enabled user accounts
 func (c *Conn) UserRead(ctx context.Context) (users []map[string]string, err error) {
-	if err := c.sessionActive(ctx); err != nil {
-		return nil, err
-	}
-
-	service, err := c.conn.Service.AccountService()
+	service, err := c.redfishwrapper.AccountService()
 	if err != nil {
 		return nil, err
 	}
@@ -52,11 +48,7 @@ func (c *Conn) UserRead(ctx context.Context) (users []map[string]string, err err
 
 // UserUpdate updates a user password and role
 func (c *Conn) UserUpdate(ctx context.Context, user, pass, role string) (ok bool, err error) {
-	if err := c.sessionActive(ctx); err != nil {
-		return false, err
-	}
-
-	service, err := c.conn.Service.AccountService()
+	service, err := c.redfishwrapper.AccountService()
 	if err != nil {
 		return false, err
 	}
@@ -101,11 +93,7 @@ func (c *Conn) UserCreate(ctx context.Context, user, pass, role string) (ok bool
 		return false, ErrUserPassParams
 	}
 
-	if err := c.sessionActive(ctx); err != nil {
-		return false, err
-	}
-
-	service, err := c.conn.Service.AccountService()
+	service, err := c.redfishwrapper.AccountService()
 	if err != nil {
 		return false, err
 	}
@@ -152,11 +140,7 @@ func (c *Conn) UserDelete(ctx context.Context, user string) (ok bool, err error)
 		return false, ErrUserPassParams
 	}
 
-	if err := c.sessionActive(ctx); err != nil {
-		return false, err
-	}
-
-	service, err := c.conn.Service.AccountService()
+	service, err := c.redfishwrapper.AccountService()
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## What does this PR implement/change/remove?

This is based on the feedback in https://github.com/bmc-toolbox/bmclib/pull/291

This moves the redfish client wrapping outside of the providers/redfish
package, these methods always check the redfish session is valid before
calling into the wrapped redfish library - gofish.

By moving this out, other providers can also import the redfishwrapper.
