### PR TITLE
Rework intel amt provider to not panic:

### DIFF
--- a/providers/intelamt/intelamt_test.go
+++ b/providers/intelamt/intelamt_test.go
@@ -47,17 +47,6 @@ func (m *mock) SetPXE(ctx context.Context) error {
 	return m.errSetPXE
 }
 
-func TestOpen(t *testing.T) {
-	conn := &Conn{client: &mock{}}
-	if err := conn.Open(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	conn = &Conn{}
-	if err := conn.Open(context.Background()); err == nil {
-		t.Fatal("expected error, got nil")
-	}
-}
-
 func TestClose(t *testing.T) {
 	conn := &Conn{client: &mock{}}
 	if err := conn.Close(); err != nil {
@@ -176,30 +165,6 @@ func TestPowerSet(t *testing.T) {
 			if err != nil && tt.err == nil {
 				t.Fatalf("expected nil error, got: %v", err)
 			}
-			if diff := cmp.Diff(got, tt.want); diff != "" {
-				t.Fatal(diff)
-			}
-		})
-	}
-}
-
-func TestCompatible(t *testing.T) {
-	tests := map[string]struct {
-		want bool
-	}{
-		"compatible":     {want: true},
-		"not compatible": {want: false},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			var err error
-			if !tt.want {
-				err = errors.New("not compatible")
-			}
-			m := &mock{errIsPoweredOn: err}
-			conn := &Conn{client: m}
-			got := conn.Compatible(context.Background())
 			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Fatal(diff)
 			}


### PR DESCRIPTION
## What does this PR implement/change/remove?
Panics were happening because of not handling return errors from `amt.NewClient`.

### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)
Intel AMT

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes
Fix IntelAMT provider panics.
```
```
