### PR TITLE
providers/redfish: fixes a panic in cases where a nil bios object was returned

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -86,6 +86,9 @@ var (
 
 	// ErrCompatibilityCheck is returned when the compatibility probe failed to complete successfully.
 	ErrCompatibilityCheck = errors.New("compatibility check failed")
+
+	// ErrNoBiosAttributes is returned when no bios attributes are available from the BMC.
+	ErrNoBiosAttributes = errors.New("no BIOS attributes available")
 )
 
 type ErrUnsupportedHardware struct {

--- a/providers/redfish/bios.go
+++ b/providers/redfish/bios.go
@@ -2,6 +2,8 @@ package redfish
 
 import (
 	"context"
+
+	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
 )
 
 func (c *Conn) GetBiosConfiguration(ctx context.Context) (biosConfig map[string]string, err error) {
@@ -21,9 +23,14 @@ func (c *Conn) GetBiosConfiguration(ctx context.Context) (biosConfig map[string]
 			return nil, err
 		}
 
+		if bios == nil {
+			return nil, bmclibErrs.ErrNoBiosAttributes
+		}
+
 		for attr := range bios.Attributes {
 			biosConfig[attr] = bios.Attributes.String(attr)
 		}
 	}
+
 	return biosConfig, nil
 }


### PR DESCRIPTION
## What does this PR implement/change/remove?

Fixes a nil panic in Redfish BIOS data queries.

### Checklist
- [ ] Tests added
     - The redfish mock code could use some work so that tests can check for non-happy cases, at the moment its not trivial to implement tests for those conditions. 
- [X] Similar commits squashed

