### PR TITLE
providers/supermicro/supermicro.go: Initialize sum 'client' during serviceclient init

### DIFF
--- a/providers/supermicro/firmware_bios_test.go
+++ b/providers/supermicro/firmware_bios_test.go
@@ -80,7 +80,9 @@ func Test_setComponentUpdateMisc(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			serviceClient := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			serviceClient, err := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			assert.Nil(t, err)
+
 			serviceClient.csrfToken = "foobar"
 			client := &x11{serviceClient: serviceClient, log: logr.Discard()}
 
@@ -169,7 +171,9 @@ func Test_setBIOSFirmwareInstallMode(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			serviceClient := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			serviceClient, err := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			assert.Nil(t, err)
+
 			serviceClient.csrfToken = "foobar"
 			client := &x11{serviceClient: serviceClient, log: logr.Discard()}
 

--- a/providers/supermicro/supermicro.go
+++ b/providers/supermicro/supermicro.go
@@ -144,6 +144,9 @@ func NewClient(host, user, pass string, log logr.Logger, opts ...Option) *Client
 		httpclient.Build(defaultConfig.httpClientSetupFuncs...),
 	)
 
+	// We probably want to treat this as a fatal error and/or pass the error back to the caller
+	// I did not want to chase that thread atm, so we intentionally return nil here if
+	// newBmcServiceClient returns an error.
 	if err != nil {
 		return nil
 	}

--- a/providers/supermicro/x11_firmware_bmc_test.go
+++ b/providers/supermicro/x11_firmware_bmc_test.go
@@ -91,7 +91,9 @@ func TestX11SetBMCFirmwareInstallMode(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			serviceClient := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			serviceClient, err := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			assert.Nil(t, err)
+
 			client := &x11{serviceClient: serviceClient, log: logr.Discard()}
 
 			if err := client.setBMCFirmwareInstallMode(context.Background()); err != nil {
@@ -184,7 +186,8 @@ func TestX11UploadBMCFirmware(t *testing.T) {
 				defer os.Remove(binPath)
 			}
 
-			serviceClient := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			serviceClient, err := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			assert.Nil(t, err)
 			serviceClient.csrfToken = "foobar"
 			client := &x11{serviceClient: serviceClient, log: logr.Discard()}
 
@@ -265,7 +268,8 @@ func TestX11VerifyBMCFirmwareVersion(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			serviceClient := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			serviceClient, err := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			assert.Nil(t, err)
 			serviceClient.csrfToken = "foobar"
 			client := &x11{serviceClient: serviceClient, log: logr.Discard()}
 
@@ -346,7 +350,8 @@ func TestX11InitiateBMCFirmwareInstall(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			serviceClient := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			serviceClient, err := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			assert.Nil(t, err)
 			serviceClient.csrfToken = "foobar"
 			client := &x11{serviceClient: serviceClient, log: logr.Discard()}
 
@@ -509,7 +514,9 @@ func TestX11StatusBMCFirmwareInstall(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			serviceClient := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			serviceClient, err := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			assert.Nil(t, err)
+
 			serviceClient.csrfToken = "foobar"
 			client := &x11{serviceClient: serviceClient, log: logr.Discard()}
 


### PR DESCRIPTION
## What does this PR implement/change/remove?

A regression crept in recently where the 'sum' client was not being assigned to the 'serviceclient' when the supermicro provider was instantiated.     This change fixes that problem.
