### PR TITLE
Check power state before issuing power off for ipmi:

### DIFF
--- a/internal/ipmi/ipmi.go
+++ b/internal/ipmi/ipmi.go
@@ -247,6 +247,9 @@ func (i *Ipmi) PowerOnForce(ctx context.Context) (status bool, err error) {
 
 // PowerOff power off the machine via bmc
 func (i *Ipmi) PowerOff(ctx context.Context) (status bool, err error) {
+	if on, err := i.IsOn(ctx); err == nil && !on {
+		return true, nil
+	}
 	output, err := i.run(ctx, []string{"chassis", "power", "off"})
 	if strings.Contains(output, "Chassis Power Control: Down/Off") {
 		return true, err


### PR DESCRIPTION
## What does this PR implement/change/remove?

Some implementations of ipmi, Dell for example, will error out if a machine is already off and an ipmitool power off command is issued. Error is `Command not supported in present state`. Checking the power state before issuing the power off command is also done in other ipmitool commands.

### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes

```
ipmitool: check power state before issuing a power off command.
```
