### PR TITLE
Supermicro redfish inventory support

### DIFF
--- a/providers/redfish/inventory.go
+++ b/providers/redfish/inventory.go
@@ -2,7 +2,6 @@ package redfish
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
@@ -30,11 +29,15 @@ var (
 	systemsOdataIDs = []string{
 		// Dells
 		"/redfish/v1/Systems/System.Embedded.1",
+		// Supermicros
+		"/redfish/v1/Systems/1",
 	}
 
 	// Supported Manager Odata IDs (BMCs)
 	managerOdataIDs = []string{
 		"/redfish/v1/Managers/iDRAC.Embedded.1",
+		// Supermicros
+		"/redfish/v1/Managers/1",
 	}
 )
 
@@ -55,9 +58,11 @@ func (c *Conn) Inventory(ctx context.Context) (device *common.Device, err error)
 		return nil, errors.Wrap(bmclibErrs.ErrRedfishSoftwareInventory, err.Error())
 	}
 
-	inv.softwareInventory, err = updateService.FirmwareInventories()
-	if err != nil {
-		return nil, errors.Wrap(bmclibErrs.ErrRedfishSoftwareInventory, err.Error())
+	if updateService != nil {
+		inv.softwareInventory, err = updateService.FirmwareInventories()
+		if err != nil && inv.failOnError {
+			return nil, errors.Wrap(bmclibErrs.ErrRedfishSoftwareInventory, err.Error())
+		}
 	}
 
 	// initialize device to be populated with inventory

--- a/providers/redfish/inventory_collect.go
+++ b/providers/redfish/inventory_collect.go
@@ -122,11 +122,14 @@ func (i *inventory) collectNICs(sys *gofishrf.ComputerSystem, device *common.Dev
 	}
 
 	for _, nic := range nics {
-
 		// collect network interface adaptor information
 		adapter, err := nic.NetworkAdapter()
 		if err != nil {
 			return err
+		}
+
+		if adapter == nil {
+			continue
 		}
 
 		n := &common.NIC{

--- a/providers/redfish/inventory_collect.go
+++ b/providers/redfish/inventory_collect.go
@@ -16,6 +16,7 @@ func (i *inventory) collectEnclosure(ch *gofishrf.Chassis, device *common.Device
 			Description: ch.Description,
 			Vendor:      common.FormatVendorName(ch.Manufacturer),
 			Model:       ch.Model,
+			Serial:      ch.SerialNumber,
 			Status: &common.Status{
 				Health: string(ch.Status.Health),
 				State:  string(ch.Status.State),
@@ -25,6 +26,10 @@ func (i *inventory) collectEnclosure(ch *gofishrf.Chassis, device *common.Device
 
 		ID:          ch.ID,
 		ChassisType: string(ch.ChassisType),
+	}
+
+	if e.Model == "" && ch.PartNumber != "" {
+		e.Model = ch.PartNumber
 	}
 
 	// include additional firmware attributes from redfish firmware inventory
@@ -167,18 +172,21 @@ func (i *inventory) collectNICs(sys *gofishrf.ComputerSystem, device *common.Dev
 }
 
 func (i *inventory) collectBIOS(sys *gofishrf.ComputerSystem, device *common.Device) (err error) {
+	device.BIOS = &common.BIOS{
+		Common: common.Common{
+			Firmware: &common.Firmware{
+				Installed: sys.BIOSVersion,
+			},
+		},
+	}
+
 	bios, err := sys.Bios()
 	if err != nil {
 		return err
 	}
 
-	device.BIOS = &common.BIOS{
-		Common: common.Common{
-			Description: bios.Description,
-			Firmware: &common.Firmware{
-				Installed: sys.BIOSVersion,
-			},
-		},
+	if bios != nil {
+		device.BIOS.Description = bios.Description
 	}
 
 	// include additional firmware attributes from redfish firmware inventory

--- a/providers/redfish/redfish.go
+++ b/providers/redfish/redfish.go
@@ -37,15 +37,17 @@ var (
 
 // Conn details for redfish client
 type Conn struct {
-	redfishwrapper *redfishwrapper.Client
-	Log            logr.Logger
+	redfishwrapper       *redfishwrapper.Client
+	failInventoryOnError bool
+	Log                  logr.Logger
 }
 
 // New returns connection with a redfish client initialized
 func New(host, port, user, pass string, log logr.Logger, opts ...redfishwrapper.Option) *Conn {
 	return &Conn{
-		Log:            log,
-		redfishwrapper: redfishwrapper.NewClient(host, port, user, pass, opts...),
+		Log:                  log,
+		failInventoryOnError: false,
+		redfishwrapper:       redfishwrapper.NewClient(host, port, user, pass, opts...),
 	}
 }
 


### PR DESCRIPTION
## What does this PR implement/change/remove?

Updates the Redfish provider inventory collection to work on Supermicro hardware,


[6029P-E1CR12L.json](https://gist.github.com/ca3232eb15552298e2b5558b6c387065)
[SYS-5019C-MR.json](https://gist.github.com/481e68f6687ae92180887f9864f4ec71)
[SYS-510T-MR.json](https://gist.github.com/71f35d7a9630428cd4947eedee74e1d3) 

### Checklist
- [ ] Tests added
- [X ] Similar commits squashed

### The HW vendor this change applies to (if applicable)

Supermicro

### The HW model number, product name this change applies to (if applicable)

Should work with all SMC hardware, tested on hardware variants,

SYS-5019C-MR
6029P-E1CR12L
SYS-510T-MR


## Description for changelog/release notes

```
Redfish inventory support for Supermicro hardware.
```
