### PR TITLE
Add timeouts everywhere

### DIFF
--- a/bmc/boot_device.go
+++ b/bmc/boot_device.go
@@ -3,6 +3,7 @@ package bmc
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
@@ -23,9 +24,9 @@ type bootDeviceProviders struct {
 //
 // setPersistent persists the next boot device.
 // efiBoot sets up the device to boot off UEFI instead of legacy.
-func setBootDevice(ctx context.Context, bootDevice string, setPersistent, efiBoot bool, b []bootDeviceProviders) (ok bool, metadata Metadata, err error) {
+func setBootDevice(ctx context.Context, timeout time.Duration, bootDevice string, setPersistent, efiBoot bool, b []bootDeviceProviders) (ok bool, metadata Metadata, err error) {
 	var metadataLocal Metadata
-Loop:
+
 	for _, elem := range b {
 		if elem.bootDeviceSetter == nil {
 			continue
@@ -33,9 +34,12 @@ Loop:
 		select {
 		case <-ctx.Done():
 			err = multierror.Append(err, ctx.Err())
-			break Loop
+
+			return false, metadata, err
 		default:
 			metadataLocal.ProvidersAttempted = append(metadataLocal.ProvidersAttempted, elem.name)
+			ctx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
 			ok, setErr := elem.bootDeviceSetter.BootDeviceSet(ctx, bootDevice, setPersistent, efiBoot)
 			if setErr != nil {
 				err = multierror.Append(err, errors.WithMessagef(setErr, "provider: %v", elem.name))
@@ -53,7 +57,7 @@ Loop:
 }
 
 // SetBootDeviceFromInterfaces identifies implementations of the BootDeviceSetter interface and passes the found implementations to the setBootDevice() wrapper
-func SetBootDeviceFromInterfaces(ctx context.Context, bootDevice string, setPersistent, efiBoot bool, generic []interface{}) (ok bool, metadata Metadata, err error) {
+func SetBootDeviceFromInterfaces(ctx context.Context, timeout time.Duration, bootDevice string, setPersistent, efiBoot bool, generic []interface{}) (ok bool, metadata Metadata, err error) {
 	bdSetters := make([]bootDeviceProviders, 0)
 	for _, elem := range generic {
 		temp := bootDeviceProviders{name: getProviderName(elem)}
@@ -69,5 +73,5 @@ func SetBootDeviceFromInterfaces(ctx context.Context, bootDevice string, setPers
 	if len(bdSetters) == 0 {
 		return ok, metadata, multierror.Append(err, errors.New("no BootDeviceSetter implementations found"))
 	}
-	return setBootDevice(ctx, bootDevice, setPersistent, efiBoot, bdSetters)
+	return setBootDevice(ctx, timeout, bootDevice, setPersistent, efiBoot, bdSetters)
 }

--- a/bmc/boot_device_test.go
+++ b/bmc/boot_device_test.go
@@ -41,7 +41,7 @@ func TestSetBootDevice(t *testing.T) {
 		"success":               {bootDevice: "pxe", want: true},
 		"not ok return":         {bootDevice: "pxe", want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider, failed to set boot device"), errors.New("failed to set boot device")}}},
 		"error":                 {bootDevice: "pxe", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider: boot device set failed"), errors.New("failed to set boot device")}}},
-		"error context timeout": {bootDevice: "pxe", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to set boot device")}}, ctxTimeout: time.Nanosecond * 1},
+		"error context timeout": {bootDevice: "pxe", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded")}}, ctxTimeout: time.Nanosecond * 1},
 	}
 
 	for name, tc := range testCases {
@@ -53,7 +53,7 @@ func TestSetBootDevice(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, _, err := setBootDevice(ctx, tc.bootDevice, false, false, []bootDeviceProviders{{"test provider", &testImplementation}})
+			result, _, err := setBootDevice(ctx, 0, tc.bootDevice, false, false, []bootDeviceProviders{{"test provider", &testImplementation}})
 			if err != nil {
 				if tc.err != nil {
 					diff := cmp.Diff(err.Error(), tc.err.Error())
@@ -97,7 +97,7 @@ func TestSetBootDeviceFromInterfaces(t *testing.T) {
 				generic = []interface{}{&testImplementation}
 			}
 			expectedResult := tc.want
-			result, metadata, err := SetBootDeviceFromInterfaces(context.Background(), tc.bootDevice, false, false, generic)
+			result, metadata, err := SetBootDeviceFromInterfaces(context.Background(), 0, tc.bootDevice, false, false, generic)
 			if err != nil {
 				diff := cmp.Diff(tc.err.Error(), err.Error())
 				if diff != "" {

--- a/bmc/connection_test.go
+++ b/bmc/connection_test.go
@@ -118,7 +118,7 @@ func TestCloseConnection(t *testing.T) {
 		ctxTimeout   time.Duration
 	}{
 		"success":                {},
-		"error context deadline": {err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to close connection")}}, ctxTimeout: time.Nanosecond * 1},
+		"error context deadline": {err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded")}}, ctxTimeout: time.Nanosecond * 1},
 		"error":                  {makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider: close connection failed"), errors.New("failed to close connection")}}},
 	}
 
@@ -132,7 +132,7 @@ func TestCloseConnection(t *testing.T) {
 			defer cancel()
 			_, err := closeConnection(ctx, []connectionProviders{{"test provider", &testImplementation}})
 			if err != nil {
-				diff := cmp.Diff(err.Error(), tc.err.Error())
+				diff := cmp.Diff(tc.err.Error(), err.Error())
 				if diff != "" {
 					t.Fatal(diff)
 				}

--- a/bmc/firmware.go
+++ b/bmc/firmware.go
@@ -35,7 +35,7 @@ type firmwareInstallerProvider struct {
 // firmwareInstall uploads and initiates firmware update for the component
 func firmwareInstall(ctx context.Context, component, applyAt string, forceInstall bool, reader io.Reader, generic []firmwareInstallerProvider) (taskID string, metadata Metadata, err error) {
 	var metadataLocal Metadata
-Loop:
+
 	for _, elem := range generic {
 		if elem.FirmwareInstaller == nil {
 			continue
@@ -43,7 +43,8 @@ Loop:
 		select {
 		case <-ctx.Done():
 			err = multierror.Append(err, ctx.Err())
-			break Loop
+
+			return taskID, metadata, err
 		default:
 			metadataLocal.ProvidersAttempted = append(metadataLocal.ProvidersAttempted, elem.name)
 			taskID, vErr := elem.FirmwareInstall(ctx, component, applyAt, forceInstall, reader)
@@ -111,7 +112,7 @@ type firmwareInstallVerifierProvider struct {
 // firmwareInstallStatus returns the status of the firmware install process
 func firmwareInstallStatus(ctx context.Context, installVersion, component, taskID string, generic []firmwareInstallVerifierProvider) (status string, metadata Metadata, err error) {
 	var metadataLocal Metadata
-Loop:
+
 	for _, elem := range generic {
 		if elem.FirmwareInstallVerifier == nil {
 			continue
@@ -119,7 +120,8 @@ Loop:
 		select {
 		case <-ctx.Done():
 			err = multierror.Append(err, ctx.Err())
-			break Loop
+
+			return status, metadata, err
 		default:
 			metadataLocal.ProvidersAttempted = append(metadataLocal.ProvidersAttempted, elem.name)
 			status, vErr := elem.FirmwareInstallStatus(ctx, installVersion, component, taskID)

--- a/bmc/inventory.go
+++ b/bmc/inventory.go
@@ -24,7 +24,7 @@ type inventoryGetterProvider struct {
 // inventory returns hardware and firmware inventory
 func inventory(ctx context.Context, generic []inventoryGetterProvider) (device *common.Device, metadata Metadata, err error) {
 	var metadataLocal Metadata
-Loop:
+
 	for _, elem := range generic {
 		if elem.InventoryGetter == nil {
 			continue
@@ -32,7 +32,8 @@ Loop:
 		select {
 		case <-ctx.Done():
 			err = multierror.Append(err, ctx.Err())
-			break Loop
+
+			return device, metadata, err
 		default:
 			metadataLocal.ProvidersAttempted = append(metadataLocal.ProvidersAttempted, elem.name)
 			device, vErr := elem.Inventory(ctx)

--- a/bmc/postcode.go
+++ b/bmc/postcode.go
@@ -26,7 +26,7 @@ type postCodeGetterProvider struct {
 // postCode returns the device BIOS/UEFI POST code
 func postCode(ctx context.Context, generic []postCodeGetterProvider) (status string, code int, metadata Metadata, err error) {
 	var metadataLocal Metadata
-Loop:
+
 	for _, elem := range generic {
 		if elem.PostCodeGetter == nil {
 			continue
@@ -34,7 +34,8 @@ Loop:
 		select {
 		case <-ctx.Done():
 			err = multierror.Append(err, ctx.Err())
-			break Loop
+
+			return status, code, metadata, err
 		default:
 			metadataLocal.ProvidersAttempted = append(metadataLocal.ProvidersAttempted, elem.name)
 			status, code, vErr := elem.PostCode(ctx)

--- a/bmc/power_test.go
+++ b/bmc/power_test.go
@@ -48,7 +48,7 @@ func TestSetPowerState(t *testing.T) {
 		"success":               {state: "off", want: true},
 		"not ok return":         {state: "off", want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider, failed to set power state"), errors.New("failed to set power state")}}},
 		"error":                 {state: "off", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider: power set failed"), errors.New("failed to set power state")}}},
-		"error context timeout": {state: "off", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to set power state")}}, ctxTimeout: time.Nanosecond * 1},
+		"error context timeout": {state: "off", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded")}}, ctxTimeout: time.Nanosecond * 1},
 	}
 
 	for name, tc := range testCases {
@@ -60,7 +60,7 @@ func TestSetPowerState(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, _, err := setPowerState(ctx, tc.state, []powerProviders{{"test provider", nil, &testImplementation}})
+			result, _, err := setPowerState(ctx, 0, tc.state, []powerProviders{{"test provider", nil, &testImplementation}})
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {
@@ -100,7 +100,7 @@ func TestSetPowerStateFromInterfaces(t *testing.T) {
 				generic = []interface{}{&testImplementation}
 			}
 			expectedResult := tc.want
-			result, metadata, err := SetPowerStateFromInterfaces(context.Background(), tc.state, generic)
+			result, metadata, err := SetPowerStateFromInterfaces(context.Background(), 0, tc.state, generic)
 			if err != nil {
 				if tc.err != nil {
 					diff := cmp.Diff(err.Error(), tc.err.Error())
@@ -134,7 +134,7 @@ func TestGetPowerState(t *testing.T) {
 	}{
 		"success":              {state: "on", err: nil},
 		"failure":              {state: "on", makeFail: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider: power state get failed"), errors.New("failed to get power state")}}},
-		"fail context timeout": {state: "on", makeFail: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to get power state")}}, ctxTimeout: time.Nanosecond * 1},
+		"fail context timeout": {state: "on", makeFail: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded")}}, ctxTimeout: time.Nanosecond * 1},
 	}
 
 	for name, tc := range testCases {
@@ -146,7 +146,7 @@ func TestGetPowerState(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, _, err := getPowerState(ctx, []powerProviders{{"test provider", &testImplementation, nil}})
+			result, _, err := getPowerState(ctx, 0, []powerProviders{{"test provider", &testImplementation, nil}})
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {
@@ -186,7 +186,7 @@ func TestGetPowerStateFromInterfaces(t *testing.T) {
 				generic = []interface{}{&testImplementation}
 			}
 			expectedResult := tc.want
-			result, metadata, err := GetPowerStateFromInterfaces(context.Background(), generic)
+			result, metadata, err := GetPowerStateFromInterfaces(context.Background(), 0, generic)
 			if err != nil {
 				if tc.err != nil {
 					diff := cmp.Diff(err.Error(), tc.err.Error())

--- a/bmc/reset_test.go
+++ b/bmc/reset_test.go
@@ -41,7 +41,7 @@ func TestResetBMC(t *testing.T) {
 		"success":               {resetType: "cold", want: true},
 		"not ok return":         {resetType: "warm", want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider, failed to reset BMC"), errors.New("failed to reset BMC")}}},
 		"error":                 {resetType: "cold", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider: bmc reset failed"), errors.New("failed to reset BMC")}}},
-		"error context timeout": {resetType: "cold", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to reset BMC")}}, ctxTimeout: time.Nanosecond * 1},
+		"error context timeout": {resetType: "cold", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded")}}, ctxTimeout: time.Nanosecond * 1},
 	}
 
 	for name, tc := range testCases {
@@ -53,7 +53,7 @@ func TestResetBMC(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, _, err := resetBMC(ctx, tc.resetType, []bmcProviders{{"test provider", &testImplementation}})
+			result, _, err := resetBMC(ctx, 0, tc.resetType, []bmcProviders{{"test provider", &testImplementation}})
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {
@@ -93,7 +93,7 @@ func TestResetBMCFromInterfaces(t *testing.T) {
 				generic = []interface{}{&testImplementation}
 			}
 			expectedResult := tc.want
-			result, metadata, err := ResetBMCFromInterfaces(context.Background(), tc.resetType, generic)
+			result, metadata, err := ResetBMCFromInterfaces(context.Background(), 0, tc.resetType, generic)
 			if err != nil {
 				if tc.err != nil {
 					diff := cmp.Diff(err.Error(), tc.err.Error())

--- a/bmc/user_test.go
+++ b/bmc/user_test.go
@@ -77,7 +77,7 @@ func TestUserCreate(t *testing.T) {
 		"success":               {want: true},
 		"not ok return":         {want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("failed to create user"), errors.New("failed to create user")}}},
 		"error":                 {makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("create user failed"), errors.New("failed to create user")}}},
-		"error context timeout": {makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to create user")}}, ctxTimeout: time.Nanosecond * 1},
+		"error context timeout": {makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded")}}, ctxTimeout: time.Nanosecond * 1},
 	}
 
 	for name, tc := range testCases {
@@ -92,7 +92,7 @@ func TestUserCreate(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, _, err := createUser(ctx, user, pass, role, []userProviders{{"", &testImplementation, nil, nil, nil}})
+			result, _, err := createUser(ctx, 0, user, pass, role, []userProviders{{"", &testImplementation, nil, nil, nil}})
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {
@@ -134,7 +134,7 @@ func TestCreateUserFromInterfaces(t *testing.T) {
 			user := "ADMIN"
 			pass := "ADMIN"
 			role := "admin"
-			result, metadata, err := CreateUserFromInterfaces(context.Background(), user, pass, role, generic)
+			result, metadata, err := CreateUserFromInterfaces(context.Background(), 0, user, pass, role, generic)
 			if err != nil {
 				if tc.err != nil {
 					diff := cmp.Diff(err.Error(), tc.err.Error())
@@ -171,7 +171,7 @@ func TestUpdateUser(t *testing.T) {
 		"success":               {want: true},
 		"not ok return":         {want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("failed to update user"), errors.New("failed to update user")}}},
 		"error":                 {makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("update user failed"), errors.New("failed to update user")}}},
-		"error context timeout": {makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to update user")}}, ctxTimeout: time.Nanosecond * 1},
+		"error context timeout": {makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded")}}, ctxTimeout: time.Nanosecond * 1},
 	}
 
 	for name, tc := range testCases {
@@ -186,7 +186,7 @@ func TestUpdateUser(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, _, err := updateUser(ctx, user, pass, role, []userProviders{{"", nil, &testImplementation, nil, nil}})
+			result, _, err := updateUser(ctx, 0, user, pass, role, []userProviders{{"", nil, &testImplementation, nil, nil}})
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {
@@ -228,7 +228,7 @@ func TestUpdateUserFromInterfaces(t *testing.T) {
 			user := "ADMIN"
 			pass := "ADMIN"
 			role := "admin"
-			result, metadata, err := UpdateUserFromInterfaces(context.Background(), user, pass, role, generic)
+			result, metadata, err := UpdateUserFromInterfaces(context.Background(), 0, user, pass, role, generic)
 			if err != nil {
 				if tc.err != nil {
 					diff := cmp.Diff(err.Error(), tc.err.Error())
@@ -264,7 +264,7 @@ func TestDeleteUser(t *testing.T) {
 		"success":               {want: true},
 		"not ok return":         {want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("failed to delete user"), errors.New("failed to delete user")}}},
 		"error":                 {makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("delete user failed"), errors.New("failed to delete user")}}},
-		"error context timeout": {makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to delete user")}}, ctxTimeout: time.Nanosecond * 1},
+		"error context timeout": {makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded")}}, ctxTimeout: time.Nanosecond * 1},
 	}
 
 	for name, tc := range testCases {
@@ -277,7 +277,7 @@ func TestDeleteUser(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, _, err := deleteUser(ctx, user, []userProviders{{"", nil, nil, &testImplementation, nil}})
+			result, _, err := deleteUser(ctx, 0, user, []userProviders{{"", nil, nil, &testImplementation, nil}})
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {
@@ -317,7 +317,7 @@ func TestDeleteUserFromInterfaces(t *testing.T) {
 			}
 			expectedResult := tc.want
 			user := "ADMIN"
-			result, metadata, err := DeleteUserFromInterfaces(context.Background(), user, generic)
+			result, metadata, err := DeleteUserFromInterfaces(context.Background(), 0, user, generic)
 			if err != nil {
 				if tc.err != nil {
 					diff := cmp.Diff(err.Error(), tc.err.Error())
@@ -351,7 +351,7 @@ func TestReadUsers(t *testing.T) {
 	}{
 		"success":               {want: true},
 		"not ok return":         {want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("read users failed"), errors.New("failed to read users")}}},
-		"error context timeout": {want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to read users")}}, ctxTimeout: time.Nanosecond * 1},
+		"error context timeout": {want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded")}}, ctxTimeout: time.Nanosecond * 1},
 	}
 
 	users := []map[string]string{
@@ -372,7 +372,7 @@ func TestReadUsers(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
 			defer cancel()
-			result, _, err := readUsers(ctx, []userProviders{{"", nil, nil, nil, &testImplementation}})
+			result, _, err := readUsers(ctx, 0, []userProviders{{"", nil, nil, nil, &testImplementation}})
 			if err != nil {
 				diff := cmp.Diff(err.Error(), tc.err.Error())
 				if diff != "" {
@@ -420,7 +420,7 @@ func TestReadUsersFromInterfaces(t *testing.T) {
 				generic = []interface{}{&testImplementation}
 			}
 			expectedResult := users
-			result, metadata, err := ReadUsersFromInterfaces(context.Background(), generic)
+			result, metadata, err := ReadUsersFromInterfaces(context.Background(), 0, generic)
 			if err != nil {
 				if tc.err != nil {
 					diff := cmp.Diff(err.Error(), tc.err.Error())

--- a/bmc/virtual_media.go
+++ b/bmc/virtual_media.go
@@ -22,7 +22,7 @@ type virtualMediaProviders struct {
 // setVirtualMedia sets the virtual media.
 func setVirtualMedia(ctx context.Context, kind string, mediaURL string, b []virtualMediaProviders) (ok bool, metadata Metadata, err error) {
 	var metadataLocal Metadata
-Loop:
+
 	for _, elem := range b {
 		if elem.virtualMediaSetter == nil {
 			continue
@@ -30,7 +30,8 @@ Loop:
 		select {
 		case <-ctx.Done():
 			err = multierror.Append(err, ctx.Err())
-			break Loop
+
+			return false, metadata, err
 		default:
 			metadataLocal.ProvidersAttempted = append(metadataLocal.ProvidersAttempted, elem.name)
 			ok, setErr := elem.virtualMediaSetter.SetVirtualMedia(ctx, kind, mediaURL)

--- a/bmc/virtual_media_test.go
+++ b/bmc/virtual_media_test.go
@@ -42,7 +42,7 @@ func TestSetVirtualMedia(t *testing.T) {
 		"success":               {kind: "cdrom", mediaURL: "example.com/some.iso", want: true},
 		"not ok return":         {kind: "cdrom", mediaURL: "example.com/some.iso", want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider, failed to set virtual media"), errors.New("failed to set virtual media")}}},
 		"error":                 {kind: "cdrom", mediaURL: "example.com/some.iso", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider: setting virtual media failed"), errors.New("failed to set virtual media")}}},
-		"error context timeout": {kind: "cdrom", mediaURL: "example.com/some.iso", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded"), errors.New("failed to set virtual media")}}, ctxTimeout: time.Nanosecond * 1},
+		"error context timeout": {kind: "cdrom", mediaURL: "example.com/some.iso", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded")}}, ctxTimeout: time.Nanosecond * 1},
 	}
 
 	for name, tc := range testCases {

--- a/client.go
+++ b/client.go
@@ -218,6 +218,8 @@ func (c *Client) Close(ctx context.Context) (err error) {
 	return err
 }
 
+// FilterForCompatible removes any drivers/providers that are not compatible. It wraps the
+// Client.Registry.FilterForCompatible func in order to provide a per provider timeout.
 func (c *Client) FilterForCompatible(ctx context.Context) {
 	perProviderTimeout, cancel := context.WithTimeout(ctx, c.perProviderTimeout(ctx))
 	defer cancel()

--- a/client_test.go
+++ b/client_test.go
@@ -83,7 +83,7 @@ func TestWithRedfishVersionsNotCompatible(t *testing.T) {
 }
 
 func TestWithConnectionTimeout(t *testing.T) {
-	/*host := "127.0.0.1"
+	host := "127.0.0.1"
 	port := "623"
 	user := "ADMIN"
 	pass := "ADMIN"
@@ -103,9 +103,8 @@ func TestWithConnectionTimeout(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cl := NewClient(host, port, user, pass, WithConnectTimeout(tt.timeout))
-			assert.Equal(t, tt.timeout, cl.connectTimeout)
+			cl := NewClient(host, port, user, pass, WithPerProviderTimeout(tt.timeout))
+			assert.Equal(t, tt.timeout, cl.perProviderTimeout(nil))
 		})
 	}
-	*/
 }

--- a/client_test.go
+++ b/client_test.go
@@ -11,16 +11,16 @@ import (
 
 func TestBMC(t *testing.T) {
 	t.Skip("needs ipmitool and real ipmi server")
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
 	host := "127.0.0.1"
 	port := "623"
-	user := "ADMIN"
-	pass := "ADMIN"
+	user := "admin"
+	pass := "admin"
 
 	log := logging.DefaultLogger()
-	cl := NewClient(host, port, user, pass, WithLogger(log))
-	cl.Registry.Drivers = cl.Registry.FilterForCompatible(ctx)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	cl := NewClient(host, port, user, pass, WithLogger(log), WithPerProviderTimeout(5*time.Second))
+	cl.FilterForCompatible(ctx)
 	var err error
 	err = cl.Open(ctx)
 	if err != nil {
@@ -29,7 +29,7 @@ func TestBMC(t *testing.T) {
 	defer cl.Close(ctx)
 	t.Logf("metadata: %+v", cl.GetMetadata())
 
-	cl.Registry.Drivers = cl.Registry.PreferDriver("dummy")
+	cl.Registry.Drivers = cl.Registry.PreferDriver("non-existent")
 	state, err := cl.GetPowerState(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -83,7 +83,7 @@ func TestWithRedfishVersionsNotCompatible(t *testing.T) {
 }
 
 func TestWithConnectionTimeout(t *testing.T) {
-	host := "127.0.0.1"
+	/*host := "127.0.0.1"
 	port := "623"
 	user := "ADMIN"
 	pass := "ADMIN"
@@ -107,4 +107,5 @@ func TestWithConnectionTimeout(t *testing.T) {
 			assert.Equal(t, tt.timeout, cl.connectTimeout)
 		})
 	}
+	*/
 }

--- a/providers/asrockrack/asrockrack.go
+++ b/providers/asrockrack/asrockrack.go
@@ -97,6 +97,9 @@ func NewWithOptions(ip string, username string, password string, log logr.Logger
 // Compatible implements the registrar.Verifier interface
 // returns true if the BMC is identified to be an asrockrack
 func (a *ASRockRack) Compatible(ctx context.Context) bool {
+	if err := a.Open(ctx); err != nil {
+		return false
+	}
 	resp, statusCode, err := a.queryHTTPS(ctx, "/", "GET", nil, nil, 0)
 	if err != nil {
 		return false

--- a/providers/asrockrack/asrockrack.go
+++ b/providers/asrockrack/asrockrack.go
@@ -97,9 +97,6 @@ func NewWithOptions(ip string, username string, password string, log logr.Logger
 // Compatible implements the registrar.Verifier interface
 // returns true if the BMC is identified to be an asrockrack
 func (a *ASRockRack) Compatible(ctx context.Context) bool {
-	if err := a.Open(ctx); err != nil {
-		return false
-	}
 	resp, statusCode, err := a.queryHTTPS(ctx, "/", "GET", nil, nil, 0)
 	if err != nil {
 		return false


### PR DESCRIPTION
## What does this PR implement/change/remove?
This expands the timeout for opening connections to all method/BMC interactions.

If a context with a timeout IS provided to a method call but no per provider timeout is defined, then we default to a timeout of the provided timeout duration divided by the number of providers/drivers in the Client.Registry.Drivers slice.

If a context with a timeout IS NOT provided to a method call and no per provider timeout is defined, then we use the defaultConnectTimeout of 30 seconds.

### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes

```
```
