### PR TITLE
Redfish override timeout for FirmwareInstall

### DIFF
--- a/internal/redfishwrapper/client.go
+++ b/internal/redfishwrapper/client.go
@@ -161,6 +161,16 @@ func (c *Client) SessionActive() error {
 	return nil
 }
 
+// Overrides the HTTP client timeout
+func (c *Client) SetHttpClientTimeout(t time.Duration) {
+	c.client.HTTPClient.Timeout = t
+}
+
+// retrieve the current HTTP client timeout
+func (c *Client) HttpClientTimeout() time.Duration {
+	return c.client.HTTPClient.Timeout
+}
+
 // RunRawRequestWithHeaders wraps the gofish client method RunRawRequestWithHeaders
 func (c *Client) RunRawRequestWithHeaders(method, url string, payloadBuffer io.ReadSeeker, contentType string, customHeaders map[string]string) (*http.Response, error) {
 	if err := c.SessionActive(); err != nil {

--- a/providers/supermicro/firmware.go
+++ b/providers/supermicro/firmware.go
@@ -28,9 +28,9 @@ func (c *Client) FirmwareInstall(ctx context.Context, component, applyAt string,
 		size = finfo.Size()
 	}
 
-	// expect atleast 30 minutes left in the deadline to proceed with the update
+	// expect atleast 10 minutes left in the deadline to proceed with the update
 	d, _ := ctx.Deadline()
-	if time.Until(d) < 30*time.Minute {
+	if time.Until(d) < 10*time.Minute {
 		return "", errors.New("remaining context deadline insufficient to perform update: " + time.Until(d).String())
 	}
 


### PR DESCRIPTION
## What does this PR implement/change/remove?

- Adds a remaining timeout check on the Redfish provider `FirmwareInstall` method.
- Overrides the Redfish wrapper HTTP client timeout for the `FirmwareInstall` method.

The Redfish wrapper client - Gofish has a context timeout on the HTTP client set when `Open()` is invoked, this timeout value is often insufficient for the `FirmwareInstall` method to complete successfully, and so the `FirmwareInstall` method overrides this timeout value and restores it when done.  

### Checklist
- [X] Tests added
- [X] Similar commits squashed


## Description for changelog/release notes

```
 - Require a higher context timeout value before proceeding with FirmwareInstall.
 - Set http client timeout to the one passed in through the context to FirmwareInstall.
```
