### PR TITLE
Upgrade gofish to v0.22.0 and add workaround for Lenovo VirtualMedia …

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,46 @@ client := bmclib.NewClient("192.168.1.1", "admin", "hunter2", opt...)
 cl.Registry.Drivers = cl.Registry.FilterForCompatible(ctx)
 ```
 
+## Virtual Media
+
+bmclib supports attaching and ejecting virtual media through the Redfish `gofish` provider.
+
+```go
+cl := bmclib.NewClient("192.168.1.1", "admin", "hunter2")
+
+if err := cl.Open(ctx); err != nil {
+  return(err)
+}
+defer cl.Close(ctx)
+
+// Attach an ISO image as CD/DVD virtual media.
+ok, err := cl.SetVirtualMedia(ctx, "CD", "https://example.com/installer.iso")
+if err != nil {
+  return(err)
+}
+if !ok {
+  return(fmt.Errorf("failed to set virtual media"))
+}
+
+// To eject currently attached virtual media, pass an empty media URL:
+ok, err := cl.SetVirtualMedia(ctx, "CD", "")
+if err != nil {
+  return(err)
+}
+if !ok {
+  return(fmt.Errorf("failed to eject virtual media"))
+}
+```
+
+Supported media kinds are:
+* CD
+* DVD
+* Floppy
+* USBStick
+
+The Redfish provider first looks for `VirtualMedia` under the `Manager` resource (/redfish/v1/Managers/{ManagerId}/VirtualMedia) and falls back to the `System` resource (/redfish/v1/Systems/{SystemId}/VirtualMedia) for implementations that expose virtual media there.
+When the BMC does not expose standard `VirtualMedia.InsertMedia` or `VirtualMedia.EjectMedia` actions, bmclib relies on gofish to fall back to PATCHing the `VirtualMedia` resource directly. This allows virtual media support on implementations such as Lenovo XCC that manage virtual media through `PATCH` instead of Redfish Actions.
+
 ## Timeouts
 
 bmclib can be configured to apply timeouts to BMC interactions. The following options are available.

--- a/README.md
+++ b/README.md
@@ -121,46 +121,6 @@ client := bmclib.NewClient("192.168.1.1", "admin", "hunter2", opt...)
 cl.Registry.Drivers = cl.Registry.FilterForCompatible(ctx)
 ```
 
-## Virtual Media
-
-bmclib supports attaching and ejecting virtual media through the Redfish `gofish` provider.
-
-```go
-cl := bmclib.NewClient("192.168.1.1", "admin", "hunter2")
-
-if err := cl.Open(ctx); err != nil {
-  return(err)
-}
-defer cl.Close(ctx)
-
-// Attach an ISO image as CD/DVD virtual media.
-ok, err := cl.SetVirtualMedia(ctx, "CD", "https://example.com/installer.iso")
-if err != nil {
-  return(err)
-}
-if !ok {
-  return(fmt.Errorf("failed to set virtual media"))
-}
-
-// To eject currently attached virtual media, pass an empty media URL:
-ok, err := cl.SetVirtualMedia(ctx, "CD", "")
-if err != nil {
-  return(err)
-}
-if !ok {
-  return(fmt.Errorf("failed to eject virtual media"))
-}
-```
-
-Supported media kinds are:
-* CD
-* DVD
-* Floppy
-* USBStick
-
-The Redfish provider first looks for `VirtualMedia` under the `Manager` resource (/redfish/v1/Managers/{ManagerId}/VirtualMedia) and falls back to the `System` resource (/redfish/v1/Systems/{SystemId}/VirtualMedia) for implementations that expose virtual media there.
-When the BMC does not expose standard `VirtualMedia.InsertMedia` or `VirtualMedia.EjectMedia` actions, bmclib relies on gofish to fall back to PATCHing the `VirtualMedia` resource directly. This allows virtual media support on implementations such as Lenovo XCC that manage virtual media through `PATCH` instead of Redfish Actions.
-
 ## Timeouts
 
 bmclib can be configured to apply timeouts to BMC interactions. The following options are available.

