### PR TITLE
Client opts fixes

### DIFF
--- a/client.go
+++ b/client.go
@@ -165,17 +165,15 @@ func (c *Client) registerIPMIProvider() error {
 }
 
 // register ASRR vendorapi provider
-func (c *Client) registerASRRProvider() error {
+func (c *Client) registerASRRProvider() {
 	asrHttpClient := *c.httpClient
 	asrHttpClient.Transport = c.httpClient.Transport.(*http.Transport).Clone()
 	driverAsrockrack := asrockrack.NewWithOptions(c.Auth.Host+":"+c.providerConfig.asrock.Port, c.Auth.User, c.Auth.Pass, c.Logger, asrockrack.WithHTTPClient(&asrHttpClient))
 	c.Registry.Register(asrockrack.ProviderName, asrockrack.ProviderProtocol, asrockrack.Features, nil, driverAsrockrack)
-
-	return nil
 }
 
 // register gofish provider
-func (c *Client) registerGofishProvider() error {
+func (c *Client) registerGofishProvider() {
 	gfHttpClient := *c.httpClient
 	gfHttpClient.Transport = c.httpClient.Transport.(*http.Transport).Clone()
 	gofishOpts := []redfish.Option{
@@ -188,12 +186,10 @@ func (c *Client) registerGofishProvider() error {
 
 	driverGoFish := redfish.New(c.Auth.Host, c.Auth.User, c.Auth.Pass, c.Logger, gofishOpts...)
 	c.Registry.Register(redfish.ProviderName, redfish.ProviderProtocol, redfish.Features, nil, driverGoFish)
-
-	return nil
 }
 
 // register Intel AMT provider
-func (c *Client) registerIntelAMTProvider() error {
+func (c *Client) registerIntelAMTProvider() {
 
 	iamtOpts := []intelamt.Option{
 		intelamt.WithLogger(c.Logger),
@@ -202,12 +198,10 @@ func (c *Client) registerIntelAMTProvider() error {
 	}
 	driverAMT := intelamt.New(c.Auth.Host, c.Auth.User, c.Auth.Pass, iamtOpts...)
 	c.Registry.Register(intelamt.ProviderName, intelamt.ProviderProtocol, intelamt.Features, nil, driverAMT)
-
-	return nil
 }
 
 // register Dell gofish provider
-func (c *Client) registerDellProvider() error {
+func (c *Client) registerDellProvider() {
 	dellGofishHttpClient := *c.httpClient
 	//dellGofishHttpClient.Transport = c.httpClient.Transport.(*http.Transport).Clone()
 	dellGofishOpts := []dell.Option{
@@ -218,12 +212,10 @@ func (c *Client) registerDellProvider() error {
 	}
 	driverGoFishDell := dell.New(c.Auth.Host, c.Auth.User, c.Auth.Pass, c.Logger, dellGofishOpts...)
 	c.Registry.Register(dell.ProviderName, redfish.ProviderProtocol, dell.Features, nil, driverGoFishDell)
-
-	return nil
 }
 
 // register supermicro vendorapi provider
-func (c *Client) registerSupermicroProvider() error {
+func (c *Client) registerSupermicroProvider() {
 	smcHttpClient := *c.httpClient
 	smcHttpClient.Transport = c.httpClient.Transport.(*http.Transport).Clone()
 	driverSupermicro := supermicro.NewClient(
@@ -236,8 +228,6 @@ func (c *Client) registerSupermicroProvider() error {
 	)
 
 	c.Registry.Register(supermicro.ProviderName, supermicro.ProviderProtocol, supermicro.Features, nil, driverSupermicro)
-
-	return nil
 }
 
 func (c *Client) registerProviders() {
@@ -257,26 +247,11 @@ func (c *Client) registerProviders() {
 		c.Logger.Info("ipmitool provider not available", "error", err.Error())
 	}
 
-	if err := c.registerASRRProvider(); err != nil {
-		c.Logger.Info("ASRR provider not available", "error", err.Error())
-	}
-
-	if err := c.registerGofishProvider(); err != nil {
-		c.Logger.Info("Gofish provider not available", "error", err.Error())
-	}
-
-	if err := c.registerIntelAMTProvider(); err != nil {
-		c.Logger.Info("Intel AMT provider not available", "error", err.Error())
-	}
-
-	if err := c.registerDellProvider(); err != nil {
-		c.Logger.Info("Dell provider not available", "error", err.Error())
-	}
-
-	if err := c.registerSupermicroProvider(); err != nil {
-		c.Logger.Info("Supermicro provider not available", "error", err.Error())
-	}
-
+	c.registerASRRProvider()
+	c.registerGofishProvider()
+	c.registerIntelAMTProvider()
+	c.registerDellProvider()
+	c.registerSupermicroProvider()
 }
 
 // GetMetadata returns the metadata that is populated after each BMC function/method call

--- a/client.go
+++ b/client.go
@@ -145,6 +145,101 @@ func (c *Client) registerRPCProvider() error {
 	return nil
 }
 
+// register ipmitool provider
+func (c *Client) registerIPMIProvider() error {
+	ipmiOpts := []ipmitool.Option{
+		ipmitool.WithLogger(c.Logger),
+		ipmitool.WithPort(c.providerConfig.ipmitool.Port),
+		ipmitool.WithCipherSuite(c.providerConfig.ipmitool.CipherSuite),
+		ipmitool.WithIpmitoolPath(c.providerConfig.ipmitool.IpmitoolPath),
+	}
+
+	driverIpmitool, err := ipmitool.New(c.Auth.Host, c.Auth.User, c.Auth.Pass, ipmiOpts...)
+	if err != nil {
+		return err
+	}
+
+	c.Registry.Register(ipmitool.ProviderName, ipmitool.ProviderProtocol, ipmitool.Features, nil, driverIpmitool)
+
+	return nil
+}
+
+// register ASRR vendorapi provider
+func (c *Client) registerASRRProvider() error {
+	asrHttpClient := *c.httpClient
+	asrHttpClient.Transport = c.httpClient.Transport.(*http.Transport).Clone()
+	driverAsrockrack := asrockrack.NewWithOptions(c.Auth.Host+":"+c.providerConfig.asrock.Port, c.Auth.User, c.Auth.Pass, c.Logger, asrockrack.WithHTTPClient(&asrHttpClient))
+	c.Registry.Register(asrockrack.ProviderName, asrockrack.ProviderProtocol, asrockrack.Features, nil, driverAsrockrack)
+
+	return nil
+}
+
+// register gofish provider
+func (c *Client) registerGofishProvider() error {
+	gfHttpClient := *c.httpClient
+	gfHttpClient.Transport = c.httpClient.Transport.(*http.Transport).Clone()
+	gofishOpts := []redfish.Option{
+		redfish.WithHttpClient(&gfHttpClient),
+		redfish.WithVersionsNotCompatible(c.providerConfig.gofish.VersionsNotCompatible),
+		redfish.WithUseBasicAuth(c.providerConfig.gofish.UseBasicAuth),
+		redfish.WithPort(c.providerConfig.gofish.Port),
+		redfish.WithEtagMatchDisabled(c.providerConfig.gofish.DisableEtagMatch),
+	}
+
+	driverGoFish := redfish.New(c.Auth.Host, c.Auth.User, c.Auth.Pass, c.Logger, gofishOpts...)
+	c.Registry.Register(redfish.ProviderName, redfish.ProviderProtocol, redfish.Features, nil, driverGoFish)
+
+	return nil
+}
+
+// register Intel AMT provider
+func (c *Client) registerIntelAMTProvider() error {
+
+	iamtOpts := []intelamt.Option{
+		intelamt.WithLogger(c.Logger),
+		intelamt.WithHostScheme(c.providerConfig.intelamt.HostScheme),
+		intelamt.WithPort(c.providerConfig.intelamt.Port),
+	}
+	driverAMT := intelamt.New(c.Auth.Host, c.Auth.User, c.Auth.Pass, iamtOpts...)
+	c.Registry.Register(intelamt.ProviderName, intelamt.ProviderProtocol, intelamt.Features, nil, driverAMT)
+
+	return nil
+}
+
+// register Dell gofish provider
+func (c *Client) registerDellProvider() error {
+	dellGofishHttpClient := *c.httpClient
+	//dellGofishHttpClient.Transport = c.httpClient.Transport.(*http.Transport).Clone()
+	dellGofishOpts := []dell.Option{
+		dell.WithHttpClient(&dellGofishHttpClient),
+		dell.WithVersionsNotCompatible(c.providerConfig.dell.VersionsNotCompatible),
+		dell.WithUseBasicAuth(c.providerConfig.dell.UseBasicAuth),
+		dell.WithPort(c.providerConfig.dell.Port),
+	}
+	driverGoFishDell := dell.New(c.Auth.Host, c.Auth.User, c.Auth.Pass, c.Logger, dellGofishOpts...)
+	c.Registry.Register(dell.ProviderName, redfish.ProviderProtocol, dell.Features, nil, driverGoFishDell)
+
+	return nil
+}
+
+// register supermicro vendorapi provider
+func (c *Client) registerSupermicroProvider() error {
+	smcHttpClient := *c.httpClient
+	smcHttpClient.Transport = c.httpClient.Transport.(*http.Transport).Clone()
+	driverSupermicro := supermicro.NewClient(
+		c.Auth.Host,
+		c.Auth.User,
+		c.Auth.Pass,
+		c.Logger,
+		supermicro.WithHttpClient(&smcHttpClient),
+		supermicro.WithPort(c.providerConfig.supermicro.Port),
+	)
+
+	c.Registry.Register(supermicro.ProviderName, supermicro.ProviderProtocol, supermicro.Features, nil, driverSupermicro)
+
+	return nil
+}
+
 func (c *Client) registerProviders() {
 	// register the rpc provider
 	// without the consumer URL there is no way to send RPC requests.
@@ -157,63 +252,31 @@ func (c *Client) registerProviders() {
 		}
 		c.Logger.Info("failed to register rpc provider, falling back to registering all other providers", "error", err.Error())
 	}
-	// register ipmitool provider
-	ipmiOpts := []ipmitool.Option{
-		ipmitool.WithLogger(c.Logger),
-		ipmitool.WithPort(c.providerConfig.ipmitool.Port),
-		ipmitool.WithCipherSuite(c.providerConfig.ipmitool.CipherSuite),
-		ipmitool.WithIpmitoolPath(c.providerConfig.ipmitool.IpmitoolPath),
-	}
-	if driverIpmitool, err := ipmitool.New(c.Auth.Host, c.Auth.User, c.Auth.Pass, ipmiOpts...); err == nil {
-		c.Registry.Register(ipmitool.ProviderName, ipmitool.ProviderProtocol, ipmitool.Features, nil, driverIpmitool)
-	} else {
+
+	if err := c.registerIPMIProvider(); err != nil {
 		c.Logger.Info("ipmitool provider not available", "error", err.Error())
 	}
 
-	// register ASRR vendorapi provider
-	asrHttpClient := *c.httpClient
-	asrHttpClient.Transport = c.httpClient.Transport.(*http.Transport).Clone()
-	driverAsrockrack := asrockrack.NewWithOptions(c.Auth.Host+":"+c.providerConfig.asrock.Port, c.Auth.User, c.Auth.Pass, c.Logger, asrockrack.WithHTTPClient(&asrHttpClient))
-	c.Registry.Register(asrockrack.ProviderName, asrockrack.ProviderProtocol, asrockrack.Features, nil, driverAsrockrack)
-
-	// register gofish provider
-	gfHttpClient := *c.httpClient
-	gfHttpClient.Transport = c.httpClient.Transport.(*http.Transport).Clone()
-	gofishOpts := []redfish.Option{
-		redfish.WithHttpClient(&gfHttpClient),
-		redfish.WithVersionsNotCompatible(c.providerConfig.gofish.VersionsNotCompatible),
-		redfish.WithUseBasicAuth(c.providerConfig.gofish.UseBasicAuth),
-		redfish.WithPort(c.providerConfig.gofish.Port),
+	if err := c.registerASRRProvider(); err != nil {
+		c.Logger.Info("ASRR provider not available", "error", err.Error())
 	}
-	driverGoFish := redfish.New(c.Auth.Host, c.Auth.User, c.Auth.Pass, c.Logger, gofishOpts...)
-	c.Registry.Register(redfish.ProviderName, redfish.ProviderProtocol, redfish.Features, nil, driverGoFish)
 
-	// register Intel AMT provider
-	iamtOpts := []intelamt.Option{
-		intelamt.WithLogger(c.Logger),
-		intelamt.WithHostScheme(c.providerConfig.intelamt.HostScheme),
-		intelamt.WithPort(c.providerConfig.intelamt.Port),
+	if err := c.registerGofishProvider(); err != nil {
+		c.Logger.Info("Gofish provider not available", "error", err.Error())
 	}
-	driverAMT := intelamt.New(c.Auth.Host, c.Auth.User, c.Auth.Pass, iamtOpts...)
-	c.Registry.Register(intelamt.ProviderName, intelamt.ProviderProtocol, intelamt.Features, nil, driverAMT)
 
-	// register Dell gofish provider
-	dellGofishHttpClient := *c.httpClient
-	//dellGofishHttpClient.Transport = c.httpClient.Transport.(*http.Transport).Clone()
-	dellGofishOpts := []dell.Option{
-		dell.WithHttpClient(&dellGofishHttpClient),
-		dell.WithVersionsNotCompatible(c.providerConfig.dell.VersionsNotCompatible),
-		dell.WithUseBasicAuth(c.providerConfig.dell.UseBasicAuth),
-		dell.WithPort(c.providerConfig.dell.Port),
+	if err := c.registerIntelAMTProvider(); err != nil {
+		c.Logger.Info("Intel AMT provider not available", "error", err.Error())
 	}
-	driverGoFishDell := dell.New(c.Auth.Host, c.Auth.User, c.Auth.Pass, c.Logger, dellGofishOpts...)
-	c.Registry.Register(dell.ProviderName, redfish.ProviderProtocol, dell.Features, nil, driverGoFishDell)
 
-	// register supermicro vendorapi provider
-	smcHttpClient := *c.httpClient
-	smcHttpClient.Transport = c.httpClient.Transport.(*http.Transport).Clone()
-	driverSupermicro := supermicro.NewClient(c.Auth.Host, c.Auth.User, c.Auth.Pass, c.Logger, supermicro.WithHttpClient(&smcHttpClient), supermicro.WithPort(c.providerConfig.supermicro.Port))
-	c.Registry.Register(supermicro.ProviderName, supermicro.ProviderProtocol, supermicro.Features, nil, driverSupermicro)
+	if err := c.registerDellProvider(); err != nil {
+		c.Logger.Info("Dell provider not available", "error", err.Error())
+	}
+
+	if err := c.registerSupermicroProvider(); err != nil {
+		c.Logger.Info("Supermicro provider not available", "error", err.Error())
+	}
+
 }
 
 // GetMetadata returns the metadata that is populated after each BMC function/method call

--- a/option.go
+++ b/option.go
@@ -111,6 +111,12 @@ func WithRedfishUseBasicAuth(useBasicAuth bool) Option {
 	}
 }
 
+func WithRedfishEtagMatchDisabled(d bool) Option {
+	return func(args *Client) {
+		args.providerConfig.gofish.DisableEtagMatch = d
+	}
+}
+
 func WithIntelAMTHostScheme(hostScheme string) Option {
 	return func(args *Client) {
 		args.providerConfig.intelamt.HostScheme = hostScheme

--- a/providers/redfish/redfish.go
+++ b/providers/redfish/redfish.go
@@ -58,8 +58,8 @@ type Config struct {
 	VersionsNotCompatible []string
 	RootCAs               *x509.CertPool
 	UseBasicAuth          bool
-	// WithEtagMatchDisabled disables the If-Match Etag header from being included by the Gofish driver.
-	disableEtagMatch bool
+	// DisableEtagMatch disables the If-Match Etag header from being included by the Gofish driver.
+	DisableEtagMatch bool
 }
 
 // Option for setting optional Client values
@@ -100,7 +100,7 @@ func WithUseBasicAuth(useBasicAuth bool) Option {
 // As of the current implementation this disables the header for POST/PATCH requests to the System entity endpoints.
 func WithEtagMatchDisabled(d bool) Option {
 	return func(c *Config) {
-		c.disableEtagMatch = d
+		c.DisableEtagMatch = d
 	}
 }
 
@@ -118,7 +118,7 @@ func New(host, user, pass string, log logr.Logger, opts ...Option) *Conn {
 	rfOpts := []redfishwrapper.Option{
 		redfishwrapper.WithHTTPClient(defaultConfig.HttpClient),
 		redfishwrapper.WithVersionsNotCompatible(defaultConfig.VersionsNotCompatible),
-		redfishwrapper.WithEtagMatchDisabled(defaultConfig.disableEtagMatch),
+		redfishwrapper.WithEtagMatchDisabled(defaultConfig.DisableEtagMatch),
 	}
 
 	if defaultConfig.RootCAs != nil {


### PR DESCRIPTION
## What does this PR implement/change/remove?

- Exposes the Redfish Etag match header disable parameter added in https://github.com/bmc-toolbox/bmclib/pull/353
- Minor refactor - move provider registration into individual methods

### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes

```
```
