### PR TITLE
Nil pointer safety

### DIFF
--- a/bmc/bios.go
+++ b/bmc/bios.go
@@ -152,6 +152,9 @@ Loop:
 func GetBiosConfigurationInterfaces(ctx context.Context, generic []interface{}) (biosConfig map[string]string, metadata Metadata, err error) {
 	implementations := make([]biosConfigurationGetterProvider, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := biosConfigurationGetterProvider{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case BiosConfigurationGetter:
@@ -178,6 +181,9 @@ func GetBiosConfigurationInterfaces(ctx context.Context, generic []interface{}) 
 func SetBiosConfigurationInterfaces(ctx context.Context, generic []interface{}, biosConfig map[string]string) (metadata Metadata, err error) {
 	implementations := make([]biosConfigurationSetterProvider, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := biosConfigurationSetterProvider{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case BiosConfigurationSetter:
@@ -204,6 +210,9 @@ func SetBiosConfigurationInterfaces(ctx context.Context, generic []interface{}, 
 func SetBiosConfigurationFromFileInterfaces(ctx context.Context, generic []interface{}, cfg string) (metadata Metadata, err error) {
 	implementations := make([]biosConfigurationSetterProvider, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := biosConfigurationSetterProvider{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case BiosConfigurationSetter:
@@ -230,6 +239,9 @@ func SetBiosConfigurationFromFileInterfaces(ctx context.Context, generic []inter
 func ResetBiosConfigurationInterfaces(ctx context.Context, generic []interface{}) (metadata Metadata, err error) {
 	implementations := make([]biosConfigurationResetterProvider, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := biosConfigurationResetterProvider{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case BiosConfigurationResetter:

--- a/bmc/boot_device.go
+++ b/bmc/boot_device.go
@@ -94,6 +94,9 @@ func setBootDevice(ctx context.Context, timeout time.Duration, bootDevice string
 func SetBootDeviceFromInterfaces(ctx context.Context, timeout time.Duration, bootDevice string, setPersistent, efiBoot bool, generic []interface{}) (ok bool, metadata Metadata, err error) {
 	bdSetters := make([]bootDeviceProviders, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := bootDeviceProviders{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case BootDeviceSetter:
@@ -148,6 +151,9 @@ func GetBootDeviceOverrideFromInterface(
 	metadata = newMetadata()
 
 	for _, elem := range providers {
+		if elem == nil {
+			continue
+		}
 		switch p := elem.(type) {
 		case BootDeviceOverrideGetter:
 			provider := &bootOverrideProvider{name: getProviderName(elem), bootOverrideGetter: p}

--- a/bmc/connection.go
+++ b/bmc/connection.go
@@ -62,6 +62,9 @@ func OpenConnectionFromInterfaces(ctx context.Context, timeout time.Duration, pr
 	// For every provider, launch a goroutine that attempts to open a connection and report
 	// back via the results channel what happened.
 	for _, elem := range providers {
+		if elem == nil {
+			continue
+		}
 		switch p := elem.(type) {
 		case Opener:
 			providerName := getProviderName(elem)
@@ -138,6 +141,9 @@ func CloseConnectionFromInterfaces(ctx context.Context, generic []interface{}) (
 
 	closers := make([]connectionProviders, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := connectionProviders{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case Closer:

--- a/bmc/firmware.go
+++ b/bmc/firmware.go
@@ -71,6 +71,9 @@ func FirmwareInstallFromInterfaces(ctx context.Context, component, operationAppl
 
 	implementations := make([]firmwareInstallerProvider, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := firmwareInstallerProvider{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case FirmwareInstaller:
@@ -152,6 +155,9 @@ func FirmwareInstallStatusFromInterfaces(ctx context.Context, installVersion, co
 
 	implementations := make([]firmwareInstallVerifierProvider, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := firmwareInstallVerifierProvider{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case FirmwareInstallVerifier:
@@ -227,6 +233,9 @@ func FirmwareInstallUploadAndInitiateFromInterfaces(ctx context.Context, compone
 
 	implementations := make([]firmwareInstallProvider, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := firmwareInstallProvider{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case FirmwareInstallProvider:
@@ -306,6 +315,9 @@ func FirmwareInstallerUploadedFromInterfaces(ctx context.Context, component, upl
 
 	implementations := make([]firmwareInstallerWithOptionsProvider, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := firmwareInstallerWithOptionsProvider{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case FirmwareInstallerUploaded:
@@ -345,6 +357,9 @@ func FirmwareInstallStepsFromInterfaces(ctx context.Context, component string, g
 
 	implementations := make([]firmwareInstallStepsGetterProvider, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := firmwareInstallStepsGetterProvider{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case FirmwareInstallStepsGetter:
@@ -413,6 +428,9 @@ func FirmwareUploadFromInterfaces(ctx context.Context, component string, file *o
 
 	implementations := make([]firmwareUploaderProvider, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := firmwareUploaderProvider{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case FirmwareUploader:
@@ -527,6 +545,9 @@ func FirmwareTaskStatusFromInterfaces(ctx context.Context, kind bconsts.Firmware
 
 	implementations := make([]firmwareTaskVerifierProvider, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := firmwareTaskVerifierProvider{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case FirmwareTaskVerifier:

--- a/bmc/floppy.go
+++ b/bmc/floppy.go
@@ -55,6 +55,9 @@ func mountFloppyImage(ctx context.Context, image io.Reader, p []floppyImageUploa
 func MountFloppyImageFromInterfaces(ctx context.Context, image io.Reader, p []interface{}) (metadata Metadata, err error) {
 	providers := make([]floppyImageUploaderProvider, 0)
 	for _, elem := range p {
+		if elem == nil {
+			continue
+		}
 		temp := floppyImageUploaderProvider{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case FloppyImageMounter:
@@ -125,6 +128,9 @@ func unmountFloppyImage(ctx context.Context, p []floppyImageUnmounterProvider) (
 func UnmountFloppyImageFromInterfaces(ctx context.Context, p []interface{}) (metadata Metadata, err error) {
 	providers := make([]floppyImageUnmounterProvider, 0)
 	for _, elem := range p {
+		if elem == nil {
+			continue
+		}
 		temp := floppyImageUnmounterProvider{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case FloppyImageUnmounter:

--- a/bmc/inventory.go
+++ b/bmc/inventory.go
@@ -57,6 +57,9 @@ func GetInventoryFromInterfaces(ctx context.Context, generic []interface{}) (dev
 
 	implementations := make([]inventoryGetterProvider, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := inventoryGetterProvider{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case InventoryGetter:

--- a/bmc/postcode.go
+++ b/bmc/postcode.go
@@ -57,6 +57,9 @@ func postCode(ctx context.Context, generic []postCodeGetterProvider) (status str
 func GetPostCodeInterfaces(ctx context.Context, generic []interface{}) (status string, code int, metadata Metadata, err error) {
 	implementations := make([]postCodeGetterProvider, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := postCodeGetterProvider{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case PostCodeGetter:

--- a/bmc/power.go
+++ b/bmc/power.go
@@ -79,6 +79,9 @@ func SetPowerStateFromInterfaces(ctx context.Context, timeout time.Duration, sta
 
 	powerSetter := make([]powerProviders, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := powerProviders{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case PowerSetter:
@@ -132,6 +135,9 @@ func GetPowerStateFromInterfaces(ctx context.Context, timeout time.Duration, gen
 
 	powerStateGetter := make([]powerProviders, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := powerProviders{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case PowerStateGetter:

--- a/bmc/provider.go
+++ b/bmc/provider.go
@@ -11,6 +11,9 @@ type Provider interface {
 // getProviderName returns the name a provider supplies if they implement the Provider interface
 // if not implemented then the concrete type is returned
 func getProviderName(provider interface{}) string {
+	if provider == nil {
+		return ""
+	}
 	switch p := provider.(type) {
 	case Provider:
 		return p.Name()

--- a/bmc/reset.go
+++ b/bmc/reset.go
@@ -61,6 +61,9 @@ func ResetBMCFromInterfaces(ctx context.Context, timeout time.Duration, resetTyp
 
 	bmcSetters := make([]bmcProviders, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := bmcProviders{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case BMCResetter:

--- a/bmc/screenshot.go
+++ b/bmc/screenshot.go
@@ -52,6 +52,9 @@ func screenshot(ctx context.Context, generic []screenshotGetterProvider) (image 
 func ScreenshotFromInterfaces(ctx context.Context, generic []interface{}) (image []byte, fileType string, metadata Metadata, err error) {
 	implementations := make([]screenshotGetterProvider, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := screenshotGetterProvider{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case ScreenshotGetter:

--- a/bmc/sel.go
+++ b/bmc/sel.go
@@ -56,6 +56,9 @@ func clearSystemEventLog(ctx context.Context, timeout time.Duration, s []systemE
 func ClearSystemEventLogFromInterfaces(ctx context.Context, timeout time.Duration, generic []interface{}) (metadata Metadata, err error) {
 	selServices := make([]systemEventLogProviders, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := systemEventLogProviders{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case SystemEventLog:
@@ -107,6 +110,9 @@ func getSystemEventLog(ctx context.Context, timeout time.Duration, s []systemEve
 func GetSystemEventLogFromInterfaces(ctx context.Context, timeout time.Duration, generic []interface{}) (sel SystemEventLogEntries, metadata Metadata, err error) {
 	selServices := make([]systemEventLogProviders, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := systemEventLogProviders{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case SystemEventLog:
@@ -158,6 +164,9 @@ func getSystemEventLogRaw(ctx context.Context, timeout time.Duration, s []system
 func GetSystemEventLogRawFromInterfaces(ctx context.Context, timeout time.Duration, generic []interface{}) (eventlog string, metadata Metadata, err error) {
 	selServices := make([]systemEventLogProviders, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := systemEventLogProviders{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case SystemEventLog:

--- a/bmc/sol.go
+++ b/bmc/sol.go
@@ -53,6 +53,9 @@ func deactivateSOL(ctx context.Context, timeout time.Duration, b []deactivatorPr
 func DeactivateSOLFromInterfaces(ctx context.Context, timeout time.Duration, generic []interface{}) (metadata Metadata, err error) {
 	deactivators := make([]deactivatorProvider, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := deactivatorProvider{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case SOLDeactivator:

--- a/bmc/user.go
+++ b/bmc/user.go
@@ -75,6 +75,9 @@ func createUser(ctx context.Context, timeout time.Duration, user, pass, role str
 func CreateUserFromInterfaces(ctx context.Context, timeout time.Duration, user, pass, role string, generic []interface{}) (ok bool, metadata Metadata, err error) {
 	userCreators := make([]userProviders, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := userProviders{name: getProviderName(elem)}
 		switch u := elem.(type) {
 		case UserCreator:
@@ -128,6 +131,9 @@ func updateUser(ctx context.Context, timeout time.Duration, user, pass, role str
 func UpdateUserFromInterfaces(ctx context.Context, timeout time.Duration, user, pass, role string, generic []interface{}) (ok bool, metadata Metadata, err error) {
 	userUpdaters := make([]userProviders, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := userProviders{name: getProviderName(elem)}
 		switch u := elem.(type) {
 		case UserUpdater:
@@ -181,6 +187,9 @@ func deleteUser(ctx context.Context, timeout time.Duration, user string, u []use
 func DeleteUserFromInterfaces(ctx context.Context, timeout time.Duration, user string, generic []interface{}) (ok bool, metadata Metadata, err error) {
 	userDeleters := make([]userProviders, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := userProviders{name: getProviderName(elem)}
 		switch u := elem.(type) {
 		case UserDeleter:
@@ -230,6 +239,9 @@ func readUsers(ctx context.Context, timeout time.Duration, u []userProviders) (u
 func ReadUsersFromInterfaces(ctx context.Context, timeout time.Duration, generic []interface{}) (users []map[string]string, metadata Metadata, err error) {
 	userReaders := make([]userProviders, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := userProviders{name: getProviderName(elem)}
 		switch u := elem.(type) {
 		case UserReader:

--- a/bmc/virtual_media.go
+++ b/bmc/virtual_media.go
@@ -54,6 +54,9 @@ func setVirtualMedia(ctx context.Context, kind string, mediaURL string, b []virt
 func SetVirtualMediaFromInterfaces(ctx context.Context, kind string, mediaURL string, generic []interface{}) (ok bool, metadata Metadata, err error) {
 	bdSetters := make([]virtualMediaProviders, 0)
 	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
 		temp := virtualMediaProviders{name: getProviderName(elem)}
 		switch p := elem.(type) {
 		case VirtualMediaSetter:

--- a/providers/supermicro/firmware_bios_test.go
+++ b/providers/supermicro/firmware_bios_test.go
@@ -80,7 +80,7 @@ func Test_setComponentUpdateMisc(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			serviceClient, err := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			serviceClient := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
 			assert.Nil(t, err)
 
 			serviceClient.csrfToken = "foobar"
@@ -171,7 +171,7 @@ func Test_setBIOSFirmwareInstallMode(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			serviceClient, err := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			serviceClient := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
 			assert.Nil(t, err)
 
 			serviceClient.csrfToken = "foobar"

--- a/providers/supermicro/x11_firmware_bmc_test.go
+++ b/providers/supermicro/x11_firmware_bmc_test.go
@@ -91,7 +91,7 @@ func TestX11SetBMCFirmwareInstallMode(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			serviceClient, err := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			serviceClient := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
 			assert.Nil(t, err)
 
 			client := &x11{serviceClient: serviceClient, log: logr.Discard()}
@@ -186,7 +186,7 @@ func TestX11UploadBMCFirmware(t *testing.T) {
 				defer os.Remove(binPath)
 			}
 
-			serviceClient, err := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			serviceClient := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
 			assert.Nil(t, err)
 			serviceClient.csrfToken = "foobar"
 			client := &x11{serviceClient: serviceClient, log: logr.Discard()}
@@ -268,7 +268,7 @@ func TestX11VerifyBMCFirmwareVersion(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			serviceClient, err := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			serviceClient := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
 			assert.Nil(t, err)
 			serviceClient.csrfToken = "foobar"
 			client := &x11{serviceClient: serviceClient, log: logr.Discard()}
@@ -350,7 +350,7 @@ func TestX11InitiateBMCFirmwareInstall(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			serviceClient, err := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			serviceClient := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
 			assert.Nil(t, err)
 			serviceClient.csrfToken = "foobar"
 			client := &x11{serviceClient: serviceClient, log: logr.Discard()}
@@ -514,7 +514,7 @@ func TestX11StatusBMCFirmwareInstall(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			serviceClient, err := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
+			serviceClient := newBmcServiceClient(parsedURL.Hostname(), parsedURL.Port(), "foo", "bar", httpclient.Build())
 			assert.Nil(t, err)
 
 			serviceClient.csrfToken = "foobar"


### PR DESCRIPTION
## What does this PR implement/change/remove?
Fix bug introduced by #402. This PR handles errors properly and adds some nil checking in the `bmc` package. By ignoring an error and returning nil objects it causes`panic: runtime error: invalid memory address or nil pointer dereference` for clients.

### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes

```
```
