### PR TITLE
redfish: fix nil check on gofish client

### DIFF
--- a/internal/redfishwrapper/client.go
+++ b/internal/redfishwrapper/client.go
@@ -123,7 +123,7 @@ func getTimeout(ctx context.Context) time.Duration {
 
 // Close closes the redfish session.
 func (c *Client) Close(ctx context.Context) error {
-	if c == nil || c.client.Service == nil {
+	if c.client == nil || c.client.Service == nil {
 		return nil
 	}
 


### PR DESCRIPTION
## What does this PR implement/change/remove?

fixes a panic on `Close()` in the Redfish provider if the Redfish client was never setup.

```
goroutine 37 [running]:
github.com/bmc-toolbox/bmclib/v2/internal/redfishwrapper.(*Client).Close(...)
        /Users/jrebello/go/pkg/mod/github.com/bmc-toolbox/bmclib/v2@v2.0.1-0.20230324092939-d39fb75b6aa9/internal/redfishwrapper/client.go:126
github.com/bmc-toolbox/bmclib/v2/providers/redfish.(*Conn).Close(0x0?, {0x100c00005a804?, 0x477d9e?})
        /Users/jrebello/go/pkg/mod/github.com/bmc-toolbox/bmclib/v2@v2.0.1-0.20230324092939-d39fb75b6aa9/providers/redfish/redfish.go:63 +0x20
github.com/bmc-toolbox/bmclib/v2/bmc.closeConnection({0x107cd78, 0xc000182660}, {0xc0002de280?, 0x2, 0x0?})
```

### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes

```
```
