### PR TITLE
[Redfish] Add support for UefiHttp boot

### DIFF
--- a/bmc/boot_device.go
+++ b/bmc/boot_device.go
@@ -23,6 +23,7 @@ const (
 	BootDeviceTypeSDCard      BootDeviceType = "sd_card"
 	BootDeviceTypeUSB         BootDeviceType = "usb"
 	BootDeviceTypeUtil        BootDeviceType = "utilities"
+	BootDeviceUefiHTTP        BootDeviceType = "uefi_http"
 )
 
 // BootDeviceSetter sets the next boot device for a machine

--- a/internal/redfishwrapper/boot_device.go
+++ b/internal/redfishwrapper/boot_device.go
@@ -59,6 +59,10 @@ var bootDeviceTypeMappings = []bootDeviceMapping{
 		BootDeviceType: bmc.BootDeviceTypeUtil,
 		RedFishTarget:  rf.UtilitiesBootSourceOverrideTarget,
 	},
+	{
+		BootDeviceType: bmc.BootDeviceUefiHTTP,
+		RedFishTarget:  rf.UefiHTTPBootSourceOverrideTarget,
+	},
 }
 
 // bootDeviceStringToTarget gets the RedFish BootSourceOverrideTarget that corresponds to the given device string,


### PR DESCRIPTION
## What does this PR implement/change/remove?

This PR adds "uefi_http" and maps it to UefiHttp for gofish.
Newer servers support UefiHttp, removing the need for a dedicated tftp server in the setup.


### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes

```
```
