### PR TITLE
Update virtual media ejecting:

### DIFF
--- a/internal/redfishwrapper/virtual_media.go
+++ b/internal/redfishwrapper/virtual_media.go
@@ -43,22 +43,20 @@ func (c *Client) SetVirtualMedia(ctx context.Context, kind string, mediaURL stri
 		}
 
 		for _, vm := range virtualMedia {
-			var ejected bool
-			if vm.Inserted && vm.SupportsMediaEject {
-				if err := vm.EjectMedia(); err != nil {
-					return false, err
-				}
-				ejected = true
-			}
 			if mediaURL == "" {
 				// Only ejecting the media was requested.
 				// For BMC's that don't support the "inserted" property, we need to eject the media if it's not already ejected.
-				if !ejected && vm.SupportsMediaEject {
+				if vm.Inserted && vm.SupportsMediaEject {
 					if err := vm.EjectMedia(); err != nil {
 						return false, err
 					}
 				}
 				return true, nil
+			}
+			if vm.Inserted && vm.SupportsMediaEject {
+				if err := vm.EjectMedia(); err != nil {
+					return false, err
+				}
 			}
 			if !slices.Contains(vm.MediaTypes, mediaKind) {
 				return false, fmt.Errorf("media kind %s not supported by BMC, supported media kinds %q", kind, vm.MediaTypes)


### PR DESCRIPTION
## What does this PR implement/change/remove?
We weren't checking vm.Inserted and on some HP ILOs this caused failures to eject even when there was nothing to eject. This makes it so that this call won't fail when there is nothing to eject.

### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes

```
```