--- a/examples/virtualmedia/doc.go
+++ b/examples/virtualmedia/doc.go
@@ -1,18 +1,26 @@
 /*
-Virtual Media is an example command to mount and umount virtual media (ISO) on a BMC.
+Virtual Media is an example command to mount and unmount virtual media on a BMC.
 
-	# mount an ISO
+	# mount an ISO as CD/DVD virtual media
 	$ go run examples/virtualmedia/main.go \
 		-host 10.1.2.3 \
 		-user root \
 		-password calvin \
+		-media-kind CD \
 		-iso http://example.com/image.iso
 
-	# unmount an ISO
+	# unmount/eject virtual media
 	$ go run examples/virtualmedia/main.go \
 		-host 10.1.2.3 \
 		-user root \
 		-password calvin \
-		-iso ""
+		-media-kind CD \
+		-eject
+
+Supported media kinds are: CD, DVD, Floppy, USBStick.
+
+The Redfish gofish provider supports BMCs that expose VirtualMedia through
+standard InsertMedia/EjectMedia actions and BMCs that require PATCHing the
+VirtualMedia resource directly.
 */
 package main

--- a/examples/virtualmedia/main.go
+++ b/examples/virtualmedia/main.go
@@ -20,13 +20,19 @@ func main() {
 	user := flag.String("user", "", "BMC username, required")
 	pass := flag.String("password", "", "BMC password, required")
 	host := flag.String("host", "", "BMC hostname or IP address, required")
-	isoURL := flag.String("iso", "", "The HTTP URL to the ISO/image to be mounted")
+	isoURL := flag.String("iso", "", "The HTTP URL to the ISO/image to be mounted; not valid with -eject")
 	mediaKind := flag.String("media-kind", "CD", "Virtual media kind: CD, DVD, Floppy, USBStick")
 	eject := flag.Bool("eject", false, "Eject/unmount virtual media instead of mounting")
 	flag.Parse()
 
 	if *user == "" || *pass == "" || *host == "" {
 		fmt.Fprintln(os.Stderr, "user, password, and host are required")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	if *eject && *isoURL != "" {
+		fmt.Fprintln(os.Stderr, "iso must not be supplied when -eject is set")
 		flag.PrintDefaults()
 		os.Exit(1)
 	}

--- a/examples/virtualmedia/main.go
+++ b/examples/virtualmedia/main.go
@@ -20,7 +20,9 @@ func main() {
 	user := flag.String("user", "", "BMC username, required")
 	pass := flag.String("password", "", "BMC password, required")
 	host := flag.String("host", "", "BMC hostname or IP address, required")
-	isoURL := flag.String("iso", "", "The HTTP URL to the ISO to be mounted, leave empty to unmount")
+	isoURL := flag.String("iso", "", "The HTTP URL to the ISO/image to be mounted")
+	mediaKind := flag.String("media-kind", "CD", "Virtual media kind: CD, DVD, Floppy, USBStick")
+	eject := flag.Bool("eject", false, "Eject/unmount virtual media instead of mounting")
 	flag.Parse()
 
 	if *user == "" || *pass == "" || *host == "" {
@@ -29,16 +31,30 @@ func main() {
 		os.Exit(1)
 	}
 
+	if !*eject && *isoURL == "" {
+		fmt.Fprintln(os.Stderr, "iso is required unless -eject is set")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
 	l := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{AddSource: true}))
 	log := logr.FromSlogHandler(l.Handler())
 
 	cl := bmclib.NewClient(*host, *user, *pass, bmclib.WithLogger(log))
+	cl.Registry.Drivers = cl.Registry.For("gofish")
 	if err := cl.Open(ctx); err != nil {
 		panic(err)
 	}
 	defer cl.Close(ctx)
 
-	ok, err := cl.SetVirtualMedia(ctx, "CD", *isoURL)
+	mediaURL := *isoURL
+	operation := "mount"
+	if *eject {
+		mediaURL = ""
+		operation = "eject"
+	}
+
+	ok, err := cl.SetVirtualMedia(ctx, *mediaKind, mediaURL)
 	if err != nil {
 		log.Info("debugging", "metadata", cl.GetMetadata())
 		panic(err)
@@ -47,5 +63,10 @@ func main() {
 		log.Info("debugging", "metadata", cl.GetMetadata())
 		panic("failed virtual media operation")
 	}
-	log.Info("virtual media operation successful", "metadata", cl.GetMetadata())
+	log.Info(
+		"virtual media operation successful",
+		"operation", operation,
+		"media-kind", *mediaKind,
+		"metadata", cl.GetMetadata(),
+	)
 }

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
 	github.com/sirupsen/logrus v1.9.3
-	github.com/stmcginnis/gofish v0.21.6
+	github.com/stmcginnis/gofish v0.22.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.29.0
 	go.opentelemetry.io/otel/trace v1.29.0

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/stmcginnis/gofish v0.21.6 h1:jK3TGD6VANaAHKHypVNfD6io2nPrU+6eF8X4qARsTlY=
-github.com/stmcginnis/gofish v0.21.6/go.mod h1:PzF5i8ecRG9A2ol8XT64npKUunyraJ+7t0kYMpQAtqU=
+github.com/stmcginnis/gofish v0.22.0 h1:OahXohfrIzAXOsWuKDQ7lm/QvdZBg1P2OzFYmbKAd/0=
+github.com/stmcginnis/gofish v0.22.0/go.mod h1:PzF5i8ecRG9A2ol8XT64npKUunyraJ+7t0kYMpQAtqU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/internal/redfishwrapper/doc.go
+++ b/internal/redfishwrapper/doc.go
@@ -1,0 +1,43 @@
+/*
+Package redfishwrapper provides a wrapper around the gofish library to interact with Redfish API.
+
+It abstracts common BMC operations like setting virtual media, getting inventory, etc.
+
+## Virtual Media
+
+bmclib supports attaching and ejecting virtual media through the Redfish `gofish` provider.
+
+		cl := bmclib.NewClient("192.168.1.1", "admin", "hunter2")
+
+		if err := cl.Open(ctx); err != nil {
+	  	return(err)
+		}
+		defer cl.Close(ctx)
+
+		# Attach an ISO image as CD/DVD virtual media:
+		ok, err := cl.SetVirtualMedia(ctx, "CD", "https://example.com/installer.iso")
+		if err != nil {
+	  	return(err)
+		}
+		if !ok {
+	  	return(fmt.Errorf("failed to set virtual media"))
+		}
+
+		# To eject currently attached virtual media, pass an empty media URL:
+		ok, err := cl.SetVirtualMedia(ctx, "CD", "")
+		if err != nil {
+	  	return(err)
+		}
+		if !ok {
+	  	return(fmt.Errorf("failed to eject virtual media"))
+		}
+
+Supported media kinds are: CD, DVD, Floppy, USBStick.
+
+The Redfish provider first looks for VirtualMedia under the Manager resource (/redfish/v1/Managers/{ManagerId}/VirtualMedia) and
+falls back to the System resource (/redfish/v1/Systems/{SystemId}/VirtualMedia) for implementations that expose virtual media there.
+When the BMC does not expose standard VirtualMedia.InsertMedia or VirtualMedia.EjectMedia actions, bmclib relies on gofish
+to fall back to PATCHing the VirtualMedia resource directly. This allows virtual media support on implementations such as Lenovo XCC
+that manage virtual media through PATCH instead of Redfish Actions.
+*/
+package redfishwrapper

--- a/internal/redfishwrapper/doc.go
+++ b/internal/redfishwrapper/doc.go
@@ -14,7 +14,7 @@ bmclib supports attaching and ejecting virtual media through the Redfish `gofish
 		}
 		defer cl.Close(ctx)
 
-		# Attach an ISO image as CD/DVD virtual media:
+		// Attach an ISO image as CD/DVD virtual media:
 		ok, err := cl.SetVirtualMedia(ctx, "CD", "https://example.com/installer.iso")
 		if err != nil {
 	  	return(err)
@@ -23,7 +23,7 @@ bmclib supports attaching and ejecting virtual media through the Redfish `gofish
 	  	return(fmt.Errorf("failed to set virtual media"))
 		}
 
-		# To eject currently attached virtual media, pass an empty media URL:
+		// To eject currently attached virtual media, pass an empty media URL:
 		ok, err := cl.SetVirtualMedia(ctx, "CD", "")
 		if err != nil {
 	  	return(err)

--- a/internal/redfishwrapper/virtual_media.go
+++ b/internal/redfishwrapper/virtual_media.go
@@ -78,6 +78,10 @@ func (c *Client) SetVirtualMedia(ctx context.Context, kind string, mediaURL stri
 
 		if mediaURL == "" {
 			// Only ejecting the media was requested.
+			// Attempt to eject media.
+			// The gofish library v0.22.0+ supports fallback to PATCH if standard Actions are not available.
+			// This logic first checks if media is inserted, then attempts eject via Action or PATCH.
+			// This is relevant for BMCs like Lenovo XCC that may not expose standard EjectMedia actions.
 			if gofish.Deref(vm.Inserted) {
 				if _, err := vm.EjectMedia(); err != nil {
 					slotErrors = append(slotErrors, fmt.Errorf("%s: eject: %w", vm.ODataID, err))
@@ -111,6 +115,12 @@ func (c *Client) SetVirtualMedia(ctx context.Context, kind string, mediaURL stri
 			},
 		}
 
+		// Attempt to insert media using different parameter combinations.
+		// The gofish library v0.22.0+ supports fallback to PATCH if standard Actions are not available.
+		// This sequence tries:
+		// 1. Image + Inserted + WriteProtected (standard)
+		// 2. Image + Inserted (for BMCs requiring Inserted but not WriteProtected, e.g., some Lenovo XCC implementations)
+		// 3. Image only (for BMCs that might not support Inserted/WriteProtected properties)
 		var insertErrors []error
 
 		// Some BMCs (e.g., Supermicro X11SDV-4C-TLN2F) don't support the

--- a/internal/redfishwrapper/virtual_media.go
+++ b/internal/redfishwrapper/virtual_media.go
@@ -94,9 +94,10 @@ func (c *Client) SetVirtualMedia(ctx context.Context, kind string, mediaURL stri
 
 		// Ejecting the media before inserting new media makes the success rate of inserting the new media higher.
 		if gofish.Deref(vm.Inserted) {
+			// Attempt to eject media. If it fails, record the error but continue to attempt insertion,
+			// as some BMCs might allow insert even if eject fails or auto-replace media.
 			if _, err := vm.EjectMedia(); err != nil {
-				slotErrors = append(slotErrors, fmt.Errorf("%s: eject before insert: %w", vm.ODataID, err))
-				continue
+				slotErrors = append(slotErrors, fmt.Errorf("%s: eject before insert failed: %w. Attempting insert anyway.", vm.ODataID, err))
 			}
 		}
 
@@ -120,11 +121,9 @@ func (c *Client) SetVirtualMedia(ctx context.Context, kind string, mediaURL stri
 		// This sequence tries:
 		// 1. Image + Inserted + WriteProtected (standard)
 		// 2. Image + Inserted (for BMCs requiring Inserted but not WriteProtected, e.g., some Lenovo XCC implementations)
-		// 3. Image only (for BMCs that might not support Inserted/WriteProtected properties)
+		// 3. Image only (for BMCs that don't support Inserted/WriteProtected properties, e.g., Supermicro X11SDV-4C-TLN2F)
 		var insertErrors []error
 
-		// Some BMCs (e.g., Supermicro X11SDV-4C-TLN2F) don't support the
-		// Inserted and WriteProtected properties, so retry without them.
 		for _, insertMedia := range insertMediaAttempts {
 			if _, err := vm.InsertMedia(&insertMedia); err != nil {
 				insertErrors = append(insertErrors, err)

--- a/internal/redfishwrapper/virtual_media.go
+++ b/internal/redfishwrapper/virtual_media.go
@@ -78,7 +78,7 @@ func (c *Client) SetVirtualMedia(ctx context.Context, kind string, mediaURL stri
 
 		if mediaURL == "" {
 			// Only ejecting the media was requested.
-			if *vm.Inserted && vm.SupportsMediaEject {
+			if gofish.Deref(vm.Inserted) {
 				if _, err := vm.EjectMedia(); err != nil {
 					slotErrors = append(slotErrors, fmt.Errorf("%s: eject: %w", vm.ODataID, err))
 					continue
@@ -89,34 +89,41 @@ func (c *Client) SetVirtualMedia(ctx context.Context, kind string, mediaURL stri
 		}
 
 		// Ejecting the media before inserting new media makes the success rate of inserting the new media higher.
-		if *vm.Inserted && vm.SupportsMediaEject {
+		if gofish.Deref(vm.Inserted) {
 			if _, err := vm.EjectMedia(); err != nil {
 				slotErrors = append(slotErrors, fmt.Errorf("%s: eject before insert: %w", vm.ODataID, err))
 				continue
 			}
 		}
 
-		if !vm.SupportsMediaInsert {
-			slotErrors = append(slotErrors, fmt.Errorf("%s: does not support insert", vm.ODataID))
-			continue
+		insertMediaAttempts := []schemas.VirtualMediaInsertMediaParameters{
+			{
+				Image:          mediaURL,
+				Inserted:       gofish.ToRef(true),
+				WriteProtected: gofish.ToRef(true),
+			},
+			{
+				Image:    mediaURL,
+				Inserted: gofish.ToRef(true),
+			},
+			{
+				Image: mediaURL,
+			},
 		}
 
-		insertMedia := schemas.VirtualMediaInsertMediaParameters{
-			Image:          mediaURL,
-			Inserted:       gofish.ToRef(true),
-			WriteProtected: gofish.ToRef(true),
-		}
-		if _, err := vm.InsertMedia(&insertMedia); err != nil {
-			// Some BMCs (e.g., Supermicro X11SDV-4C-TLN2F) don't support the
-			// Inserted and WriteProtected properties, so retry without them.
-			insertMedia = schemas.VirtualMediaInsertMediaParameters{Image: mediaURL}
+		var insertErrors []error
+
+		for _, insertMedia := range insertMediaAttempts {
 			if _, err := vm.InsertMedia(&insertMedia); err != nil {
-				slotErrors = append(slotErrors, fmt.Errorf("%s: insert: %w", vm.ODataID, err))
+				insertErrors = append(insertErrors, err)
 				continue
 			}
+
+			return true, nil
 		}
 
-		return true, nil
+		slotErrors = append(slotErrors, fmt.Errorf("%s: insert: %w", vm.ODataID, errors.Join(insertErrors...)))
+		continue
 	}
 
 	if len(slotErrors) > 0 {
@@ -135,7 +142,7 @@ func (c *Client) InsertedVirtualMedia(ctx context.Context) ([]string, error) {
 	var inserted []string
 
 	for _, media := range virtualMedia {
-		if *media.Inserted {
+		if gofish.Deref(media.Inserted) {
 			inserted = append(inserted, media.ID)
 		}
 	}

--- a/internal/redfishwrapper/virtual_media.go
+++ b/internal/redfishwrapper/virtual_media.go
@@ -113,6 +113,8 @@ func (c *Client) SetVirtualMedia(ctx context.Context, kind string, mediaURL stri
 
 		var insertErrors []error
 
+		// Some BMCs (e.g., Supermicro X11SDV-4C-TLN2F) don't support the
+		// Inserted and WriteProtected properties, so retry without them.
 		for _, insertMedia := range insertMediaAttempts {
 			if _, err := vm.InsertMedia(&insertMedia); err != nil {
 				insertErrors = append(insertErrors, err)

--- a/internal/redfishwrapper/virtual_media_test.go
+++ b/internal/redfishwrapper/virtual_media_test.go
@@ -2,9 +2,11 @@ package redfishwrapper
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -217,6 +219,254 @@ func TestSetVirtualMedia_SlotFallback(t *testing.T) {
 	ok, err := client.SetVirtualMedia(ctx, "CD", "http://example.com/boot.iso")
 	assert.NoError(t, err)
 	assert.True(t, ok)
+}
+
+func TestSetVirtualMedia_InsertPatchFallbackWithoutAction(t *testing.T) {
+	const virtualMediaCollection = `{
+		"@odata.context": "/redfish/v1/$metadata#VirtualMediaCollection.VirtualMediaCollection",
+		"@odata.id": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia",
+		"@odata.type": "#VirtualMediaCollection.VirtualMediaCollection",
+		"Members": [
+			{
+				"@odata.id": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/1"
+			}
+		],
+		"Members@odata.count": 1,
+		"Name": "Virtual Media Services"
+	}`
+
+	const virtualMediaWithoutActions = `{
+		"@odata.context": "/redfish/v1/$metadata#VirtualMedia.VirtualMedia",
+		"@odata.id": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/1",
+		"@odata.type": "#VirtualMedia.v1_2_0.VirtualMedia",
+		"Id": "1",
+		"Name": "VirtualMedia",
+		"Image": "",
+		"Inserted": false,
+		"ConnectedVia": "NotConnected",
+		"WriteProtected": true,
+		"MediaTypes": ["CD", "DVD"]
+	}`
+
+	var patchCalled bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/", endpointFunc(t, "dell/serviceroot.json"))
+	mux.HandleFunc("/redfish/v1/Managers", endpointFunc(t, "dell/managers.json"))
+	mux.HandleFunc("/redfish/v1/Managers/iDRAC.Embedded.1", endpointFunc(t, "dell/manager.idrac.embedded.1.json"))
+	mux.HandleFunc("/redfish/v1/Systems", endpointFunc(t, "dell/systems.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1", endpointFunc(t, "dell/system.embedded.1.virtualmedia.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/VirtualMedia", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		_, _ = w.Write([]byte(virtualMediaCollection))
+	})
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/VirtualMedia/1", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(virtualMediaWithoutActions))
+		case http.MethodPatch:
+			patchCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	client := NewClient(parsedURL.Hostname(), parsedURL.Port(), "", "", WithBasicAuthEnabled(true))
+
+	err = client.Open(ctx)
+	require.NoError(t, err)
+
+	defer client.Close(ctx)
+
+	ok, err := client.SetVirtualMedia(ctx, "CD", "http://example.com/boot.iso")
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.True(t, patchCalled, "expected InsertMedia fallback to PATCH the VirtualMedia resource")
+}
+
+func TestSetVirtualMedia_InsertPatchFallbackRequiresInsertedWithoutWriteProtected(t *testing.T) {
+	const virtualMediaCollection = `{
+		"@odata.context": "/redfish/v1/$metadata#VirtualMediaCollection.VirtualMediaCollection",
+		"@odata.id": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia",
+		"@odata.type": "#VirtualMediaCollection.VirtualMediaCollection",
+		"Members": [
+			{
+				"@odata.id": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/1"
+			}
+		],
+		"Members@odata.count": 1,
+		"Name": "Virtual Media Services"
+	}`
+
+	const virtualMediaWithoutActions = `{
+		"@odata.context": "/redfish/v1/$metadata#VirtualMedia.VirtualMedia",
+		"@odata.id": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/1",
+		"@odata.type": "#VirtualMedia.v1_2_0.VirtualMedia",
+		"Id": "1",
+		"Name": "VirtualMedia",
+		"Image": "",
+		"Inserted": false,
+		"ConnectedVia": "NotConnected",
+		"WriteProtected": true,
+		"MediaTypes": ["CD", "DVD"]
+	}`
+
+	var patchAttempts int
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/", endpointFunc(t, "dell/serviceroot.json"))
+	mux.HandleFunc("/redfish/v1/Managers", endpointFunc(t, "dell/managers.json"))
+	mux.HandleFunc("/redfish/v1/Managers/iDRAC.Embedded.1", endpointFunc(t, "dell/manager.idrac.embedded.1.json"))
+	mux.HandleFunc("/redfish/v1/Systems", endpointFunc(t, "dell/systems.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1", endpointFunc(t, "dell/system.embedded.1.virtualmedia.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/VirtualMedia", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		_, _ = w.Write([]byte(virtualMediaCollection))
+	})
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/VirtualMedia/1", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(virtualMediaWithoutActions))
+		case http.MethodPatch:
+			patchAttempts++
+
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+
+			payload := string(body)
+
+			// First attempt includes WriteProtected and is rejected by this BMC.
+			if strings.Contains(payload, "WriteProtected") {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":{"message":"WriteProtected is not accepted"}}`))
+				return
+			}
+
+			// The BMC requires Inserted to be present.
+			if !strings.Contains(payload, "Inserted") {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":{"message":"The property Inserted is a required property and must be included in the request."}}`))
+				return
+			}
+
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	client := NewClient(parsedURL.Hostname(), parsedURL.Port(), "", "", WithBasicAuthEnabled(true))
+
+	err = client.Open(ctx)
+	require.NoError(t, err)
+
+	defer client.Close(ctx)
+
+	ok, err := client.SetVirtualMedia(ctx, "CD", "http://example.com/boot.iso")
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, 2, patchAttempts)
+}
+
+func TestSetVirtualMedia_EjectPatchFallbackWithoutAction(t *testing.T) {
+	const virtualMediaCollection = `{
+		"@odata.context": "/redfish/v1/$metadata#VirtualMediaCollection.VirtualMediaCollection",
+		"@odata.id": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia",
+		"@odata.type": "#VirtualMediaCollection.VirtualMediaCollection",
+		"Members": [
+			{
+				"@odata.id": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/1"
+			}
+		],
+		"Members@odata.count": 1,
+		"Name": "Virtual Media Services"
+	}`
+
+	const insertedVirtualMediaWithoutActions = `{
+		"@odata.context": "/redfish/v1/$metadata#VirtualMedia.VirtualMedia",
+		"@odata.id": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/1",
+		"@odata.type": "#VirtualMedia.v1_2_0.VirtualMedia",
+		"Id": "1",
+		"Name": "VirtualMedia",
+		"Image": "http://example.com/old.iso",
+		"Inserted": true,
+		"ConnectedVia": "URI",
+		"WriteProtected": true,
+		"MediaTypes": ["CD", "DVD"]
+	}`
+
+	var patchCalled bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/", endpointFunc(t, "dell/serviceroot.json"))
+	mux.HandleFunc("/redfish/v1/Managers", endpointFunc(t, "dell/managers.json"))
+	mux.HandleFunc("/redfish/v1/Managers/iDRAC.Embedded.1", endpointFunc(t, "dell/manager.idrac.embedded.1.json"))
+	mux.HandleFunc("/redfish/v1/Systems", endpointFunc(t, "dell/systems.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1", endpointFunc(t, "dell/system.embedded.1.virtualmedia.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/VirtualMedia", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		_, _ = w.Write([]byte(virtualMediaCollection))
+	})
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/VirtualMedia/1", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(insertedVirtualMediaWithoutActions))
+		case http.MethodPatch:
+			patchCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	client := NewClient(parsedURL.Hostname(), parsedURL.Port(), "", "", WithBasicAuthEnabled(true))
+
+	err = client.Open(ctx)
+	require.NoError(t, err)
+
+	defer client.Close(ctx)
+
+	ok, err := client.SetVirtualMedia(ctx, "CD", "")
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.True(t, patchCalled, "expected EjectMedia fallback to PATCH the VirtualMedia resource")
 }
 
 func TestSetVirtualMedia_InvalidMediaType(t *testing.T) {

--- a/internal/redfishwrapper/virtual_media_test.go
+++ b/internal/redfishwrapper/virtual_media_test.go
@@ -248,7 +248,7 @@ func TestSetVirtualMedia_InsertPatchFallbackWithoutAction(t *testing.T) {
 		"MediaTypes": ["CD", "DVD"]
 	}`
 
-	var patchCalled bool
+	var patchAttempts int
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/redfish/v1/", endpointFunc(t, "dell/serviceroot.json"))
@@ -269,7 +269,7 @@ func TestSetVirtualMedia_InsertPatchFallbackWithoutAction(t *testing.T) {
 		case http.MethodGet:
 			_, _ = w.Write([]byte(virtualMediaWithoutActions))
 		case http.MethodPatch:
-			patchCalled = true
+			patchAttempts++
 			w.WriteHeader(http.StatusNoContent)
 		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)
@@ -294,7 +294,7 @@ func TestSetVirtualMedia_InsertPatchFallbackWithoutAction(t *testing.T) {
 	ok, err := client.SetVirtualMedia(ctx, "CD", "http://example.com/boot.iso")
 	assert.NoError(t, err)
 	assert.True(t, ok)
-	assert.True(t, patchCalled, "expected InsertMedia fallback to PATCH the VirtualMedia resource")
+	assert.Equal(t, 1, patchAttempts, "expected InsertMedia fallback to PATCH the VirtualMedia resource once")
 }
 
 func TestSetVirtualMedia_InsertPatchFallbackRequiresInsertedWithoutWriteProtected(t *testing.T) {


### PR DESCRIPTION
## What does this PR implement/change/remove?

This PR updates the `gofish` dependency to v0.22.0 and adapts `bmclib`'s Virtual Media handling to leverage new fallback mechanisms.

### Key changes:
- **Virtual Media PATCH Fallback:** `bmclib` now supports `InsertMedia` and `EjectMedia` operations via `PATCH` requests for BMCs that do not expose standard Redfish Actions for Virtual Media (e.g., Lenovo XCC). This is achieved by relying on `gofish v0.22.0`'s ability to fallback to PATCHing the VirtualMedia resource directly.
- **Safer Field Access:** Uses `gofish.Deref` for safer access to optional fields like `Inserted`, preventing potential panics if the field is not returned by the BMC.
- **Updated Tests:** New unit tests (`TestSetVirtualMedia_InsertPatchFallbackWithoutAction`, `TestSetVirtualMedia_EjectPatchFallbackWithoutAction`) have been added to specifically cover the new `PATCH` fallback behavior.
- **Documentation and Examples:** `internal/redfishwrapper/doc.go` includes a new section on Virtual Media, detailing the `PATCH` fallback and the `-eject` flag. The `examples/virtualmedia/doc.go` has been updated to use the `-eject` flag and explicitly select the `gofish` provider.

### Checklist
- [x] Tests added
- [ ] Similar commits squashed (Assuming this PR is a single logical change, no complex squashing needed unless requested)

### The HW vendor this change applies to (if applicable)
Lenovo (specifically XCC mentioned in context), and potentially other BMCs that do not expose standard Redfish Virtual Media Actions.

### The HW model number, product name this change applies to (if applicable)
Not specified, but context points to Lenovo XCC.

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)
BMC firmware versions compatible with `gofish v0.22.0` that lack standard Virtual Media Actions.

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)
- `gofish` v0.22.0

## Description for changelog/release notes

Updated `gofish` dependency to v0.22.0. `bmclib` now supports inserting and ejecting virtual media via `PATCH` requests for BMCs that do not expose standard Redfish Virtual Media Actions (e.g., Lenovo XCC). This fallback mechanism ensures broader compatibility. Added new unit tests for this functionality and updated documentation and examples accordingly.
