### PR TITLE
Smc checks

### DIFF
--- a/providers/supermicro/firmware.go
+++ b/providers/supermicro/firmware.go
@@ -26,6 +26,7 @@ var (
 		"X11DPT-B",
 		"X11SSE-F",
 		"X12STH-SYS",
+		"X12SPO-NTF",
 	}
 
 	errUploadTaskIDExpected = errors.New("expected an firmware upload taskID")


### PR DESCRIPTION
## What does this PR implement/change/remove?
- list `x12spo-ntf` as supported.
- Ensure session is closed on a partial `Open()` failure. 

### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)
SMC