### PR TITLE
Fix mergify configuration issue:

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,5 +1,6 @@
 queue_rules:
   - name: default
+    batch_size: 1
     queue_conditions:
       - base=main
       - "#approved-reviews-by>=1"
@@ -9,9 +10,13 @@ queue_rules:
       - label!=do-not-merge
       - label=ready-to-merge
     merge_conditions:
-      # Conditions to get out of the queue (= merged)
-      - check-success=lint
-      - check-success=test
+      - base=main
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - check-success='lint'
+      - check-success='test'
+      - label!=do-not-merge
+      - label=ready-to-merge
     merge_method: merge
     commit_message_template: |
       {{ title }} (#{{ number }})
@@ -21,3 +26,5 @@ pull_request_rules:
     conditions: []
     actions:
       queue:
+merge_queue:
+  max_parallel_checks: 1


### PR DESCRIPTION
## What does this PR implement/change/remove?
Mergify won't do its job. Showing this
message and disabling the branch protection in
GitHub didn't work:
Configuration not compatible with a branch protection setting The branch protection setting Require branches to be up to date before merging is not compatible withdraft PR checks. To keep this branch protection enabled, update your Mergify configuration to enable in-place checks:
set merge_queue.max_parallel_checks: 1,
set every queue rule batch_size: 1, and avoid
two-step CI (make merge_conditions identical to queue_conditions). Otherwise, disable this branch protection.

### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes

```
```
