### PR TITLE
Redfish versions param

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,54 @@ import (
 
 More sample code can be found in [examples](./examples/)
 
-### Versions
+### BMC connections
+
+bmclib performs queries on BMCs using [multiple `drivers`](https://github.com/bmc-toolbox/bmclib/blob/main/bmc/connection.go#L30),
+these `drivers` are the various services exposed by a BMC - `redfish` `IPMI` `SSH` and `vendor API` which is basically a custom vendor API endpoint.
+
+The bmclib client determines which driver to use for an action like `Power cycle` or `Create user`
+based on its availability or through a compatibility test (when enabled).
+
+When querying multiple BMCs through bmclib its often useful to to limit the BMCs and
+drivers that bmclib will attempt to use to connect, the options to limit or filter
+out BMCs are described below,
+
+Query just using the `redfish` endpoint.
+```
+cl := bmclib.NewClient("192.168.1.1", "", "admin", "hunter2")
+cl.Registry.Drivers = cl.Registry.Using("redfish")
+```
+
+Query using the `redfish` endpoint and fall back to `IPMI`
+```
+client := bmclib.NewClient("192.168.1.1", "", "admin", "hunter2")
+
+// overwrite registered drivers by appending Redfish, IPMI drivers in order
+drivers := append(registrar.Drivers{}, bmcClient.Registry.Using("redfish")...)
+drivers = append(drivers, bmcClient.Registry.Using("ipmi")...)
+client.Registry.Drivers = driver
+```
+
+Filter drivers to query based on compatibility, this will attempt to check if the driver is
+[compatible](https://github.com/bmc-toolbox/bmclib/blob/main/providers/redfish/redfish.go#L70)
+ideally, this method should be invoked when the client is ready to perform a BMC action.
+```
+client := bmclib.NewClient("192.168.1.1", "", "admin", "hunter2")
+client.Registry.Drivers = cl.Registry.FilterForCompatible(ctx)
+```
+
+Ignore the Redfish endpoint completely on BMCs running a specific Redfish version.
+
+Note: this version should match the one returned through `curl -k  "https://<BMC IP>/redfish/v1" | jq .RedfishVersion`
+```
+opt := bmclib.WithRedfishVersionsNotCompatible([]string{"1.5.0"})
+
+client := bmclib.NewClient("192.168.1.1", "", "admin", "hunter2", opt...)
+cl.Registry.Drivers = cl.Registry.FilterForCompatible(ctx)
+```
+
+
+### bmclib versions
 
 The current bmclib version is `v2` and is being developed on the `main` branch.
 

--- a/client_test.go
+++ b/client_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/bmc-toolbox/bmclib/v2/logging"
+	"gopkg.in/go-playground/assert.v1"
 )
 
 func TestBMC(t *testing.T) {
@@ -52,4 +53,31 @@ func TestBMC(t *testing.T) {
 	t.Logf("metadata: %+v", cl.GetMetadata())
 
 	t.Fatal()
+}
+
+func TestWithRedfishVersionsNotCompatible(t *testing.T) {
+	host := "127.0.0.1"
+	port := "623"
+	user := "ADMIN"
+	pass := "ADMIN"
+
+	tests := []struct {
+		name     string
+		versions []string
+	}{
+		{
+			"no versions",
+			[]string{},
+		},
+		{
+			"with versions",
+			[]string{"1.2.3", "4.5.6"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cl := NewClient(host, port, user, pass, WithRedfishVersionsNotCompatible(tt.versions))
+			assert.Equal(t, tt.versions, cl.redfishVersionsNotCompatible)
+		})
+	}
 }

--- a/examples/inventory/main.go
+++ b/examples/inventory/main.go
@@ -25,7 +25,7 @@ func main() {
 	pass := flag.String("password", "", "Username to login with")
 	host := flag.String("host", "", "BMC hostname to connect to")
 	port := flag.Int("port", 443, "BMC port to connect to")
-	incompatibleRedfishVersions := flag.String("incompat-redfish-versions", "", "Comma separated list of redfish versions to deem incompatible")
+	incompatibleRedfishVersions := flag.String("incompatible-redfish-versions", "", "Comma separated list of redfish versions to deem incompatible")
 	withSecureTLS := flag.Bool("secure-tls", false, "Enable secure TLS")
 	certPoolFile := flag.String("cert-pool", "", "Path to an file containing x509 CAs. An empty string uses the system CAs. Only takes effect when --secure-tls=true")
 	flag.Parse()

--- a/examples/inventory/main.go
+++ b/examples/inventory/main.go
@@ -6,9 +6,10 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	bmclib "github.com/bmc-toolbox/bmclib/v2"
@@ -24,6 +25,7 @@ func main() {
 	pass := flag.String("password", "", "Username to login with")
 	host := flag.String("host", "", "BMC hostname to connect to")
 	port := flag.Int("port", 443, "BMC port to connect to")
+	incompatibleRedfishVersions := flag.String("incompat-redfish-versions", "", "Comma separated list of redfish versions to deem incompatible")
 	withSecureTLS := flag.Bool("secure-tls", false, "Enable secure TLS")
 	certPoolFile := flag.String("cert-pool", "", "Path to an file containing x509 CAs. An empty string uses the system CAs. Only takes effect when --secure-tls=true")
 	flag.Parse()
@@ -38,7 +40,7 @@ func main() {
 		var pool *x509.CertPool
 		if *certPoolFile != "" {
 			pool = x509.NewCertPool()
-			data, err := ioutil.ReadFile(*certPoolFile)
+			data, err := os.ReadFile(*certPoolFile)
 			if err != nil {
 				l.Fatal(err)
 			}
@@ -48,8 +50,16 @@ func main() {
 		clientOpts = append(clientOpts, bmclib.WithSecureTLS(pool))
 	}
 
+	if len(*incompatibleRedfishVersions) > 0 {
+		// blacklist a redfish version
+		clientOpts = append(
+			clientOpts,
+			bmclib.WithRedfishVersionsNotCompatible(strings.Split(*incompatibleRedfishVersions, ",")))
+	}
+
 	cl := bmclib.NewClient(*host, strconv.Itoa(*port), *user, *pass, clientOpts...)
-	//	cl.Registry.Drivers = cl.Registry.Using("redfish")
+
+	cl.Registry.Drivers = cl.Registry.FilterForCompatible(ctx)
 
 	err := cl.Open(ctx)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/stmcginnis/gofish v0.13.1-0.20221107140645-5cc43fad050f
 	github.com/stretchr/testify v1.7.2
 	golang.org/x/crypto v0.1.0
+	golang.org/x/exp v0.0.0-20230127130021-4ca2cb1a16b7
 	golang.org/x/net v0.1.0
 	gopkg.in/go-playground/assert.v1 v1.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
+golang.org/x/exp v0.0.0-20230127130021-4ca2cb1a16b7 h1:o7Ps2IYdzLRolS9/nadqeMSHpa9k8pu8u+VKBFUG7cQ=
+golang.org/x/exp v0.0.0-20230127130021-4ca2cb1a16b7/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=

--- a/internal/redfishwrapper/client_test.go
+++ b/internal/redfishwrapper/client_test.go
@@ -1,0 +1,33 @@
+package redfishwrapper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithVersionsNotCompatible(t *testing.T) {
+	host := "127.0.0.1"
+	user := "ADMIN"
+	pass := "ADMIN"
+
+	tests := []struct {
+		name     string
+		versions []string
+	}{
+		{
+			"no versions",
+			[]string{},
+		},
+		{
+			"with versions",
+			[]string{"1.2.3", "4.5.6"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewClient(host, "", user, pass, WithVersionsNotCompatible(tt.versions))
+			assert.Equal(t, tt.versions, client.versionsNotCompatible)
+		})
+	}
+}

--- a/providers/redfish/redfish.go
+++ b/providers/redfish/redfish.go
@@ -80,6 +80,15 @@ func (c *Conn) Compatible(ctx context.Context) bool {
 	}
 	defer c.Close(ctx)
 
+	if !c.redfishwrapper.VersionCompatible() {
+		c.Log.V(2).WithValues(
+			"provider",
+			c.Name(),
+		).Info("info", bmclibErrs.ErrCompatibilityCheck.Error(), "incompatible redfish version")
+
+		return false
+	}
+
 	_, err = c.PowerStateGet(ctx)
 	if err != nil {
 		c.Log.V(2).WithValues(
@@ -138,6 +147,6 @@ func (c *Conn) PowerSet(ctx context.Context, state string) (ok bool, err error) 
 }
 
 // BootDeviceSet sets the boot device
-func (c * Conn) BootDeviceSet(ctx context.Context, bootDevice string, setPersistent, efiBoot bool) (ok bool, err error) {
+func (c *Conn) BootDeviceSet(ctx context.Context, bootDevice string, setPersistent, efiBoot bool) (ok bool, err error) {
 	return c.redfishwrapper.SystemBootDeviceSet(ctx, bootDevice, setPersistent, efiBoot)
 }


### PR DESCRIPTION
## What does this PR implement/change/remove?

This enables the client to optionally define Redfish versions its not compatible
with, giving the user the option to ignore the Redfish endpoint on BMCs
for cases where the Redfish version is too old or is known to not have an expected functionality.

### Checklist
- [X] Tests added
- [X] Similar commits squashed

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes

```
- Adds the incompatible Redfish versions option parameter. 
```
