### PR TITLE
Revert to Go 1.18 in go.mod and make policy around this official

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,12 @@ The current bmclib version is `v2` and is being developed on the `main` branch.
 
 The previous bmclib version is in maintenance mode and can be found here [v1](https://github.com/bmc-toolbox/bmclib/v1).
 
+## Go version in `go.mod`
+
+As a library we will only bump the version of Go in the `go.mod` file when there are required dependencies in bmclib that necessitate
+a version bump. When consuming bmclib in your project, we recommend always building with the latest Go version but this
+should be in your hands as a user as much as possible.
+
 ## Acknowledgments
 
 bmclib v2 interfaces with Redfish on BMCs through the Gofish library https://github.com/stmcginnis/gofish

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bmc-toolbox/bmclib/v2
 
-go 1.22
+go 1.18
 
 require (
 	dario.cat/mergo v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -88,7 +88,6 @@ golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
 golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.19.0 h1:+ThwsDv+tYfnJFhF4L8jITxu1tdTWRTZpdsWgEgjL6Q=
-golang.org/x/term v0.19.0/go.mod h1:2CuTdWZ7KHSQwUzKva0cbMg6q2DMI3Mmxp+gKJbskEk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=


### PR DESCRIPTION
## What does this PR implement/change/remove?
We don't seem to have an official strategy for the Go version in go.mod. I believe that, as a library, we should only bump this version if there are dependencies we use that would require us to move to this version ([ref](https://go.dev/doc/modules/gomod-ref#:~:text=The%20minimum%20version%20of%20Go%20required%20by%20the%20current%20module.)). I don't believe that we have any dependencies that warrant a bump. Bumping this version will require user to update to this version. While it is a good practice to build with the latest version of Go, this requirement will be making a decision for users that should be theirs and not ours. We are a library not a binary to be built. In this aspect, we are using the version in go.mod incorrectly, in my opinion, by doing this. This assumes we don't have a known use case where bumping this version if needed. I don't know of any at the moment. If there are any we should bring them up.

Apologies, i know i approved the [PR](https://github.com/bmc-toolbox/bmclib/pull/386) to update this. The affects of this didn't dawn on me then.

### __The other side of the coin__

There can be reasons to bump this version. I think before we bump the version we should have use cases the bump and more carefully consider the affects. From the official Go docs:
_"At go 1.21 or higher:
The go line declares a required minimum version of Go to use with this module.
The go line must be greater than or equal to the go line of all dependencies.
The go command no longer attempts to maintain compatibility with the previous older version of Go.
The go command is more careful about keeping checksums of go.mod files in the go.sum file."_ - [ref](https://go.dev/doc/modules/gomod-ref#:~:text=At%20go%201.21,go.sum%20file.)

### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes

```
```
