### PR TITLE
Remove returning the response body:

### DIFF
--- a/providers/rpc/http.go
+++ b/providers/rpc/http.go
@@ -58,8 +58,7 @@ func (p *Provider) handleResponse(statusCode int, headers http.Header, body *byt
 		if statusCode != http.StatusOK {
 			return ResponsePayload{}, fmt.Errorf("unexpected status code: %d, response error(optional): %v", statusCode, res.Error)
 		}
-		example, _ := json.Marshal(ResponsePayload{ID: 123, Host: p.Host, Error: &ResponseError{Code: 1, Message: "error message"}})
-		return ResponsePayload{}, fmt.Errorf("failed to parse response: got: %q, error: %w, expected response json spec: %v", body.String(), err, string(example))
+		return ResponsePayload{}, fmt.Errorf("failed to parse response: %w", err)
 	}
 	if statusCode != http.StatusOK {
 		return ResponsePayload{}, fmt.Errorf("unexpected status code: %d, response error(optional): %v", statusCode, res.Error)

--- a/providers/rpc/rpc_test.go
+++ b/providers/rpc/rpc_test.go
@@ -124,7 +124,7 @@ func TestPowerStateGet(t *testing.T) {
 		shouldErr  bool
 		url        string
 	}{
-		"success":       {},
+		"success":       {powerState: "on"},
 		"unknown state": {shouldErr: true},
 	}
 


### PR DESCRIPTION
## What does this PR implement/change/remove?

In testing this was causing issues with consumers of the provider using the error string. Also, for security reasons we might not want to return an arbitrary response body, especially when it doesn't conform to the response contract.

### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes

```
```
