### PR TITLE
Supermicro no CSRF

### DIFF
--- a/providers/supermicro/firmware.go
+++ b/providers/supermicro/firmware.go
@@ -28,7 +28,6 @@ var (
 		"X12STH-SYS",
 	}
 
-	errUnexpectedModel      = errors.New("unexpected device model")
 	errUploadTaskIDExpected = errors.New("expected an firmware upload taskID")
 )
 

--- a/providers/supermicro/floppy.go
+++ b/providers/supermicro/floppy.go
@@ -50,18 +50,23 @@ func (c *Client) MountFloppyImage(ctx context.Context, image io.Reader) error {
 
 	var payloadBuffer bytes.Buffer
 
-	formParts := []struct {
+	type form struct {
 		name string
 		data io.Reader
-	}{
+	}
+
+	formParts := []form{
 		{
 			name: "img_file",
 			data: image,
 		},
-		{
+	}
+
+	if c.serviceClient.csrfToken != "" {
+		formParts = append(formParts, form{
 			name: "csrf-token",
 			data: bytes.NewBufferString(c.serviceClient.csrfToken),
-		},
+		})
 	}
 
 	payloadWriter := multipart.NewWriter(&payloadBuffer)

--- a/providers/supermicro/supermicro_test.go
+++ b/providers/supermicro/supermicro_test.go
@@ -50,6 +50,11 @@ func TestParseToken(t *testing.T) {
 			[]byte(`<script>SmcCsrfInsert ("CSRF_TOKEN", "RYjdEjWIhU+PCRFMBP2ZRPPePcQ4n3dM3s+rCgTnBBU");</script></body>`),
 			"RYjdEjWIhU+PCRFMBP2ZRPPePcQ4n3dM3s+rCgTnBBU",
 		},
+		{
+			"token with key type 5 found",
+			[]byte(`<script>SmcCsrfInsert ("CSRF-TOKEN", "RYjdEjWIhU+PCRFMBP2ZRPPePcQ4n3dM3s+rCgTnBBU");</script></body>`),
+			"RYjdEjWIhU+PCRFMBP2ZRPPePcQ4n3dM3s+rCgTnBBU",
+		},
 	}
 
 	for _, tc := range testcases {

--- a/providers/supermicro/x11_firmware_bios.go
+++ b/providers/supermicro/x11_firmware_bios.go
@@ -195,18 +195,23 @@ func (c *x11) uploadBIOSFirmware(ctx context.Context, fwReader io.Reader) error 
 	var payloadBuffer bytes.Buffer
 	var err error
 
-	formParts := []struct {
+	type form struct {
 		name string
 		data io.Reader
-	}{
+	}
+
+	formParts := []form{
 		{
 			name: "bios_rom",
 			data: fwReader,
 		},
-		{
+	}
+
+	if c.csrfToken != "" {
+		formParts = append(formParts, form{
 			name: "csrf-token",
 			data: bytes.NewBufferString(c.csrfToken),
-		},
+		})
 	}
 
 	payloadWriter := multipart.NewWriter(&payloadBuffer)

--- a/providers/supermicro/x11_firmware_bmc.go
+++ b/providers/supermicro/x11_firmware_bmc.go
@@ -106,18 +106,23 @@ func (c *x11) uploadBMCFirmware(ctx context.Context, fwReader io.Reader) error {
 	var payloadBuffer bytes.Buffer
 	var err error
 
-	formParts := []struct {
+	type form struct {
 		name string
 		data io.Reader
-	}{
+	}
+
+	formParts := []form{
 		{
 			name: "fw_image",
 			data: fwReader,
 		},
-		{
+	}
+
+	if c.csrfToken != "" {
+		formParts = append(formParts, form{
 			name: "csrf-token",
 			data: bytes.NewBufferString(c.csrfToken),
-		},
+		})
 	}
 
 	payloadWriter := multipart.NewWriter(&payloadBuffer)


### PR DESCRIPTION
## What does this PR implement/change/remove?

Supermicro X11s running on older firmware don't have CSRF support and this change removes the requirement to have a CSRF token so firmware can be updated on those devices.

### Checklist
- [] Tests added
- [X] Similar commits squashed

### The HW vendor this change applies to (if applicable)

Supermicro X11s running BMC firmware `01.71.11 10/25/2019` and older

### The HW model number, product name this change applies to (if applicable)

X11DPH-T

