### PR TITLE
openbmc, supermicro: implement BMCResetter interface

### DIFF
--- a/providers/openbmc/openbmc.go
+++ b/providers/openbmc/openbmc.go
@@ -29,6 +29,7 @@ var (
 	Features = registrar.Features{
 		providers.FeaturePowerState,
 		providers.FeaturePowerSet,
+		providers.FeatureBmcReset,
 		providers.FeatureFirmwareInstallSteps,
 		providers.FeatureFirmwareUploadInitiateInstall,
 		providers.FeatureFirmwareTaskStatus,
@@ -177,4 +178,9 @@ func (c *Conn) PowerSet(ctx context.Context, state string) (ok bool, err error) 
 // Inventory collects hardware inventory and install firmware information
 func (c *Conn) Inventory(ctx context.Context) (device *common.Device, err error) {
 	return c.redfishwrapper.Inventory(ctx, false)
+}
+
+// BmcReset power cycles the BMC
+func (c *Conn) BmcReset(ctx context.Context, resetType string) (ok bool, err error) {
+	return c.redfishwrapper.BMCReset(ctx, resetType)
 }

--- a/providers/supermicro/supermicro.go
+++ b/providers/supermicro/supermicro.go
@@ -50,6 +50,7 @@ var (
 		providers.FeatureInventoryRead,
 		providers.FeaturePowerSet,
 		providers.FeaturePowerState,
+		providers.FeatureBmcReset,
 	}
 )
 
@@ -208,6 +209,15 @@ func (c *Client) PowerSet(ctx context.Context, state string) (ok bool, err error
 	}
 
 	return c.serviceClient.redfish.PowerSet(ctx, state)
+}
+
+// BmcReset power cycles the BMC
+func (c *Client) BmcReset(ctx context.Context, resetType string) (ok bool, err error) {
+	if c.serviceClient == nil || c.serviceClient.redfish == nil {
+		return false, errors.Wrap(bmclibErrs.ErrLoginFailed, "client not initialized")
+	}
+
+	return c.serviceClient.redfish.BMCReset(ctx, resetType)
 }
 
 // Inventory collects hardware inventory and install firmware information


### PR DESCRIPTION
## What does this PR implement/change/remove?

This makes sure when the provider is pinned/filtered* the BmcReset method is available.

* https://github.com/bmc-toolbox/bmclib#one-time-filtering


### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)

OpenBMC firmware, Supermicros 