### PR TITLE
Use renamed module for go-amt

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,7 +8,7 @@ queue_rule:
 pull_request_rules:
   - name: Automatic merge on approval
     conditions:
-      - base=v2
+      - base=main
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - check-success='lint'

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/bmc-toolbox/bmclib/v2
 go 1.18
 
 require (
-	github.com/ammmze/go-amt v0.0.4
 	github.com/bmc-toolbox/common v0.0.0-20221115135648-0b584f504396
 	github.com/bombsimon/logrusr/v2 v2.0.1
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.8
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/jacobweinstock/go-amt v0.0.0-20221125040441-53475f4ae023
 	github.com/jacobweinstock/registrar v0.4.6
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
@@ -22,9 +22,9 @@ require (
 require (
 	github.com/VictorLowther/simplexml v0.0.0-20180716164440-0bff93621230 // indirect
 	github.com/VictorLowther/soap v0.0.0-20150314151524-8e36fca84b22 // indirect
-	github.com/ammmze/wsman v0.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/jacobweinstock/wsman v0.0.0-20221125035617-2eae65734c77 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/satori/go.uuid v1.2.0 // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
@@ -34,7 +34,3 @@ require (
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/ammmze/go-amt => github.com/jacobweinstock/go-amt v0.0.0-20221115190754-36c39f21b864
-
-replace github.com/ammmze/wsman => github.com/jacobweinstock/wsman v0.0.0-20221115191137-e06ce6a5341d

--- a/go.sum
+++ b/go.sum
@@ -20,12 +20,12 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/jacobweinstock/go-amt v0.0.0-20221115190754-36c39f21b864 h1:zxKkYlCaG1m44m8t7gWFshvkV1R9lW7BtIqkbT1KN78=
-github.com/jacobweinstock/go-amt v0.0.0-20221115190754-36c39f21b864/go.mod h1:m5VV8U4094KLqoHHV319u18LVhIVCD5yGxeX6uM8IkE=
+github.com/jacobweinstock/go-amt v0.0.0-20221125040441-53475f4ae023 h1:ethqol+SkT5WtPI23GXlgQhRu/AYSHFTelrve/Acsr4=
+github.com/jacobweinstock/go-amt v0.0.0-20221125040441-53475f4ae023/go.mod h1:5SFONG5z/Tqp3iZuxd/k5p/YX2Gu7vVhxpLEmCLrJRQ=
 github.com/jacobweinstock/registrar v0.4.6 h1:0O3g2jT2Lx+Bf+yl4QsMUN48fVZxUpM3kS+NtIJ+ucw=
 github.com/jacobweinstock/registrar v0.4.6/go.mod h1:IDx65tQ7DLJ2UqiVjE1zo74jMZZfel9YZW8VrC26m6o=
-github.com/jacobweinstock/wsman v0.0.0-20221115191137-e06ce6a5341d h1:cqP9HwELK3GwWH5NZs4EFp8PzwwGVyVzwIng1cv5hX0=
-github.com/jacobweinstock/wsman v0.0.0-20221115191137-e06ce6a5341d/go.mod h1:TJdzGFrJZfTvF3Mu+tCLrXqap5/75eqPVguHUXbYoHA=
+github.com/jacobweinstock/wsman v0.0.0-20221125035617-2eae65734c77 h1:ks0g5tEGDIW4y+2vGQsfF1Um47u6Cw2AzH6sQC4uGD4=
+github.com/jacobweinstock/wsman v0.0.0-20221125035617-2eae65734c77/go.mod h1:XHdWy9hT+4XUjR4lnmA/129m9XGA2gh4EB+GbG/cC+c=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/providers/intelamt/intelamt.go
+++ b/providers/intelamt/intelamt.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ammmze/go-amt"
 	"github.com/bmc-toolbox/bmclib/v2/providers"
 	"github.com/go-logr/logr"
+	"github.com/jacobweinstock/go-amt"
 	"github.com/jacobweinstock/registrar"
 )
 

--- a/providers/intelamt/intelamt_test.go
+++ b/providers/intelamt/intelamt_test.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ammmze/go-amt"
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/jacobweinstock/go-amt"
 )
 
 type mock struct {


### PR DESCRIPTION
## What does this PR implement/change/remove?
The Go module of my fork of github.com/ammmze/wsman has been updated to github.com/jacobweinstock/wsman
This will allow imports of this to not have to specify replace directives in go.mod. The hope is that the upstream will accept the context changes and this won't be necessary.

Fixes #295 

### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes

```
```
