### PR TITLE
e3c256d4i support

### DIFF
--- a/providers/asrockrack/mock_test.go
+++ b/providers/asrockrack/mock_test.go
@@ -82,6 +82,7 @@ func mockASRockBMC() *httptest.Server {
 	// fw update endpoints - in order of invocation
 	handler.HandleFunc("/api/maintenance/flash", bmcFirmwareUpgrade)
 	handler.HandleFunc("/api/maintenance/firmware", bmcFirmwareUpgrade)
+	handler.HandleFunc("/api/maintenance/firmware/firmware", bmcFirmwareUpgrade)
 	handler.HandleFunc("/api/maintenance/firmware/verification", bmcFirmwareUpgrade)
 	handler.HandleFunc("/api/maintenance/firmware/upgrade", bmcFirmwareUpgrade)
 	handler.HandleFunc("/api/maintenance/firmware/flash-progress", bmcFirmwareUpgrade)
@@ -211,7 +212,7 @@ func bmcFirmwareUpgrade(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 
 		// 2. upload firmware
-		case "/api/maintenance/firmware":
+		case "/api/maintenance/firmware", "/api/maintenance/firmware/firmware":
 
 			// validate flash mode set
 			if !fwUpgradeState.FlashModeSet {


### PR DESCRIPTION
By default, update is broken on e3c256d4i. This PR fixes it. Compatibility with e3c246d4i needs to be tested