### PR TITLE
Connection timeouts

### DIFF
--- a/bmc/connection.go
+++ b/bmc/connection.go
@@ -3,6 +3,7 @@ package bmc
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
@@ -27,7 +28,7 @@ type connectionProviders struct {
 // OpenConnectionFromInterfaces will try all opener interfaces and remove failed ones.
 // The reason failed ones need to be removed is so that when other methods are called (like powerstate)
 // implementations that have connections wont nil pointer error when their connection fails.
-func OpenConnectionFromInterfaces(ctx context.Context, generic []interface{}) (opened []interface{}, metadata Metadata, err error) {
+func OpenConnectionFromInterfaces(ctx context.Context, timeout time.Duration, generic []interface{}) (opened []interface{}, metadata Metadata, err error) {
 	var metadataLocal Metadata
 Loop:
 	for _, elem := range generic {
@@ -44,13 +45,19 @@ Loop:
 		switch p := elem.(type) {
 		case Opener:
 			metadataLocal.ProvidersAttempted = append(metadataLocal.ProvidersAttempted, providerName)
+
+			ctx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+
 			er := p.Open(ctx)
 			if er != nil {
 				err = multierror.Append(err, errors.WithMessagef(er, "provider: %v", providerName))
 				continue
 			}
+
 			opened = append(opened, elem)
 			metadataLocal.SuccessfulOpenConns = append(metadataLocal.SuccessfulOpenConns, providerName)
+
 		default:
 			e := fmt.Sprintf("not a Opener implementation: %T", p)
 			err = multierror.Append(err, errors.New(e))

--- a/client.go
+++ b/client.go
@@ -78,6 +78,7 @@ func WithHTTPClient(c *http.Client) Option {
 }
 
 // WithConnectTimeout sets the timeout when connecting to a BMC to create a new session.
+// This timeout value applies for each provider.
 // When not defined the default connection timeout applies.
 func WithConnectTimeout(t time.Duration) Option {
 	return func(args *Client) {

--- a/client_test.go
+++ b/client_test.go
@@ -81,3 +81,30 @@ func TestWithRedfishVersionsNotCompatible(t *testing.T) {
 		})
 	}
 }
+
+func TestWithConnectionTimeout(t *testing.T) {
+	host := "127.0.0.1"
+	port := "623"
+	user := "ADMIN"
+	pass := "ADMIN"
+
+	tests := []struct {
+		name    string
+		timeout time.Duration
+	}{
+		{
+			"no connection timeout",
+			0,
+		},
+		{
+			"with timeout",
+			5 * time.Second,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cl := NewClient(host, port, user, pass, WithConnectTimeout(tt.timeout))
+			assert.Equal(t, tt.timeout, cl.connectTimeout)
+		})
+	}
+}

--- a/providers/intelamt/intelamt.go
+++ b/providers/intelamt/intelamt.go
@@ -82,25 +82,13 @@ func (c *Conn) Open(ctx context.Context) (err error) {
 		Logger: c.Log,
 	}
 
-	connChan := make(chan error)
-
-	// since we can't pass a context into amt.NewClient()
-	// spawn a routine and watch for timeouts in the select below.
-	go func() {
-		var err error
-		// amt.NewClient is used here in Open instead of in New because amt.NewClient makes a connection to the BMC.
-		c.client, err = amt.NewClient(conn)
-		connChan <- err
-	}()
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case err := <-connChan:
-		if err != nil {
-			return err
-		}
+	// amt.NewClient is used here in Open instead of in New because amt.NewClient makes a connection to the BMC.
+	client, err := amt.NewClient(conn)
+	if err != nil {
+		return err
 	}
+
+	c.client = client
 
 	return nil
 }

--- a/providers/intelamt/intelamt.go
+++ b/providers/intelamt/intelamt.go
@@ -82,7 +82,7 @@ func (c *Conn) Open(ctx context.Context) (err error) {
 		Logger: c.Log,
 	}
 
-	connChan := make(chan error, 0)
+	connChan := make(chan error)
 
 	// since we can't pass a context into amt.NewClient()
 	// spawn a routine and watch for timeouts in the select below.


### PR DESCRIPTION
## What does this PR implement/change/remove?

Wraps the Intel AMT provider connection setup to return on context deadline.

Adds a connection timeout parameter for opening connection,

As of now, a user may choose to pass in a context deadline into the bmclib client, which
is shared between all the [bmclib providers](https://github.com/bmc-toolbox/bmclib/blob/main/client.go#L115) that is - when creating an a new connection/session on a BMC.

The shared timeout value entails that a single provider can attempt to connect for the the whole timeout deadline, and so leaving the other providers (which may be the successful ones) with much lesser time to connect and carry out their operation.

The `WithConnectTimeout()` client option sets the timeout when connecting to a BMC to create a new session.
When not defined the deadline value passed in (if any) through the context applies.

This timeout value will best work when its lesser than the passed in context deadline value.


### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)
 - Intel AMT

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes

```
```
