### PR TITLE
Supermicro redfish methods

### DIFF
--- a/providers/redfish/main_test.go
+++ b/providers/redfish/main_test.go
@@ -57,9 +57,7 @@ func TestMain(m *testing.M) {
 		handler := http.NewServeMux()
 		handler.HandleFunc("/redfish/v1/", serviceRoot)
 		handler.HandleFunc("/redfish/v1/SessionService/Sessions", sessionService)
-		handler.HandleFunc("/redfish/v1/UpdateService/MultipartUpload", multipartUpload)
 		handler.HandleFunc("/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/Jobs?$expand=*($levels=1)", dellJobs)
-		handler.HandleFunc("/redfish/v1/TaskService/Tasks/", openbmcStatus)
 
 		return httptest.NewTLSServer(handler)
 	}()

--- a/providers/redfish/tasks.go
+++ b/providers/redfish/tasks.go
@@ -99,27 +99,6 @@ func (c *Conn) GetFirmwareInstallTaskQueued(ctx context.Context, component strin
 	return task, nil
 }
 
-// purgeQueuedFirmwareInstallTask removes any existing queued firmware install task for the given component slug
-func (c *Conn) purgeQueuedFirmwareInstallTask(ctx context.Context, component string) error {
-	vendor, _, err := c.redfishwrapper.DeviceVendorModel(ctx)
-	if err != nil {
-		return errors.Wrap(err, "unable to determine device vendor, model attributes")
-	}
-
-	// check an update task for the component is currently scheduled
-	switch {
-	case strings.Contains(vendor, constants.Dell):
-		err = c.dellPurgeScheduledFirmwareInstallJob(component)
-	default:
-		err = errors.Wrap(
-			bmclibErrs.ErrFirmwareInstall,
-			"Update is already running",
-		)
-	}
-
-	return err
-}
-
 // GetTask returns the current Task fir the given TaskID
 func (c *Conn) GetTask(taskID string) (task *gofishrf.Task, err error) {
 	resp, err := c.redfishwrapper.Get("/redfish/v1/TaskService/Tasks/" + taskID)

--- a/providers/supermicro/docs/x11.md
+++ b/providers/supermicro/docs/x11.md
@@ -1,0 +1,31 @@
+#### x11 XML API power commands
+
+power-off - immediate - `op=POWER_INFO.XML&r=(1,0)&_=`
+power-on - `op=POWER_INFO.XML&r=(1,1)&_=`
+power-off - `acpi/orderly - op=POWER_INFO.XML&r=(1,5)&_=`
+reset server - cold powercycle - `op=POWER_INFO.XML&r=(1,3)&_=`
+power cycle - `op=POWER_INFO.XML&r=(1,2)&_=`
+
+
+ref invocation
+```go
+// powerCycle using SMC XML API
+func (c *x11) powerCycle(ctx context.Context) (bool, error) {
+	payload := []byte(`op=POWER_INFO.XML&r=(1,3)&_=`)
+
+	headers := map[string]string{
+		"Content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+	}
+
+	body, status, err := c.serviceClient.query(ctx, "cgi/ipmi.cgi", http.MethodPost, bytes.NewBuffer(payload), headers, 0)
+	if err != nil {
+		return false, err
+	}
+
+	if status != http.StatusOK {
+		return false, unexpectedResponseErr(payload, body, status)
+	}
+
+	return true, nil
+}
+```

--- a/providers/supermicro/floppy.go
+++ b/providers/supermicro/floppy.go
@@ -20,7 +20,7 @@ var (
 )
 
 func (c *Client) floppyImageMounted(ctx context.Context) (bool, error) {
-	if err := c.openRedfish(ctx); err != nil {
+	if err := c.serviceClient.redfishSession(ctx); err != nil {
 		return false, err
 	}
 

--- a/providers/supermicro/supermicro.go
+++ b/providers/supermicro/supermicro.go
@@ -20,6 +20,7 @@ import (
 	"github.com/bmc-toolbox/bmclib/v2/internal/httpclient"
 	"github.com/bmc-toolbox/bmclib/v2/internal/redfishwrapper"
 	"github.com/bmc-toolbox/bmclib/v2/providers"
+	"github.com/bmc-toolbox/common"
 
 	"github.com/go-logr/logr"
 	"github.com/jacobweinstock/registrar"
@@ -46,6 +47,9 @@ var (
 		providers.FeatureFirmwareInstallUploaded,
 		providers.FeatureFirmwareTaskStatus,
 		providers.FeatureFirmwareInstallSteps,
+		providers.FeatureInventoryRead,
+		providers.FeaturePowerSet,
+		providers.FeaturePowerState,
 	}
 )
 
@@ -182,6 +186,33 @@ func (c *Client) Open(ctx context.Context) (err error) {
 	}
 
 	return nil
+}
+
+// PowerStateGet gets the power state of a BMC machine
+func (c *Client) PowerStateGet(ctx context.Context) (state string, err error) {
+	if c.serviceClient == nil || c.serviceClient.redfish == nil {
+		return "", errors.Wrap(bmclibErrs.ErrLoginFailed, "client not initialized")
+	}
+
+	return c.serviceClient.redfish.SystemPowerStatus(ctx)
+}
+
+// PowerSet sets the power state of a server
+func (c *Client) PowerSet(ctx context.Context, state string) (ok bool, err error) {
+	if c.serviceClient == nil || c.serviceClient.redfish == nil {
+		return false, errors.Wrap(bmclibErrs.ErrLoginFailed, "client not initialized")
+	}
+
+	return c.serviceClient.redfish.PowerSet(ctx, state)
+}
+
+// Inventory collects hardware inventory and install firmware information
+func (c *Client) Inventory(ctx context.Context) (device *common.Device, err error) {
+	if c.serviceClient == nil || c.serviceClient.redfish == nil {
+		return nil, errors.Wrap(bmclibErrs.ErrLoginFailed, "client not initialized")
+	}
+
+	return c.serviceClient.redfish.Inventory(ctx, false)
 }
 
 func (c *Client) bmcQueryor(ctx context.Context) (bmcQueryor, error) {


### PR DESCRIPTION
## What does this PR implement/change/remove?

- Implements the Inventory, PowerStateGet, PowerSet methods for the Supermicro provider using the redfishwrapper package.

### Checklist
- [ ] Tests added
- [X] Similar commits squashed


