### PR TITLE
Enables support for supermicro x11ssl-f and x11scz-f

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	dario.cat/mergo v1.0.1
 	github.com/Jeffail/gabs/v2 v2.7.0
-	github.com/bmc-toolbox/common v0.0.0-20241031162543-6b96e5981a0d
+	github.com/bmc-toolbox/common v0.0.0-20250112191656-b6de52e8303d
 	github.com/bombsimon/logrusr/v2 v2.0.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/VictorLowther/soap v0.0.0-20150314151524-8e36fca84b22 h1:a0MBqYm44o0N
 github.com/VictorLowther/soap v0.0.0-20150314151524-8e36fca84b22/go.mod h1:/B7V22rcz4860iDqstGvia/2+IYWXf3/JdQCVd/1D2A=
 github.com/bmc-toolbox/common v0.0.0-20241031162543-6b96e5981a0d h1:dMmFDAAEpXizInaNwPSa5LM6tX/xDIPKjL6v9jYfMxo=
 github.com/bmc-toolbox/common v0.0.0-20241031162543-6b96e5981a0d/go.mod h1:Cdnkm+edb6C0pVkyCrwh3JTXAe0iUF9diDG/DztPI9I=
+github.com/bmc-toolbox/common v0.0.0-20250112191656-b6de52e8303d h1:5c0jhS9jNLm1t3GVEESsWv+p6recFRLGW90zp8HDIDs=
+github.com/bmc-toolbox/common v0.0.0-20250112191656-b6de52e8303d/go.mod h1:Cdnkm+edb6C0pVkyCrwh3JTXAe0iUF9diDG/DztPI9I=
 github.com/bombsimon/logrusr/v2 v2.0.1 h1:1VgxVNQMCvjirZIYaT9JYn6sAVGVEcNtRE0y4mvaOAM=
 github.com/bombsimon/logrusr/v2 v2.0.1/go.mod h1:ByVAX+vHdLGAfdroiMg6q0zgq2FODY2lc5YJvzmOJio=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=

--- a/providers/supermicro/errors.go
+++ b/providers/supermicro/errors.go
@@ -12,6 +12,7 @@ var (
 	ErrXMLAPIUnsupported    = errors.New("XML API is unsupported")
 	ErrModelUnknown         = errors.New("Model number unknown")
 	ErrModelUnsupported     = errors.New("Model not supported")
+	ErrBoardIDUnknown       = errors.New("BoardID could not be identified")
 	ErrUnexpectedResponse   = errors.New("Unexpected response content")
 	ErrUnexpectedStatusCode = errors.New("Unexpected status code")
 )

--- a/providers/supermicro/errors.go
+++ b/providers/supermicro/errors.go
@@ -8,10 +8,12 @@ import (
 )
 
 var (
-	ErrQueryFRUInfo      = errors.New("FRU information query returned error")
-	ErrXMLAPIUnsupported = errors.New("XML API is unsupported")
-	ErrModelUnknown      = errors.New("Model number unknown")
-	ErrModelUnsupported  = errors.New("Model not supported")
+	ErrQueryFRUInfo         = errors.New("FRU information query returned error")
+	ErrXMLAPIUnsupported    = errors.New("XML API is unsupported")
+	ErrModelUnknown         = errors.New("Model number unknown")
+	ErrModelUnsupported     = errors.New("Model not supported")
+	ErrUnexpectedResponse   = errors.New("Unexpected response content")
+	ErrUnexpectedStatusCode = errors.New("Unexpected status code")
 )
 
 type UnexpectedResponseError struct {

--- a/providers/supermicro/supermicro_test.go
+++ b/providers/supermicro/supermicro_test.go
@@ -187,21 +187,13 @@ func TestOpen(t *testing.T) {
 		},
 		{
 			"login error",
-			"401: failed to login",
+			"failed to login",
 			"foo",
 			"bar",
 			handlerFuncMap{
 				"/cgi/login.cgi": func(w http.ResponseWriter, r *http.Request) {
 					assert.Equal(t, r.Method, http.MethodPost)
 					assert.Equal(t, r.Header.Get("Content-Type"), "application/x-www-form-urlencoded")
-
-					b, err := io.ReadAll(r.Body)
-					if err != nil {
-						t.Fatal(err)
-					}
-
-					assert.Equal(t, `name=Zm9v&pwd=YmFy&check=00`, string(b))
-
 					response := []byte(`barf`)
 					w.WriteHeader(401)
 					_, _ = w.Write(response)


### PR DESCRIPTION
## What does this PR implement/change/remove?

- Enables login to these older SMC hardware along with identifying the hardware model from the board ID

For merge after https://github.com/bmc-toolbox/common/pull/25 

### Checklist
- [ ] Tests added
- [X] Similar commits squashed

### The HW vendor this change applies to (if applicable)
- Supermicro

### The HW model number, product name this change applies to (if applicable)
- x11ssl-f
- x11scz-f

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes

```
```
