### PR TITLE
Fix media mounting eject implementation:

### DIFF
--- a/internal/redfishwrapper/virtual_media.go
+++ b/internal/redfishwrapper/virtual_media.go
@@ -44,7 +44,7 @@ func (c *Client) SetVirtualMedia(ctx context.Context, kind string, mediaURL stri
 
 		for _, vm := range virtualMedia {
 			var ejected bool
-			if vm.Inserted {
+			if vm.Inserted && vm.SupportsMediaEject {
 				if err := vm.EjectMedia(); err != nil {
 					return false, err
 				}
@@ -53,7 +53,7 @@ func (c *Client) SetVirtualMedia(ctx context.Context, kind string, mediaURL stri
 			if mediaURL == "" {
 				// Only ejecting the media was requested.
 				// For BMC's that don't support the "inserted" property, we need to eject the media if it's not already ejected.
-				if !ejected {
+				if !ejected && vm.SupportsMediaEject {
 					if err := vm.EjectMedia(); err != nil {
 						return false, err
 					}


### PR DESCRIPTION
## What does this PR implement/change/remove?

Some redfish implementations will fail to eject media if no media is mounted. The redfish server behavior is to report that the virtual media doesn't support media ejection. So we need to check for this.

### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes

```
```
