### PR TITLE
Supermicro X13 inventory/firmware support FS-1671

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        args: -v --config .golangci.yml --timeout=5m
+        args: -v --config .golangci.yml --timeout=5m --out-format=colored-line-number
         version: latest
     - name: make all-checks
       run: make all-checks

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         args: -v --config .golangci.yml --timeout=5m --out-format=colored-line-number
-        version: latest
+        version: v1.55.2
     - name: make all-checks
       run: make all-checks
   test:

--- a/internal/redfishwrapper/firmware.go
+++ b/internal/redfishwrapper/firmware.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/bmc-toolbox/bmclib/v2/constants"
 	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
+	redfish "github.com/stmcginnis/gofish/redfish"
 )
 
 type installMethod string
@@ -103,6 +104,14 @@ func (c *Client) FirmwareUpload(ctx context.Context, updateFile *os.File, params
 			bmclibErrs.ErrFirmwareUpload,
 			"unexpected status code returned: "+resp.Status,
 		)
+	}
+
+	// For X13 the full Task structure is returned in the body.   If we can Unmarshall then we can safely assume
+	// that redfishTask.ID contains the ID.
+	redfishTask := &redfish.Task{}
+	err = json.Unmarshal(response, redfishTask)
+	if err == nil {
+		return redfishTask.ID, nil
 	}
 
 	// The response contains a location header pointing to the task URI

--- a/providers/supermicro/firmware.go
+++ b/providers/supermicro/firmware.go
@@ -47,7 +47,7 @@ func (c *Client) FirmwareUpload(ctx context.Context, component string, file *os.
 		return "", err
 	}
 
