### PR TITLE
supermicro/firmware: support firmware installs on BMCs running older firmware

### DIFF
--- a/providers/supermicro/firmware_bios.go
+++ b/providers/supermicro/firmware_bios.go
@@ -234,7 +234,12 @@ func (c *Client) uploadBIOSFirmware(ctx context.Context, fwReader io.Reader) err
 		case "csrf-token":
 			// Add csrf token field
 			h := make(textproto.MIMEHeader)
-			h.Set("Content-Disposition", `form-data; name="CSRF-TOKEN"`)
+			// BMCs with newer firmware (>=1.74.09) accept the form with this name value
+			// h.Set("Content-Disposition", `form-data; name="CSRF-TOKEN"`)
+			//
+			// the BMCs running older firmware (<=1.23.06) versions expects the name value in this format
+			// and the newer firmware (>=1.74.09) seem to be backwards compatible with this name value format.
+			h.Set("Content-Disposition", `form-data; name="CSRF_TOKEN"`)
 
 			if partWriter, err = payloadWriter.CreatePart(h); err != nil {
 				return errors.Wrap(ErrMultipartForm, err.Error())

--- a/providers/supermicro/firmware_bmc.go
+++ b/providers/supermicro/firmware_bmc.go
@@ -155,7 +155,12 @@ func (c *Client) uploadBMCFirmware(ctx context.Context, fwReader io.Reader) erro
 		case "csrf-token":
 			// Add csrf token field
 			h := make(textproto.MIMEHeader)
-			h.Set("Content-Disposition", `form-data; name="CSRF-TOKEN"`)
+			// BMCs with newer firmware (>=1.74.09) accept the form with this name value
+			// h.Set("Content-Disposition", `form-data; name="CSRF-TOKEN"`)
+			//
+			// the BMCs running older firmware (<=1.23.06) versions expects the name value in this format
+			// this seems to be backwards compatible with the newer firmware.
+			h.Set("Content-Disposition", `form-data; name="CSRF_TOKEN"`)
 
 			if partWriter, err = payloadWriter.CreatePart(h); err != nil {
 				return errors.Wrap(ErrMultipartForm, err.Error())

--- a/providers/supermicro/firmware_bmc_test.go
+++ b/providers/supermicro/firmware_bmc_test.go
@@ -145,7 +145,7 @@ func Test_uploadBMCFirmware(t *testing.T) {
 				part, err = reader.NextPart()
 				assert.Nil(t, err)
 
-				assert.Equal(t, `form-data; name="CSRF-TOKEN"`, part.Header.Get("Content-Disposition"))
+				assert.Equal(t, `form-data; name="CSRF_TOKEN"`, part.Header.Get("Content-Disposition"))
 			},
 		},
 	}

--- a/providers/supermicro/supermicro_test.go
+++ b/providers/supermicro/supermicro_test.go
@@ -44,6 +44,11 @@ func Test_parseToken(t *testing.T) {
 			</html>`),
 			"fYQ/Xhd1AvA+kP/bM/tO5mhOzv4eM5evCOH/YSuBN70",
 		},
+		{
+			"token with key type 4 found",
+			[]byte(`<script>SmcCsrfInsert ("CSRF_TOKEN", "RYjdEjWIhU+PCRFMBP2ZRPPePcQ4n3dM3s+rCgTnBBU");</script></body>`),
+			"RYjdEjWIhU+PCRFMBP2ZRPPePcQ4n3dM3s+rCgTnBBU",
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
support firmware installs on BMCs running firmware <= 1.23.06

The older firmware expects Host headers to be in a certain format (without the port) and it expects a Referrer header. The firmware upload endpoint expects the multipart header slightly different as well.

Tested this change works on the newer firmware (1.74.x) as well.

## What does this PR implement/change/remove?

### Checklist
- [X] Tests added
- [X] Similar commits squashed

### The HW vendor this change applies to (if applicable)
- SMC X11s

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes

```
- Support for SMC firmware updates on BMCs running firmware <=1.23.06
```
