### PR TITLE
redfish: added support for adapters with multiple ports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bmc-toolbox/bmclib/v2
 go 1.18
 
 require (
-	github.com/bmc-toolbox/common v0.0.0-20221115135648-0b584f504396
+	github.com/bmc-toolbox/common v0.0.0-20230220061748-93ff001f4a1d
 	github.com/bombsimon/logrusr/v2 v2.0.1
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.8

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/VictorLowther/simplexml v0.0.0-20180716164440-0bff93621230 h1:t95Grn2
 github.com/VictorLowther/simplexml v0.0.0-20180716164440-0bff93621230/go.mod h1:t2EzW1qybnPDQ3LR/GgeF0GOzHUXT5IVMLP2gkW1cmc=
 github.com/VictorLowther/soap v0.0.0-20150314151524-8e36fca84b22 h1:a0MBqYm44o0NcthLKCljZHe1mxlN6oahCQHHThnSwB4=
 github.com/VictorLowther/soap v0.0.0-20150314151524-8e36fca84b22/go.mod h1:/B7V22rcz4860iDqstGvia/2+IYWXf3/JdQCVd/1D2A=
-github.com/bmc-toolbox/common v0.0.0-20221115135648-0b584f504396 h1:MAIYVFtt/Hnhx0Cth6T9pnLTJnZKppzi7LHue4KpPtg=
-github.com/bmc-toolbox/common v0.0.0-20221115135648-0b584f504396/go.mod h1:SY//n1PJjZfbFbmAsB6GvEKbc7UXz3d30s3kWxfJQ/c=
+github.com/bmc-toolbox/common v0.0.0-20230220061748-93ff001f4a1d h1:cQ30Wa8mhLzK1TSOG+g3FlneIsXtFgun61mmPwVPmD0=
+github.com/bmc-toolbox/common v0.0.0-20230220061748-93ff001f4a1d/go.mod h1:SY//n1PJjZfbFbmAsB6GvEKbc7UXz3d30s3kWxfJQ/c=
 github.com/bombsimon/logrusr/v2 v2.0.1 h1:1VgxVNQMCvjirZIYaT9JYn6sAVGVEcNtRE0y4mvaOAM=
 github.com/bombsimon/logrusr/v2 v2.0.1/go.mod h1:ByVAX+vHdLGAfdroiMg6q0zgq2FODY2lc5YJvzmOJio=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/providers/redfish/inventory_collect_test.go
+++ b/providers/redfish/inventory_collect_test.go
@@ -1,0 +1,177 @@
+package redfish
+
+import (
+	"github.com/bmc-toolbox/common"
+	common2 "github.com/stmcginnis/gofish/common"
+	gofishrf "github.com/stmcginnis/gofish/redfish"
+	"reflect"
+	"testing"
+)
+
+func Test_inventory_collectNetworkPortInfo(t *testing.T) {
+
+	testAdapter := &gofishrf.NetworkAdapter{
+		Manufacturer: "Acme",
+		Model:        "Anvil 3000",
+	}
+	testNetworkPort := &gofishrf.NetworkPort{
+		Entity:                     common2.Entity{ID: "NetworkPort-1"},
+		Description:                "NetworkPort One",
+		VendorID:                   "Vendor-ID",
+		PhysicalPortNumber:         "10",
+		LinkStatus:                 "Up",
+		ActiveLinkTechnology:       "Ethernet",
+		CurrentLinkSpeedMbps:       1000,
+		AssociatedNetworkAddresses: []string{"98:E7:43:00:01:0A"},
+	}
+	testFirmwareVersion := "1.2.3"
+
+	wNicPortOnlyAdapter := &common.NICPort{Common: common.Common{Vendor: testAdapter.Manufacturer, Model: testAdapter.Model}}
+	wNicPortOnlyNPort := &common.NICPort{
+		Common: common.Common{
+			Description: testNetworkPort.Description,
+			PCIVendorID: testNetworkPort.VendorID,
+			Status: &common.Status{
+				Health: string(testNetworkPort.Status.Health),
+				State:  string(testNetworkPort.Status.State),
+			},
+		},
+		ID:                   testNetworkPort.ID,
+		PhysicalID:           testNetworkPort.PhysicalPortNumber,
+		LinkStatus:           string(testNetworkPort.LinkStatus),
+		ActiveLinkTechnology: string(testNetworkPort.ActiveLinkTechnology),
+		SpeedBits:            1000000000,
+		MacAddress:           testNetworkPort.AssociatedNetworkAddresses[0],
+	}
+	wNicPortOnlyFirmware := &common.NICPort{Common: common.Common{Firmware: &common.Firmware{Installed: testFirmwareVersion}}}
+	wNicPortFull := &common.NICPort{
+		Common: common.Common{
+			Description: testNetworkPort.Description,
+			Vendor:      testAdapter.Manufacturer,
+			Model:       testAdapter.Model,
+			PCIVendorID: testNetworkPort.VendorID,
+			Firmware:    &common.Firmware{Installed: testFirmwareVersion},
+			Status: &common.Status{
+				Health: string(testNetworkPort.Status.Health),
+				State:  string(testNetworkPort.Status.State),
+			},
+		},
+		ID:                   testNetworkPort.ID,
+		PhysicalID:           testNetworkPort.PhysicalPortNumber,
+		LinkStatus:           string(testNetworkPort.LinkStatus),
+		ActiveLinkTechnology: string(testNetworkPort.ActiveLinkTechnology),
+		SpeedBits:            1000000000,
+		MacAddress:           testNetworkPort.AssociatedNetworkAddresses[0],
+	}
+
+	tests := []struct {
+		name          string
+		nicPort       *common.NICPort
+		adapter       *gofishrf.NetworkAdapter
+		networkPort   *gofishrf.NetworkPort
+		firmware      string
+		wantedNicPort *common.NICPort
+	}{
+		{name: "nil"},
+		{name: "empty", nicPort: &common.NICPort{}, wantedNicPort: &common.NICPort{}},
+		{
+			name:          "only adapter",
+			nicPort:       &common.NICPort{},
+			adapter:       testAdapter,
+			wantedNicPort: wNicPortOnlyAdapter,
+		},
+		{
+			name:          "only network port",
+			nicPort:       &common.NICPort{},
+			networkPort:   testNetworkPort,
+			wantedNicPort: wNicPortOnlyNPort,
+		},
+		{
+			name:          "only firmware",
+			nicPort:       &common.NICPort{},
+			firmware:      testFirmwareVersion,
+			wantedNicPort: wNicPortOnlyFirmware,
+		},
+		{
+			name:          "full",
+			nicPort:       &common.NICPort{},
+			adapter:       testAdapter,
+			networkPort:   testNetworkPort,
+			firmware:      testFirmwareVersion,
+			wantedNicPort: wNicPortFull,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &inventory{}
+			i.collectNetworkPortInfo(tt.nicPort, tt.adapter, tt.networkPort, tt.firmware)
+			if !reflect.DeepEqual(tt.nicPort, tt.wantedNicPort) {
+				t.Errorf("collectNetworkPortInfo() gotNicPort = %v, want %v", tt.nicPort, tt.wantedNicPort)
+			}
+		})
+	}
+
+}
+
+func Test_inventory_collectEthernetInfo(t *testing.T) {
+	testNicPortID := "test NIC port ID"
+	testEthernetID := "test NIC port ID ethernet"
+	testNicPort := &common.NICPort{
+		ID: testNicPortID,
+	}
+	testUnmatchingEthList := []*gofishrf.EthernetInterface{
+		{Entity: common2.Entity{ID: "other ID"}},
+		{Entity: common2.Entity{ID: "another one"}},
+	}
+	testMatchingEth := &gofishrf.EthernetInterface{
+		Entity:      common2.Entity{ID: testEthernetID},
+		Description: "Ethernet Interface",
+		Status: common2.Status{
+			Health: "OK",
+			State:  "Enabled",
+		},
+		SpeedMbps:  10000,
+		AutoNeg:    true,
+		MTUSize:    1500,
+		MACAddress: "f6:a9:26:e3:e6:32",
+	}
+	testMatchingEthList := append(testUnmatchingEthList, testMatchingEth)
+
+	wNicPortFull := &common.NICPort{
+		Common: common.Common{
+			Description: testMatchingEth.Description,
+			Status: &common.Status{
+				Health: string(testMatchingEth.Status.Health),
+				State:  string(testMatchingEth.Status.State),
+			},
+		},
+		ID:         testMatchingEth.ID,
+		SpeedBits:  10000000000,
+		AutoNeg:    testMatchingEth.AutoNeg,
+		MTUSize:    testMatchingEth.MTUSize,
+		MacAddress: testMatchingEth.MACAddress,
+	}
+
+	tests := []struct {
+		name               string
+		nicPort            *common.NICPort
+		ethernetInterfaces []*gofishrf.EthernetInterface
+		wantedNicPort      *common.NICPort
+	}{
+		{name: "nil"},
+		{name: "empty", nicPort: testNicPort, wantedNicPort: testNicPort},
+		{name: "empty ethernet list", nicPort: testNicPort, ethernetInterfaces: []*gofishrf.EthernetInterface{}, wantedNicPort: testNicPort},
+		{name: "unmatching ethernet list", nicPort: testNicPort, ethernetInterfaces: testUnmatchingEthList, wantedNicPort: testNicPort},
+		{
+			name:               "full",
+			nicPort:            testNicPort,
+			ethernetInterfaces: testMatchingEthList,
+			wantedNicPort:      wNicPortFull},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &inventory{}
+			i.collectEthernetInfo(tt.nicPort, tt.ethernetInterfaces)
+		})
+	}
+}


### PR DESCRIPTION
Reworked according to discussion in https://github.com/bmc-toolbox/bmclib/pull/308.

## What does this PR implement/change/remove?
Multiple ports in the same network adapter are now inventoried as different NICPorts under the same NIC.
Added some network port fields.
Fixed network speed conversion.
Added unit tests for network port and ethernet interface processing.

## Description for changelog/release notes
```
Added support for NICs with multiple ports.
Fixed network speed conversion.
```