-	//	// expect atleast 5 minutes left in the deadline to proceed with the upload
+	// expect atleast 5 minutes left in the deadline to proceed with the upload
 	d, _ := ctx.Deadline()
 	if time.Until(d) < 5*time.Minute {
 		return "", errors.New("remaining context deadline insufficient to perform update: " + time.Until(d).String())

--- a/providers/supermicro/firmware.go
+++ b/providers/supermicro/firmware.go
@@ -27,6 +27,7 @@ var (
 		"X11SSE-F",
 		"X12STH-SYS",
 		"X12SPO-NTF",
+		"X13DEM",
 	}
 
 	errUploadTaskIDExpected = errors.New("expected an firmware upload taskID")

--- a/providers/supermicro/supermicro.go
+++ b/providers/supermicro/supermicro.go
@@ -315,13 +315,7 @@ func (c *Client) bmcQueryor(ctx context.Context) (bmcQueryor, error) {
 	for _, bmc := range []bmcQueryor{x11bmc, x12bmc, x13bmc} {
 		var err error
 
-<<<<<<< HEAD
-		// Note to maintainers: x12 lacks support for the ipmi.cgi endpoint,
-		// which will lead to our graceful handling of ErrXMLAPIUnsupported below.
-		_, err = bmc.queryDeviceModel(ctx)
-=======
 		deviceModel, err := bmc.queryDeviceModel(ctx)
->>>>>>> 3d1fe09 (providers/supermicro/supermicro.go: Fix bmcQueryor to properly match queryor to model)
 		if err != nil {
 			if errors.Is(err, ErrXMLAPIUnsupported) {
 				continue

--- a/providers/supermicro/supermicro_test.go
+++ b/providers/supermicro/supermicro_test.go
@@ -143,7 +143,7 @@ func TestOpen(t *testing.T) {
 					<title></title>
 					<script language="JavaScript" type="text/javascript">
 				<!--
-					self.location = "../cgi/url_redirect.cgi?url_name=mainmenu";
+					self.location = "../cgi/url_redirect.cgi?url_name=topmenu";
 				-->
 					</script>
 				</head>

--- a/providers/supermicro/x11.go
+++ b/providers/supermicro/x11.go
@@ -39,7 +39,6 @@ func (c *x11) queryDeviceModel(ctx context.Context) (string, error) {
 	errBoardPartNumUnknown := errors.New("baseboard part number unknown")
 	data, err := c.fruInfo(ctx)
 	if err != nil {
-		c.log.Error(err, "fruInfo error")
 		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "<html>") {
 			return "", ErrXMLAPIUnsupported
 		}

--- a/providers/supermicro/x11.go
+++ b/providers/supermicro/x11.go
@@ -39,7 +39,8 @@ func (c *x11) queryDeviceModel(ctx context.Context) (string, error) {
 	errBoardPartNumUnknown := errors.New("baseboard part number unknown")
 	data, err := c.fruInfo(ctx)
 	if err != nil {
-		if strings.Contains(err.Error(), "404") {
+		c.log.Error(err, "fruInfo error")
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "<html>") {
 			return "", ErrXMLAPIUnsupported
 		}
 

--- a/providers/supermicro/x12.go
+++ b/providers/supermicro/x12.go
@@ -222,7 +222,7 @@ func (c *x12) biosFwInstallParams() (map[string]bool, error) {
 		}, nil
 	default:
 		// ideally we never get in this position, since theres model number validation in parent callers.
-		return nil, errors.New("unsupported model for BIOS fw install: " + c.model)
+		return nil, errors.New("unsupported model for x12 BIOS fw install: " + c.model)
 	}
 }
 

--- a/providers/supermicro/x12.go
+++ b/providers/supermicro/x12.go
@@ -142,6 +142,10 @@ func (c *x12) firmwareTaskActive(ctx context.Context, component string) error {
 
 // noTasksRunning returns an error if a firmware related task was found active
 func noTasksRunning(component string, t *redfish.Task) error {
+	if t.TaskState == "Killed" {
+		return nil
+	}
+
 	errTaskActive := errors.New("A firmware task was found active for component: " + component)
 
 	const (

--- a/providers/supermicro/x13.go
+++ b/providers/supermicro/x13.go
@@ -1,0 +1,312 @@
+package supermicro
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/bmc-toolbox/bmclib/v2/constants"
+	brrs "github.com/bmc-toolbox/bmclib/v2/errors"
+	rfw "github.com/bmc-toolbox/bmclib/v2/internal/redfishwrapper"
+	"github.com/bmc-toolbox/common"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"github.com/stmcginnis/gofish/redfish"
+	"golang.org/x/exp/slices"
+)
+
+type x13 struct {
+	*serviceClient
+	model string
+	log   logr.Logger
+}
+
+func newX13Client(client *serviceClient, logger logr.Logger) bmcQueryor {
+	return &x13{
+		serviceClient: client,
+		log:           logger,
+	}
+}
+
+func (c *x13) deviceModel() string {
+	return c.model
+}
+
+func (c *x13) queryDeviceModel(ctx context.Context) (string, error) {
+	if err := c.redfishSession(ctx); err != nil {
+		return "", err
+	}
+
+	_, model, err := c.redfish.DeviceVendorModel(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	if model == "" {
+		return "", errors.Wrap(ErrModelUnknown, "empty value")
+	}
+
+	c.model = common.FormatProductName(model)
+
+	return c.model, nil
+}
+
+func (c *x13) supportsInstall(component string) error {
+	errComponentNotSupported := fmt.Errorf("component %s on device %s not supported", component, c.model)
+
+	supported := []string{common.SlugBIOS, common.SlugBMC}
+	if !slices.Contains(supported, strings.ToUpper(component)) {
+		return errComponentNotSupported
+	}
+
+	return nil
+}
+
+func (c *x13) firmwareInstallSteps(component string) ([]constants.FirmwareInstallStep, error) {
+	if err := c.supportsInstall(component); err != nil {
+		return nil, err
+	}
+
+	return []constants.FirmwareInstallStep{
+		constants.FirmwareInstallStepUpload,
+		constants.FirmwareInstallStepUploadStatus,
+		constants.FirmwareInstallStepInstallUploaded,
+		constants.FirmwareInstallStepInstallStatus,
+	}, nil
+}
+
+// upload firmware
+func (c *x13) firmwareUpload(ctx context.Context, component string, file *os.File) (taskID string, err error) {
+	if err = c.supportsInstall(component); err != nil {
+		return "", err
+	}
+
+	err = c.firmwareTaskActive(ctx, component)
+	if err != nil {
+		return "", err
+	}
+
+	targetID, err := c.redfishOdataID(ctx, component)
+	if err != nil {
+		return "", err
+	}
+
+	params, err := c.redfishParameters(component, targetID)
+	if err != nil {
+		return "", err
+	}
+
+	taskID, err = c.redfish.FirmwareUpload(ctx, file, params)
+	if err != nil {
+		if strings.Contains(err.Error(), "OemFirmwareAlreadyInUpdateMode") {
+			return "", errors.Wrap(brrs.ErrBMCColdResetRequired, "BMC currently in update mode, either continue the update OR if no update is currently running - reset the BMC")
+		}
+
+		return "", errors.Wrap(err, "error in firmware upload")
+	}
+
+	if taskID == "" {
+		return "", errUploadTaskIDEmpty
+	}
+
+	return taskID, nil
+}
+
+// returns an error when a bmc firmware install is active
+func (c *x13) firmwareTaskActive(ctx context.Context, component string) error {
+	tasks, err := c.redfish.Tasks(ctx)
+	if err != nil {
+		return errors.Wrap(err, "error querying redfish tasks")
+	}
+
+	for _, t := range tasks {
+		t := t
+
+		if stateFinalized(t.TaskState) {
+			continue
+		}
+
+		if err := noTasksRunning(component, t); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// // noTasksRunning returns an error if a firmware related task was found active
+// func noTasksRunning(component string, t *redfish.Task) error {
+// 	errTaskActive := errors.New("A firmware task was found active for component: " + component)
+
+// 	const (
+// 		// The redfish task name when the BMC is verifies the uploaded BMC firmware.
+// 		verifyBMCFirmware = "BMC Verify"
+// 		// The redfish task name when the BMC is installing the uploaded BMC firmware.
+// 		updateBMCFirmware = "BMC Update"
+// 		// The redfish task name when the BMC is verifies the uploaded BIOS firmware.
+// 		verifyBIOSFirmware = "BIOS Verify"
+// 		// The redfish task name when the BMC is installing the uploaded BIOS firmware.
+// 		updateBIOSFirmware = "BIOS Update"
+// 	)
+
+// 	var verifyTaskName, updateTaskName string
+
+// 	switch strings.ToUpper(component) {
+// 	case common.SlugBMC:
+// 		verifyTaskName = verifyBMCFirmware
+// 		updateTaskName = updateBMCFirmware
+// 	case common.SlugBIOS:
+// 		verifyTaskName = verifyBIOSFirmware
+// 		updateTaskName = updateBIOSFirmware
+// 	}
+
+// 	taskInfo := fmt.Sprintf("id: %s, state: %s, status: %s", t.ID, t.TaskState, t.TaskStatus)
+
+// 	switch t.Name {
+// 	case verifyTaskName:
+// 		return errors.Wrap(errTaskActive, taskInfo)
+// 	case updateTaskName:
+// 		return errors.Wrap(errTaskActive, taskInfo)
+// 	default:
+// 		return nil
+// 	}
+// }
+
+// func stateFinalized(s redfish.TaskState) bool {
+// 	finalized := []redfish.TaskState{
+// 		redfish.CompletedTaskState,
+// 		redfish.CancelledTaskState,
+// 		redfish.InterruptedTaskState,
+// 		redfish.ExceptionTaskState,
+// 	}
+
+// 	return slices.Contains(finalized, s)
+// }
+
+// type Supermicro struct {
+// 	BIOS map[string]bool `json:"BIOS,omitempty"`
+// 	BMC  map[string]bool `json:"BMC,omitempty"`
+// }
+
+// type OEM struct {
+// 	Supermicro `json:"Supermicro"`
+// }
+
+// redfish OEM fw install parameters
+func (c *x13) biosFwInstallParams() (map[string]bool, error) {
+	switch c.model {
+	case "x13spo-ntf":
+		return map[string]bool{
+			"PreserveME":       false,
+			"PreserveNVRAM":    false,
+			"PreserveSMBIOS":   true,
+			"BackupBIOS":       false,
+			"PreserveBOOTCONF": true,
+		}, nil
+	case "x13sth-sys":
+		return map[string]bool{
+			"PreserveME":         false,
+			"PreserveNVRAM":      false,
+			"PreserveSMBIOS":     true,
+			"PreserveOA":         true,
+			"PreserveSETUPCONF":  true,
+			"PreserveSETUPPWD":   true,
+			"PreserveSECBOOTKEY": true,
+			"PreserveBOOTCONF":   true,
+		}, nil
+	default:
+		// ideally we never get in this position, since theres model number validation in parent callers.
+		return nil, errors.New("unsupported model for BIOS fw install: " + c.model)
+	}
+}
+
+// redfish OEM fw install parameters
+func (c *x13) bmcFwInstallParams() map[string]bool {
+	return map[string]bool{
+		"PreserveCfg": true,
+		"PreserveSdr": true,
+		"PreserveSsl": true,
+	}
+}
+
+func (c *x13) redfishParameters(component, targetODataID string) (*rfw.RedfishUpdateServiceParameters, error) {
+	errUnsupported := errors.New("redfish parameters for x13 hardware component not supported: " + component)
+
+	oem := OEM{}
+
+	biosInstallParams, err := c.biosFwInstallParams()
+	if err != nil {
+		return nil, err
+	}
+
+	switch strings.ToUpper(component) {
+	case common.SlugBIOS:
+		oem.Supermicro.BIOS = biosInstallParams
+	case common.SlugBMC:
+		oem.Supermicro.BMC = c.bmcFwInstallParams()
+	default:
+		return nil, errUnsupported
+	}
+
+	b, err := json.Marshal(oem)
+	if err != nil {
+		return nil, errors.Wrap(err, "error preparing redfish parameters")
+	}
+
+	return &rfw.RedfishUpdateServiceParameters{
+		// NOTE:
+		// X13s support the OnReset Apply time for BIOS updates if we want to implement that in the future.
+		OperationApplyTime: constants.OnStartUpdateRequest,
+		Targets:            []string{targetODataID},
+		Oem:                b,
+	}, nil
+}
+
+func (c *x13) redfishOdataID(ctx context.Context, component string) (string, error) {
+	errUnsupported := errors.New("unable to return redfish OData ID for unsupported component: " + component)
+
+	switch strings.ToUpper(component) {
+	case common.SlugBMC:
+		return c.redfish.ManagerOdataID(ctx)
+	case common.SlugBIOS:
+		// hardcoded since SMCs without the DCMS license will throw license errors
+		return "/redfish/v1/Systems/1/Bios", nil
+		//return c.redfish.SystemsBIOSOdataID(ctx)
+	}
+
+	return "", errUnsupported
+}
+
+func (c *x13) firmwareInstallUploaded(ctx context.Context, component, uploadTaskID string) (installTaskID string, err error) {
+	if err = c.supportsInstall(component); err != nil {
+		return "", err
+	}
+
+	task, err := c.redfish.Task(ctx, uploadTaskID)
+	if err != nil {
+		e := fmt.Sprintf("error querying redfish tasks for firmware upload taskID: %s, err: %s", uploadTaskID, err.Error())
+		return "", errors.Wrap(brrs.ErrFirmwareVerifyTask, e)
+	}
+
+	taskInfo := fmt.Sprintf("id: %s, state: %s, status: %s", task.ID, task.TaskState, task.TaskStatus)
+
+	if task.TaskState != redfish.CompletedTaskState {
+		return "", errors.Wrap(brrs.ErrFirmwareVerifyTask, taskInfo)
+	}
+
+	if task.TaskStatus != "OK" {
+		return "", errors.Wrap(brrs.ErrFirmwareVerifyTask, taskInfo)
+	}
+
+	return c.redfish.StartUpdateForUploadedFirmware(ctx)
+}
+
+func (c *x13) firmwareTaskStatus(ctx context.Context, component, taskID string) (state constants.TaskState, status string, err error) {
+	if err = c.supportsInstall(component); err != nil {
+		return "", "", errors.Wrap(brrs.ErrFirmwareTaskStatus, err.Error())
+	}
+
+	return c.redfish.TaskStatus(ctx, taskID)
+}

--- a/providers/supermicro/x13.go
+++ b/providers/supermicro/x13.go
@@ -69,10 +69,12 @@ func (c *x13) firmwareInstallSteps(component string) ([]constants.FirmwareInstal
 		return nil, err
 	}
 
+	// return []constants.FirmwareInstallStep{
+	// 	constants.FirmwareInstallStepUploadInitiateInstall,
+	// 	constants.FirmwareInstallStepInstallStatus,
+	// }, nil
 	return []constants.FirmwareInstallStep{
-		constants.FirmwareInstallStepUpload,
-		constants.FirmwareInstallStepUploadStatus,
-		constants.FirmwareInstallStepInstallUploaded,
+		constants.FirmwareInstallStepUploadInitiateInstall,
 		constants.FirmwareInstallStepInstallStatus,
 	}, nil
 }

--- a/providers/supermicro/x13.go
+++ b/providers/supermicro/x13.go
@@ -197,15 +197,7 @@ func (c *x13) firmwareTaskActive(ctx context.Context, component string) error {
 // redfish OEM fw install parameters
 func (c *x13) biosFwInstallParams() (map[string]bool, error) {
 	switch c.model {
-	case "x13spo-ntf":
-		return map[string]bool{
-			"PreserveME":       false,
-			"PreserveNVRAM":    false,
-			"PreserveSMBIOS":   true,
-			"BackupBIOS":       false,
-			"PreserveBOOTCONF": true,
-		}, nil
-	case "x13sth-sys":
+	case "x13dem":
 		return map[string]bool{
 			"PreserveME":         false,
 			"PreserveNVRAM":      false,

--- a/providers/supermicro/x13.go
+++ b/providers/supermicro/x13.go
@@ -246,3 +246,21 @@ func (c *x13) firmwareTaskStatus(ctx context.Context, component, taskID string) 
 
 	return c.redfish.TaskStatus(ctx, taskID)
 }
+
+func (c *x13) getBootProgress() (*redfish.BootProgress, error) {
+	bps, err := c.redfish.GetBootProgress()
+	if err != nil {
+		return nil, err
+	}
+	return bps[0], nil
+}
+
+// this is some syntactic sugar to avoid having to code potentially provider- or model-specific knowledge into a caller
+func (c *x13) bootComplete() (bool, error) {
+	bp, err := c.getBootProgress()
+	if err != nil {
+		return false, err
+	}
+	// we determined this by experiment on X12STH-SYS with redfish 1.14.0
+	return bp.LastState == redfish.SystemHardwareInitializationCompleteBootProgressTypes, nil
+}

--- a/providers/supermicro/x13.go
+++ b/providers/supermicro/x13.go
@@ -136,64 +136,6 @@ func (c *x13) firmwareTaskActive(ctx context.Context, component string) error {
 	return nil
 }
 
-// // noTasksRunning returns an error if a firmware related task was found active
-// func noTasksRunning(component string, t *redfish.Task) error {
-// 	errTaskActive := errors.New("A firmware task was found active for component: " + component)
-
-// 	const (
-// 		// The redfish task name when the BMC is verifies the uploaded BMC firmware.
-// 		verifyBMCFirmware = "BMC Verify"
-// 		// The redfish task name when the BMC is installing the uploaded BMC firmware.
-// 		updateBMCFirmware = "BMC Update"
-// 		// The redfish task name when the BMC is verifies the uploaded BIOS firmware.
-// 		verifyBIOSFirmware = "BIOS Verify"
-// 		// The redfish task name when the BMC is installing the uploaded BIOS firmware.
-// 		updateBIOSFirmware = "BIOS Update"
-// 	)
-
-// 	var verifyTaskName, updateTaskName string
-
-// 	switch strings.ToUpper(component) {
-// 	case common.SlugBMC:
-// 		verifyTaskName = verifyBMCFirmware
-// 		updateTaskName = updateBMCFirmware
-// 	case common.SlugBIOS:
-// 		verifyTaskName = verifyBIOSFirmware
-// 		updateTaskName = updateBIOSFirmware
-// 	}
-
-// 	taskInfo := fmt.Sprintf("id: %s, state: %s, status: %s", t.ID, t.TaskState, t.TaskStatus)
-
-// 	switch t.Name {
-// 	case verifyTaskName:
-// 		return errors.Wrap(errTaskActive, taskInfo)
-// 	case updateTaskName:
-// 		return errors.Wrap(errTaskActive, taskInfo)
-// 	default:
-// 		return nil
-// 	}
-// }
-
-// func stateFinalized(s redfish.TaskState) bool {
-// 	finalized := []redfish.TaskState{
-// 		redfish.CompletedTaskState,
-// 		redfish.CancelledTaskState,
-// 		redfish.InterruptedTaskState,
-// 		redfish.ExceptionTaskState,
-// 	}
-
-// 	return slices.Contains(finalized, s)
-// }
-
-// type Supermicro struct {
-// 	BIOS map[string]bool `json:"BIOS,omitempty"`
-// 	BMC  map[string]bool `json:"BMC,omitempty"`
-// }
-
-// type OEM struct {
-// 	Supermicro `json:"Supermicro"`
-// }
-
 // redfish OEM fw install parameters
 func (c *x13) biosFwInstallParams() (map[string]bool, error) {
 	switch c.model {
@@ -210,7 +152,7 @@ func (c *x13) biosFwInstallParams() (map[string]bool, error) {
 		}, nil
 	default:
 		// ideally we never get in this position, since theres model number validation in parent callers.
-		return nil, errors.New("unsupported model for BIOS fw install: " + c.model)
+		return nil, errors.New("unsupported model for x13 BIOS fw install: " + c.model)
 	}
 }
 


### PR DESCRIPTION
## What does this PR implement/change/remove?

Support for hw inventory and firmware management for Supermicro X13 boards.

### The HW vendor this change applies to (if applicable)

Supermicro

### The HW model number, product name this change applies to (if applicable)

X13

## Description for changelog/release notes

```
Supermicro X13 inventory/firmware support FS-1671
```
