### PR TITLE
Taskstate constant

### DIFF
--- a/bmc/firmware.go
+++ b/bmc/firmware.go
@@ -406,7 +406,7 @@ type FirmwareTaskVerifier interface {
 	// return values:
 	// state - returns one of the FirmwareTask statuses (see devices/constants.go).
 	// status - returns firmware task progress or other arbitrary task information.
-	FirmwareTaskStatus(ctx context.Context, kind bconsts.FirmwareInstallStep, component, taskID, installVersion string) (state string, status string, err error)
+	FirmwareTaskStatus(ctx context.Context, kind bconsts.FirmwareInstallStep, component, taskID, installVersion string) (state constants.TaskState, status string, err error)
 }
 
 // firmwareTaskVerifierProvider is an internal struct to correlate an implementation/provider and its name
@@ -416,7 +416,7 @@ type firmwareTaskVerifierProvider struct {
 }
 
 // firmwareTaskStatus returns the status of the firmware upload process.
-func firmwareTaskStatus(ctx context.Context, kind bconsts.FirmwareInstallStep, component, taskID, installVersion string, generic []firmwareTaskVerifierProvider) (state, status string, metadata Metadata, err error) {
+func firmwareTaskStatus(ctx context.Context, kind bconsts.FirmwareInstallStep, component, taskID, installVersion string, generic []firmwareTaskVerifierProvider) (state constants.TaskState, status string, metadata Metadata, err error) {
 	var metadataLocal Metadata
 
 	for _, elem := range generic {
@@ -446,7 +446,7 @@ func firmwareTaskStatus(ctx context.Context, kind bconsts.FirmwareInstallStep, c
 }
 
 // FirmwareTaskStatusFromInterfaces identifies implementations of the FirmwareTaskVerifier interface and passes the found implementations to the firmwareTaskStatus() wrapper.
-func FirmwareTaskStatusFromInterfaces(ctx context.Context, kind bconsts.FirmwareInstallStep, component, taskID, installVersion string, generic []interface{}) (state, status string, metadata Metadata, err error) {
+func FirmwareTaskStatusFromInterfaces(ctx context.Context, kind bconsts.FirmwareInstallStep, component, taskID, installVersion string, generic []interface{}) (state constants.TaskState, status string, metadata Metadata, err error) {
 	metadata = newMetadata()
 
 	implementations := make([]firmwareTaskVerifierProvider, 0)

--- a/bmc/firmware_test.go
+++ b/bmc/firmware_test.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/bmc-toolbox/bmclib/v2/constants"
-	"github.com/bmc-toolbox/bmclib/v2/errors"
 	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
 	"github.com/bmc-toolbox/common"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,7 +41,7 @@ func TestFirmwareInstall(t *testing.T) {
 		providersAttempted int
 	}{
 		{"success with metadata", common.SlugBIOS, string(constants.OnReset), false, nil, "1234", nil, 5 * time.Second, "foo", 1},
-		{"failure with metadata", common.SlugBIOS, string(constants.OnReset), false, nil, "1234", errors.ErrNon200Response, 5 * time.Second, "foo", 1},
+		{"failure with metadata", common.SlugBIOS, string(constants.OnReset), false, nil, "1234", bmclibErrs.ErrNon200Response, 5 * time.Second, "foo", 1},
 		{"failure with context timeout", common.SlugBIOS, string(constants.OnReset), false, nil, "1234", context.DeadlineExceeded, 1 * time.Nanosecond, "foo", 1},
 	}
 
@@ -136,7 +136,7 @@ func TestFirmwareInstallStatus(t *testing.T) {
 		providersAttempted int
 	}{
 		{"success with metadata", common.SlugBIOS, "1.1", "1234", constants.FirmwareInstallComplete, nil, 5 * time.Second, "foo", 1},
-		{"failure with metadata", common.SlugBIOS, "1.1", "1234", constants.FirmwareInstallFailed, errors.ErrNon200Response, 5 * time.Second, "foo", 1},
+		{"failure with metadata", common.SlugBIOS, "1.1", "1234", constants.FirmwareInstallFailed, bmclibErrs.ErrNon200Response, 5 * time.Second, "foo", 1},
 		{"failure with context timeout", common.SlugBIOS, "1.1", "1234", "", context.DeadlineExceeded, 1 * time.Nanosecond, "foo", 1},
 	}
 
@@ -459,12 +459,12 @@ func TestFirmwareInstallSteps(t *testing.T) {
 }
 
 type firmwareTaskStatusTester struct {
-	returnState  string
+	returnState  constants.TaskState
 	returnStatus string
 	returnError  error
 }
 
-func (f *firmwareTaskStatusTester) FirmwareTaskStatus(ctx context.Context, kind constants.FirmwareInstallStep, component, taskID, installVersion string) (state string, status string, err error) {
+func (f *firmwareTaskStatusTester) FirmwareTaskStatus(ctx context.Context, kind constants.FirmwareInstallStep, component, taskID, installVersion string) (state constants.TaskState, status string, err error) {
 	return f.returnState, f.returnStatus, f.returnError
 }
 
@@ -479,7 +479,7 @@ func TestFirmwareTaskStatus(t *testing.T) {
 		component          string
 		taskID             string
 		installVersion     string
-		returnState        string
+		returnState        constants.TaskState
 		returnStatus       string
 		returnError        error
 		ctxTimeout         time.Duration
@@ -487,7 +487,7 @@ func TestFirmwareTaskStatus(t *testing.T) {
 		providersAttempted int
 	}{
 		{"success with metadata", constants.FirmwareInstallStepUpload, common.SlugBIOS, "1234", "1.0", constants.FirmwareInstallComplete, "Upload completed", nil, 5 * time.Second, "foo", 1},
-		{"failure with metadata", constants.FirmwareInstallStepUpload, common.SlugBIOS, "1234", "1.0", constants.FirmwareInstallFailed, "Upload failed", errors.ErrNon200Response, 5 * time.Second, "foo", 1},
+		{"failure with metadata", constants.FirmwareInstallStepUpload, common.SlugBIOS, "1234", "1.0", constants.FirmwareInstallFailed, "Upload failed", bmclibErrs.ErrNon200Response, 5 * time.Second, "foo", 1},
 		{"failure with context timeout", constants.FirmwareInstallStepUpload, common.SlugBIOS, "1234", "1.0", "", "", context.DeadlineExceeded, 1 * time.Nanosecond, "foo", 1},
 	}
 
@@ -523,15 +523,15 @@ func TestFirmwareTaskStatusFromInterfaces(t *testing.T) {
 		component          string
 		taskID             string
 		installVersion     string
-		returnState        string
+		returnState        constants.TaskState
 		returnStatus       string
 		returnError        error
 		ctxTimeout         time.Duration
 		providerName       string
 		providersAttempted int
 	}{
-		{"success with metadata", constants.FirmwareInstallStepUpload, common.SlugBIOS, "1234", "1.0", constants.FirmwareInstallComplete, "uploading", nil, 5 * time.Second, "foo", 1},
-		{"failure with metadata", constants.FirmwareInstallStepUpload, common.SlugBIOS, "1234", "1.0", constants.FirmwareInstallFailed, "failed", errors.ErrNon200Response, 5 * time.Second, "foo", 1},
+		{"success with metadata", constants.FirmwareInstallStepUpload, common.SlugBIOS, "1234", "1.0", constants.Complete, "uploading", nil, 5 * time.Second, "foo", 1},
+		{"failure with metadata", constants.FirmwareInstallStepUpload, common.SlugBIOS, "1234", "1.0", constants.Failed, "failed", bmclibErrs.ErrNon200Response, 5 * time.Second, "foo", 1},
 		{"failure with context timeout", constants.FirmwareInstallStepUpload, common.SlugBIOS, "1234", "1.0", "", "", context.DeadlineExceeded, 1 * time.Nanosecond, "foo", 1},
 	}
 

--- a/bmc/firmware_test.go
+++ b/bmc/firmware_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/bmc-toolbox/bmclib/v2/constants"
 	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
 	"github.com/bmc-toolbox/common"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/bmc/firmware_test.go
+++ b/bmc/firmware_test.go
@@ -230,7 +230,7 @@ func TestFirmwareInstallUploaded(t *testing.T) {
 		providersAttempted int
 	}{
 		{"success with metadata", common.SlugBIOS, "1234", "5678", nil, 5 * time.Second, "foo", 1},
-		{"failure with metadata", common.SlugBIOS, "1234", "", errors.ErrNon200Response, 5 * time.Second, "foo", 1},
+		{"failure with metadata", common.SlugBIOS, "1234", "", bmclibErrs.ErrNon200Response, 5 * time.Second, "foo", 1},
 		{"failure with context timeout", common.SlugBIOS, "1234", "", context.DeadlineExceeded, 1 * time.Nanosecond, "foo", 1},
 	}
 
@@ -325,7 +325,7 @@ func TestFirmwareUpload(t *testing.T) {
 		providersAttempted int
 	}{
 		{"success with metadata", common.SlugBIOS, nil, "1234", nil, 5 * time.Second, "foo", 1},
-		{"failure with metadata", common.SlugBIOS, nil, "1234", errors.ErrNon200Response, 5 * time.Second, "foo", 1},
+		{"failure with metadata", common.SlugBIOS, nil, "1234", bmclibErrs.ErrNon200Response, 5 * time.Second, "foo", 1},
 		{"failure with context timeout", common.SlugBIOS, nil, "1234", context.DeadlineExceeded, 1 * time.Nanosecond, "foo", 1},
 	}
 
@@ -430,7 +430,7 @@ func TestFirmwareInstallSteps(t *testing.T) {
 		providersAttempted int
 	}{
 		{"success with metadata", common.SlugBIOS, []constants.FirmwareInstallStep{constants.FirmwareInstallStepUpload, constants.FirmwareInstallStepInstallStatus}, nil, 5 * time.Second, "foo", 1},
-		{"failure with metadata", common.SlugBIOS, nil, errors.ErrNon200Response, 5 * time.Second, "foo", 1},
+		{"failure with metadata", common.SlugBIOS, nil, bmclibErrs.ErrNon200Response, 5 * time.Second, "foo", 1},
 		{"failure with context timeout", common.SlugBIOS, nil, context.DeadlineExceeded, 1 * time.Nanosecond, "foo", 1},
 	}
 

--- a/client.go
+++ b/client.go
@@ -623,7 +623,7 @@ func (c *Client) FirmwareUpload(ctx context.Context, component string, file *os.
 }
 
 // FirmwareTaskStatus pass through library function to check firmware task statuses
-func (c *Client) FirmwareTaskStatus(ctx context.Context, kind constants.FirmwareInstallStep, component, taskID, installVersion string) (state, status string, err error) {
+func (c *Client) FirmwareTaskStatus(ctx context.Context, kind constants.FirmwareInstallStep, component, taskID, installVersion string) (state constants.TaskState, status string, err error) {
 	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "FirmwareTaskStatus")
 	defer span.End()
 

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -6,12 +6,11 @@ type (
 
 	// The FirmwareInstallStep identifies each phase of a firmware install process.
 	FirmwareInstallStep string
+
+	TaskState string
 )
 
 const (
-	// Unknown is the constant that defines unknown things
-	Unknown = "Unknown"
-
 	// EnvEnableDebug is the const for the environment variable to cause bmclib to dump debugging debugging information.
 	// the valid parameter for this environment variable is 'true'
 	EnvEnableDebug = "DEBUG_BMCLIB"
@@ -49,33 +48,41 @@ const (
 	// FirmwareInstallInitializing indicates the device is performing init actions to install the update
 	// this covers the redfish states - 'starting', 'downloading'
 	// no action is required from the callers part in this state
-	FirmwareInstallInitializing = "initializing"
+	FirmwareInstallInitializing           = "initializing"
+	Initializing                TaskState = "initializing"
 
 	// FirmwareInstallQueued indicates the device has queued the update, but has not started the update task yet
 	// this covers the redfish states - 'pending', 'new'
 	// no action is required from the callers part in this state
-	FirmwareInstallQueued = "queued"
+	FirmwareInstallQueued           = "queued"
+	Queued                TaskState = "queued"
 
 	// FirmwareInstallRunner indicates the device is installing the update
 	// this covers the redfish states - 'running', 'stopping', 'cancelling'
 	// no action is required from the callers part in this state
-	FirmwareInstallRunning = "running"
+	FirmwareInstallRunning           = "running"
+	Running                TaskState = "running"
 
 	// FirmwareInstallComplete indicates the device completed the firmware install
 	// this covers the redfish state - 'complete'
-	FirmwareInstallComplete = "complete"
+	FirmwareInstallComplete           = "complete"
+	Complete                TaskState = "complete"
 
 	// FirmwareInstallFailed indicates the firmware install failed
 	// this covers the redfish states - 'interrupted', 'killed', 'exception', 'cancelled', 'suspended'
-	FirmwareInstallFailed = "failed"
+	FirmwareInstallFailed           = "failed"
+	Failed                TaskState = "failed"
 
 	// FirmwareInstallPowerCycleHost indicates the firmware install requires a host power cycle
-	FirmwareInstallPowerCycleHost = "powercycle-host"
+	FirmwareInstallPowerCycleHost           = "powercycle-host"
+	PowerCycleHost                TaskState = "powercycle-host"
 
 	// FirmwareInstallPowerCycleBMC indicates the firmware install requires a BMC power cycle
-	FirmwareInstallPowerCycleBMC = "powercycle-bmc"
+	FirmwareInstallPowerCycleBMC           = "powercycle-bmc"
+	PowerCycleBMC                TaskState = "powercycle-bmc"
 
-	FirmwareInstallUnknown = "unknown"
+	FirmwareInstallUnknown           = "unknown"
+	Unknown                TaskState = "unknown"
 
 	// FirmwareInstallStepUploadInitiateInstall identifies the step to upload _and_ initialize the firmware install.
 	// as part of the same call.

--- a/internal/redfishwrapper/task.go
+++ b/internal/redfishwrapper/task.go
@@ -11,6 +11,10 @@ import (
 	gofishrf "github.com/stmcginnis/gofish/redfish"
 )
 
+var (
+	errUnexpectedTaskState = errors.New("unexpected task state")
+)
+
 func (c *Client) Task(ctx context.Context, taskID string) (*gofishrf.Task, error) {
 	tasks, err := c.Tasks(ctx)
 	if err != nil {
@@ -28,29 +32,43 @@ func (c *Client) Task(ctx context.Context, taskID string) (*gofishrf.Task, error
 	return nil, bmclibErrs.ErrTaskNotFound
 }
 
-func (c *Client) TaskStatus(ctx context.Context, taskID string) (state, status string, err error) {
+func (c *Client) TaskStatus(ctx context.Context, taskID string) (constants.TaskState, string, error) {
 	task, err := c.Task(ctx, taskID)
 	if err != nil {
 		return "", "", errors.Wrap(err, "error querying redfish for taskID: "+taskID)
 	}
 	taskInfo := fmt.Sprintf("id: %s, state: %s, status: %s", task.ID, task.TaskState, task.TaskStatus)
 
-	state = strings.ToLower(string(task.TaskState))
+	state := strings.ToLower(string(task.TaskState))
+	return c.ConvertTaskState(state), taskInfo, nil
+}
 
+func (c *Client) ConvertTaskState(state string) constants.TaskState {
 	switch state {
 	case "starting", "downloading", "downloaded":
-		return constants.FirmwareInstallInitializing, taskInfo, nil
+		return constants.Initializing
 	case "running", "stopping", "cancelling", "scheduling":
-		return constants.FirmwareInstallRunning, taskInfo, nil
+		return constants.Running
 	case "pending", "new":
-		return constants.FirmwareInstallQueued, taskInfo, nil
+		return constants.Queued
 	case "scheduled":
-		return constants.FirmwareInstallPowerCycleHost, taskInfo, nil
+		return constants.PowerCycleHost
 	case "interrupted", "killed", "exception", "cancelled", "suspended", "failed":
-		return constants.FirmwareInstallFailed, taskInfo, nil
+		return constants.Failed
 	case "completed":
-		return constants.FirmwareInstallComplete, taskInfo, nil
+		return constants.Complete
 	default:
-		return constants.FirmwareInstallUnknown, taskInfo, nil
+		return constants.Unknown
+	}
+}
+
+func (c *Client) TaskStateActive(state constants.TaskState) (bool, error) {
+	switch state {
+	case constants.Initializing, constants.Running, constants.Queued:
+		return true, nil
+	case constants.Complete, constants.Failed:
+		return false, nil
+	default:
+		return false, errors.Wrap(errUnexpectedTaskState, string(state))
 	}
 }

--- a/providers/supermicro/firmware.go
+++ b/providers/supermicro/firmware.go
@@ -68,7 +68,7 @@ func (c *Client) FirmwareInstallUploaded(ctx context.Context, component, uploadT
 }
 
 // FirmwareTaskStatus returns the status of a firmware related task queued on the BMC.
-func (c *Client) FirmwareTaskStatus(ctx context.Context, kind constants.FirmwareInstallStep, component, taskID, installVersion string) (state, status string, err error) {
+func (c *Client) FirmwareTaskStatus(ctx context.Context, kind constants.FirmwareInstallStep, component, taskID, installVersion string) (state constants.TaskState, status string, err error) {
 	if err := c.serviceClient.supportsFirmwareInstall(ctx, c.bmc.deviceModel()); err != nil {
 		return "", "", errors.Wrap(bmclibErrs.ErrFirmwareInstallStatus, err.Error())
 	}

--- a/providers/supermicro/supermicro.go
+++ b/providers/supermicro/supermicro.go
@@ -104,7 +104,7 @@ type bmcQueryor interface {
 	firmwareInstallSteps(component string) ([]constants.FirmwareInstallStep, error)
 	firmwareUpload(ctx context.Context, component string, file *os.File) (taskID string, err error)
 	firmwareInstallUploaded(ctx context.Context, component, uploadTaskID string) (installTaskID string, err error)
-	firmwareTaskStatus(ctx context.Context, component, taskID string) (state, status string, err error)
+	firmwareTaskStatus(ctx context.Context, component, taskID string) (state constants.TaskState, status string, err error)
 	// query device model from the bmc
 	queryDeviceModel(ctx context.Context) (model string, err error)
 	// returns the device model, that was queried previously with queryDeviceModel

--- a/providers/supermicro/x11.go
+++ b/providers/supermicro/x11.go
@@ -131,7 +131,7 @@ func (c *x11) firmwareInstallUploaded(ctx context.Context, component, _ string) 
 	return "", errors.Wrap(bmclibErrs.ErrFirmwareInstallUploaded, "component unsupported: "+component)
 }
 
-func (c *x11) firmwareTaskStatus(ctx context.Context, component, _ string) (state, status string, err error) {
+func (c *x11) firmwareTaskStatus(ctx context.Context, component, _ string) (state constants.TaskState, status string, err error) {
 	component = strings.ToUpper(component)
 
 	switch component {

--- a/providers/supermicro/x11_firmware_bmc_test.go
+++ b/providers/supermicro/x11_firmware_bmc_test.go
@@ -366,7 +366,7 @@ func TestX11InitiateBMCFirmwareInstall(t *testing.T) {
 func TestX11StatusBMCFirmwareInstall(t *testing.T) {
 	testcases := []struct {
 		name          string
-		expectState   string
+		expectState   constants.TaskState
 		expectStatus  string
 		errorContains string
 		endpoint      string
@@ -374,7 +374,7 @@ func TestX11StatusBMCFirmwareInstall(t *testing.T) {
 	}{
 		{
 			"state complete 0",
-			constants.FirmwareInstallComplete,
+			constants.Complete,
 			"0%",
 			"",
 			"/cgi/upgrade_process.cgi",
@@ -399,7 +399,7 @@ func TestX11StatusBMCFirmwareInstall(t *testing.T) {
 		},
 		{
 			"state complete 100",
-			constants.FirmwareInstallComplete,
+			constants.Complete,
 			"100%",
 			"",
 			"/cgi/upgrade_process.cgi",
@@ -424,7 +424,7 @@ func TestX11StatusBMCFirmwareInstall(t *testing.T) {
 		},
 		{
 			"state initializing",
-			constants.FirmwareInstallInitializing,
+			constants.Initializing,
 			"1%",
 			"",
 			"/cgi/upgrade_process.cgi",
@@ -449,7 +449,7 @@ func TestX11StatusBMCFirmwareInstall(t *testing.T) {
 		},
 		{
 			"status running",
-			constants.FirmwareInstallRunning,
+			constants.Running,
 			"95%",
 			"",
 			"/cgi/upgrade_process.cgi",
@@ -474,7 +474,7 @@ func TestX11StatusBMCFirmwareInstall(t *testing.T) {
 		},
 		{
 			"status unknown",
-			constants.FirmwareInstallUnknown,
+			constants.Unknown,
 			"",
 			"session expired",
 			"/cgi/upgrade_process.cgi",

--- a/providers/supermicro/x12.go
+++ b/providers/supermicro/x12.go
@@ -294,7 +294,7 @@ func (c *x12) firmwareInstallUploaded(ctx context.Context, component, uploadTask
 	return c.redfish.StartUpdateForUploadedFirmware(ctx)
 }
 
-func (c *x12) firmwareTaskStatus(ctx context.Context, component, taskID string) (state, status string, err error) {
+func (c *x12) firmwareTaskStatus(ctx context.Context, component, taskID string) (state constants.TaskState, status string, err error) {
 	if err = c.supportsInstall(component); err != nil {
 		return "", "", errors.Wrap(brrs.ErrFirmwareTaskStatus, err.Error())
 	}


### PR DESCRIPTION
## What does this PR implement/change/remove?

Updates the `FirmwareTaskVerifier` interface and its implementations to return a `constant.TaskState` type.

### Checklist
- [X] Tests added
- [X] Similar commits squashed
