### PR TITLE
Redfish stream multipart uploads

### DIFF
--- a/examples/install-firmware/main.go
+++ b/examples/install-firmware/main.go
@@ -114,7 +114,7 @@ func main() {
 		}
 
 		switch state {
-		case constants.FirmwareInstallRunning:
+		case constants.FirmwareInstallRunning, constants.FirmwareInstallInitializing:
 			l.WithFields(logrus.Fields{"state": state, "component": *component}).Info("firmware install running")
 
 		case constants.FirmwareInstallFailed:

--- a/providers/redfish/firmware_test.go
+++ b/providers/redfish/firmware_test.go
@@ -1,7 +1,6 @@
 package redfish
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -207,7 +206,7 @@ func TestMultipartPayloadSize(t *testing.T) {
 		{
 			"content length as expected",
 			&multipartPayload{
-				updateParameters: bytes.NewReader(updateParameters),
+				updateParameters: updateParameters,
 				updateFile:       testfileFH,
 			},
 			475,

--- a/providers/redfish/firmware_test.go
+++ b/providers/redfish/firmware_test.go
@@ -97,6 +97,17 @@ func TestFirmwareInstall(t *testing.T) {
 			false,
 			nil,
 			"",
+			bmclibErrs.ErrFirmwareInstall,
+			"method expects an *os.File object",
+			"expect *os.File object",
+		},
+		{
+			common.SlugBIOS,
+			constants.FirmwareApplyOnReset,
+			false,
+			false,
+			&os.File{},
+			"",
 			errInsufficientCtxTimeout,
 			"",
 			"remaining context deadline",
@@ -106,7 +117,7 @@ func TestFirmwareInstall(t *testing.T) {
 			"invalidApplyAt",
 			false,
 			true,
-			nil,
+			&os.File{},
 			"",
 			bmclibErrs.ErrFirmwareInstall,
 			"invalid applyAt parameter",
@@ -189,15 +200,15 @@ func TestMultipartPayloadSize(t *testing.T) {
 
 	testCases := []struct {
 		testName     string
-		payload      []map[string]io.Reader
+		payload      *multipartPayload
 		expectedSize int64
 		errorMsg     string
 	}{
 		{
 			"content length as expected",
-			[]map[string]io.Reader{
-				{"UpdateParameters": bytes.NewReader(updateParameters)},
-				{"UpdateFile": testfileFH},
+			&multipartPayload{
+				updateParameters: bytes.NewReader(updateParameters),
+				updateFile:       testfileFH,
 			},
 			475,
 			"",


### PR DESCRIPTION
## What does this PR implement/change/remove?

The Redfish provider currently reads the firmware files into memory before a multipart upload,
this results in high memory consumption for the client and can be problematic for cases
where firmware installs have to be performed simultaneously.


This change was part of bmclib v1 https://github.com/bmc-toolbox/bmclib/pull/279 
but was somehow missed from being included in v2.

Tested with Dell R6515's, R7640.

heap profile - with streaming uploads
```
(pprof) top 20
Showing nodes accounting for 2059.99kB, 100% of 2059.99kB total
Showing top 20 nodes out of 29
      flat  flat%   sum%        cum   cum%
  520.04kB 25.24% 25.24%  1034.42kB 50.21%  encoding/json.(*Decoder).refill
  514.38kB 24.97% 50.21%   514.38kB 24.97%  compress/flate.NewReader
  513.56kB 24.93% 75.15%   513.56kB 24.93%  regexp/syntax.init
  512.01kB 24.85%   100%   512.01kB 24.85%  sync.(*Map).Swap
         0     0%   100%   514.38kB 24.97%  compress/gzip.(*Reader).Reset
         0     0%   100%   514.38kB 24.97%  compress/gzip.(*Reader).readHeader
         0     0%   100%   514.38kB 24.97%  compress/gzip.NewReader
         0     0%   100%  1546.43kB 75.07%  encoding/json.(*Decoder).Decode
         0     0%   100%  1034.42kB 50.21%  encoding/json.(*Decoder).readValue
         0     0%   100%   512.01kB 24.85%  encoding/json.(*decodeState).object
         0     0%   100%   512.01kB 24.85%  encoding/json.(*decodeState).unmarshal
         0     0%   100%   512.01kB 24.85%  encoding/json.(*decodeState).value
         0     0%   100%   512.01kB 24.85%  encoding/json.Unmarshal
         0     0%   100%   512.01kB 24.85%  encoding/json.cachedTypeFields
         0     0%   100%   512.01kB 24.85%  encoding/json.typeEncoder
         0     0%   100%   512.01kB 24.85%  encoding/json.typeFields
         0     0%   100%  1032.05kB 50.10%  github.com/stmcginnis/gofish/common.(*Entity).Get
         0     0%   100%  1032.05kB 50.10%  github.com/stmcginnis/gofish/common.CollectCollection.func1
         0     0%   100%   514.38kB 24.97%  github.com/stmcginnis/gofish/common.CollectList
         0     0%   100%   514.38kB 24.97%  github.com/stmcginnis/gofish/common.GetCollection
```

heap profile - without streaming uploads
```
(pprof) top 30
Showing nodes accounting for 240MB, 99.58% of 241MB total
Dropped 16 nodes (cum <= 1.21MB)
      flat  flat%   sum%        cum   cum%
     240MB 99.58% 99.58%      240MB 99.58%  bytes.growSlice
         0     0% 99.58%      240MB 99.58%  bytes.(*Buffer).Write
         0     0% 99.58%      240MB 99.58%  bytes.(*Buffer).grow
         0     0% 99.58%   240.50MB 99.79%  github.com/bmc-toolbox/bmclib/v2.(*Client).FirmwareInstall
         0     0% 99.58%   240.50MB 99.79%  github.com/bmc-toolbox/bmclib/v2/bmc.FirmwareInstallFromInterfaces
         0     0% 99.58%   240.50MB 99.79%  github.com/bmc-toolbox/bmclib/v2/bmc.firmwareInstall
         0     0% 99.58%   240.50MB 99.79%  github.com/bmc-toolbox/bmclib/v2/providers/redfish.(*Conn).FirmwareInstall
         0     0% 99.58%   240.50MB 99.79%  github.com/bmc-toolbox/bmclib/v2/providers/redfish.(*Conn).runRequestWithMultipartPayload
         0     0% 99.58%      240MB 99.58%  io.Copy (inline)
         0     0% 99.58%      240MB 99.58%  io.copyBuffer
         0     0% 99.58%   240.50MB 99.79%  main.main
         0     0% 99.58%      240MB 99.58%  mime/multipart.(*part).Write
         0     0% 99.58%      241MB   100%  runtime.main
```



### Checklist
- [X] Tests added
- [X] Similar commits squashed


## Description for changelog/release notes

```
- Redfish streaming multipart uploads
```
