### PR TITLE
Remove union in .FilterForCompatible:

### DIFF
--- a/client.go
+++ b/client.go
@@ -19,7 +19,6 @@ import (
 	"github.com/bmc-toolbox/bmclib/v2/providers/redfish"
 	"github.com/bmc-toolbox/common"
 	"github.com/go-logr/logr"
-	"github.com/google/go-cmp/cmp"
 	"github.com/jacobweinstock/registrar"
 )
 
@@ -257,20 +256,6 @@ func (c *Client) Close(ctx context.Context) (err error) {
 	return err
 }
 
-// union is a helper to preserve the order of the current registry while filtering against a one time registry.
-func union(cur, oneTime []*registrar.Driver) []*registrar.Driver {
-	result := []*registrar.Driver{}
-	for _, elem := range cur {
-		for _, em := range oneTime {
-			if cmp.Diff(*em, *elem) == "" {
-				result = append(result, elem)
-			}
-		}
-	}
-
-	return result
-}
-
 // FilterForCompatible removes any drivers/providers that are not compatible. It wraps the
 // Client.Registry.FilterForCompatible func in order to provide a per provider timeout.
 func (c *Client) FilterForCompatible(ctx context.Context) {
@@ -278,9 +263,7 @@ func (c *Client) FilterForCompatible(ctx context.Context) {
 	defer cancel()
 
 	reg := c.registry().FilterForCompatible(perProviderTimeout)
-	// if the registry used a one time filter, the order could be different than the current registry.
-	// Because of this we need to get the union of the two keeping the current order.
-	c.Registry.Drivers = union(c.Registry.Drivers, reg)
+	c.Registry.Drivers = reg
 }
 
 // GetPowerState pass through to library function

--- a/client_test.go
+++ b/client_test.go
@@ -172,39 +172,6 @@ func TestDefaultTimeout(t *testing.T) {
 	}
 }
 
-func TestUnion(t *testing.T) {
-	tests := map[string]struct {
-		oneTime []*registrar.Driver
-		want    []*registrar.Driver
-	}{
-		"empty":           {oneTime: []*registrar.Driver{}, want: []*registrar.Driver{}},
-		"partial overlap": {oneTime: []*registrar.Driver{{Name: "one", Protocol: "redfish"}}, want: []*registrar.Driver{{Name: "one", Protocol: "redfish"}}},
-	}
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			cur := []*registrar.Driver{
-				{
-					Name:     "one",
-					Protocol: "redfish",
-				},
-				{
-					Name:     "two",
-					Protocol: "ipmi",
-				},
-				{
-					Name:     "three",
-					Protocol: "intelamt",
-				},
-			}
-			got := union(cur, tt.oneTime)
-			if diff := cmp.Diff(got, tt.want); diff != "" {
-				t.Errorf("unexpected union (-got +want):\n%s", diff)
-				t.Log("got", got)
-			}
-		})
-	}
-}
-
 type testProvider struct {
 	PName        string
 	Powerstate   string


### PR DESCRIPTION
This was erroring with `cmp.Diff` complaining about comparing `logr`. I retested again and this is not needed at all.

## What does this PR implement/change/remove?

### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes

```
```
