### PR TITLE
redfishwrapper: return true on successful power off

### DIFF
--- a/internal/redfishwrapper/power.go
+++ b/internal/redfishwrapper/power.go
@@ -92,7 +92,7 @@ func (c *Client) SystemPowerOff(ctx context.Context) (ok bool, err error) {
 		return false, err
 	}
 
-	return false, nil
+	return true, nil
 }
 
 // SystemReset power cycles the system.


### PR DESCRIPTION
## What does this PR implement/change/remove?

SystemPowerOff in redfishwrapper returns false, nil even if power off went success. Because of this, bmc/power.go always returns an error. This change corrects this behavior.

### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

N/A — no dependency changes

## Description for changelog/release notes

```
SystemPowerOff in redfishwrapper now doesn't causes error on successful execution.
```
