### PR TITLE
fix panic in FilterForCompatible()

### DIFF
--- a/providers/intelamt/intelamt.go
+++ b/providers/intelamt/intelamt.go
@@ -107,7 +107,12 @@ func (c *Conn) Close() (err error) {
 
 // Compatible tests whether a BMC is compatible with the ipmitool provider
 func (c *Conn) Compatible(ctx context.Context) bool {
-	if _, err := c.client.IsPoweredOn(ctx); err != nil {
+	amtclient, ok := c.client.(*amt.Client)
+	if !ok || amtclient == nil {
+		return false
+	}
+
+	if _, err := amtclient.IsPoweredOn(ctx); err != nil {
 		return false
 	}
 


### PR DESCRIPTION

## What does this PR implement/change/remove?

This fixes a panic in the bmclib client init when calling `FilterForCompatible()` on the registered drivers.

```
panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x174ca88]

goroutine 126 [running]:
github.com/jacobweinstock/go-amt.getPowerStatus({0x1c3ccf8, 0xc00057a270}, 0xc0001c6d20?)
        /Users/jrebello/go/pkg/mod/github.com/jacobweinstock/go-amt@v0.0.0-20221125040441-53475f4ae023/power.go:50 +0x28
github.com/jacobweinstock/go-amt.isPoweredOn({0x1c3ccf8?, 0xc00057a270?}, 0x0)
        /Users/jrebello/go/pkg/mod/github.com/jacobweinstock/go-amt@v0.0.0-20221125040441-53475f4ae023/power.go:140 +0x28
github.com/jacobweinstock/go-amt.(*Client).IsPoweredOn(0x1c36a20?, {0x1c3ccf8?, 0xc00057a270?})
        /Users/jrebello/go/pkg/mod/github.com/jacobweinstock/go-amt@v0.0.0-20221125040441-53475f4ae023/client.go:69 +0x2f
github.com/bmc-toolbox/bmclib/v2/providers/intelamt.(*Conn).Compatible(0xc000735da0, {0x1c3ccf8, 0xc00057a270})
        /Users/jrebello/go/src/github.com/bmc-toolbox/bmclib.v2/providers/intelamt/intelamt.go:118 +0xde
github.com/jacobweinstock/registrar.Registry.FilterForCompatible.func1({0x1a11c00?, 0xc000735da0}, 0xc000735e00, 0x0?)
        /Users/jrebello/go/pkg/mod/github.com/jacobweinstock/registrar@v0.4.6/registrar.go:106 +0x278
created by github.com/jacobweinstock/registrar.Registry.FilterForCompatible
        /Users/jrebello/go/pkg/mod/github.com/jacobweinstock/registrar@v0.4.6/registrar.go:103 +0x252
exit status 2
```


