### PR TITLE
Sets basic auth on the gofish driver

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -83,6 +83,38 @@ func TestWithRedfishVersionsNotCompatible(t *testing.T) {
 	}
 }
 
+func TestWithRedfishBasicAuth(t *testing.T) {
+	host := "127.0.0.1"
+	port := "623"
+	user := "ADMIN"
+	pass := "ADMIN"
+
+	tests := []struct {
+		name    string
+		enabled bool
+	}{
+		{
+			"disabled",
+			false,
+		},
+		{
+			"enabled",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts []Option
+			if tt.enabled {
+				opts = append(opts, WithRedfishBasicAuth())
+			}
+
+			cl := NewClient(host, port, user, pass, opts...)
+			assert.Equal(t, tt.enabled, cl.redfishBasicAuthEnabled)
+		})
+	}
+}
+
 func TestWithConnectionTimeout(t *testing.T) {
 	host := "127.0.0.1"
 	port := "623"

--- a/examples/status/main.go
+++ b/examples/status/main.go
@@ -30,7 +30,10 @@ func main() {
 		l.Fatal("required host/user/pass parameters not defined")
 	}
 
-	clientOpts := []bmclib.Option{bmclib.WithLogger(logger)}
+	clientOpts := []bmclib.Option{
+		bmclib.WithLogger(logger),
+		bmclib.WithRedfishBasicAuth(),
+	}
 
 	if *withSecureTLS {
 		var pool *x509.CertPool
@@ -58,18 +61,9 @@ func main() {
 	}
 	defer cl.Close(ctx)
 
-	inventory, err := cl.Inventory(ctx)
-	if err != nil {
-		l.Fatal(err)
-	}
-
-	l.WithField("bmc-version", inventory.BMC.Firmware.Installed).Info()
-
 	state, err := cl.GetPowerState(ctx)
 	if err != nil {
 		l.WithError(err).Error()
 	}
 	l.WithField("power-state", state).Info()
-
-	l.WithField("bios-version", inventory.BIOS.Firmware.Installed).Info()
 }

--- a/internal/redfishwrapper/client_test.go
+++ b/internal/redfishwrapper/client_test.go
@@ -31,3 +31,29 @@ func TestWithVersionsNotCompatible(t *testing.T) {
 		})
 	}
 }
+
+func TestWithBasicAuthEnabled(t *testing.T) {
+	host := "127.0.0.1"
+	user := "ADMIN"
+	pass := "ADMIN"
+
+	tests := []struct {
+		name    string
+		enabled bool
+	}{
+		{
+			"disabled",
+			false,
+		},
+		{
+			"enabled",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewClient(host, "", user, pass, WithBasicAuthEnabled(tt.enabled))
+			assert.Equal(t, tt.enabled, client.basicAuth)
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR implement/change/remove?

Implements client option to enable Basic Auth on the Gofish redfish driver
fixes #328 


### Checklist
- [X] Tests added
- [X] Similar commits squashed
