### PR TITLE
Feature/provider lenovo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,11 @@ tags
 out/
 
 coverage.txt
+
+# Compiled example binaries (e.g. `go build ./examples/lenovo-smoketest/` drops
+# a `lenovo-smoketest` ELF in the repo root). Anchored so it never matches the
+# examples/lenovo-smoketest/ source directory.
+/lenovo-smoketest
+
+# Real-hardware dump output from examples/lenovo-smoketest/dump-xcc.sh
+xcc-dump/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ bmclib v2 is a library to abstract interacting with baseboard management control
  - [IPMItool](https://github.com/bmc-toolbox/bmclib/tree/main/providers/ipmitool)
  - [Intel AMT](https://github.com/bmc-toolbox/bmclib/tree/main/providers/intelamt)
  - [Asrockrack](https://github.com/bmc-toolbox/bmclib/tree/main/providers/asrockrack)
+ - [Lenovo XClarity Controller (XCC)](https://github.com/bmc-toolbox/bmclib/tree/main/providers/lenovo)
  - [RPC](providers/rpc/)
 
 ## Installation

--- a/bmc/certificate.go
+++ b/bmc/certificate.go
@@ -1,0 +1,54 @@
+package bmc
+
+import "context"
+
+// CSRRequest describes a certificate-signing-request to generate.
+type CSRRequest struct {
+	// CommonName is the fully-qualified domain name of the entity (required).
+	CommonName string
+	// Country, State, City, Organization, OrganizationalUnit and Email are the
+	// optional distinguished-name fields.
+	Country            string
+	State              string
+	City               string
+	Organization       string
+	OrganizationalUnit string
+	Email              string
+	// CertificateCollection is the target certificate collection @odata.id. When
+	// empty the provider uses its default (the BMC HTTPS certificate collection).
+	CertificateCollection string
+}
+
+// CertificateInfo describes an installed certificate.
+type CertificateInfo struct {
+	// ID is the Redfish Certificate Id.
+	ID string
+	// SubjectCommonName is the certificate subject common name.
+	SubjectCommonName string
+	// IssuerCommonName is the certificate issuer common name.
+	IssuerCommonName string
+	// ValidNotBefore / ValidNotAfter are the validity bounds.
+	ValidNotBefore string
+	ValidNotAfter  string
+}
+
+// CertificateManager is implemented by providers that can manage BMC
+// certificates.
+type CertificateManager interface {
+	// CertificateLocations returns the @odata.id locations of installed
+	// certificates.
+	CertificateLocations(ctx context.Context) ([]string, error)
+	// Certificate returns a certificate's properties by its @odata.id location.
+	Certificate(ctx context.Context, location string) (CertificateInfo, error)
+	// GenerateCSR generates a certificate-signing-request and returns the PEM CSR.
+	GenerateCSR(ctx context.Context, req CSRRequest) (csr string, err error)
+	// ReplaceCertificate replaces the certificate at targetURI with the given PEM
+	// certificate.
+	ReplaceCertificate(ctx context.Context, certificatePEM, targetURI string) error
+	// RekeyCertificate generates a new key pair and CSR for the certificate at
+	// certURI.
+	RekeyCertificate(ctx context.Context, certURI string) error
+	// RenewCertificate generates a CSR using the existing key for the certificate
+	// at certURI.
+	RenewCertificate(ctx context.Context, certURI string) error
+}

--- a/bmc/event_subscription.go
+++ b/bmc/event_subscription.go
@@ -1,0 +1,56 @@
+package bmc
+
+import "context"
+
+// EventServiceInfo describes the Redfish EventService configuration.
+type EventServiceInfo struct {
+	// ServiceEnabled reports whether the event service is enabled.
+	ServiceEnabled bool
+	// DeliveryRetryAttempts is the number of delivery retry attempts.
+	DeliveryRetryAttempts int
+	// DeliveryRetryIntervalSeconds is the delivery retry interval.
+	DeliveryRetryIntervalSeconds int
+	// SSEFilterURI is the Server-Sent-Events stream URI, when supported.
+	SSEFilterURI string
+}
+
+// EventSubscription describes an event destination (subscription).
+type EventSubscription struct {
+	// ID is the Redfish subscription Id.
+	ID string
+	// Destination is the subscription delivery URL.
+	Destination string
+	// Protocol is the subscription protocol (e.g. "Redfish").
+	Protocol string
+	// Context is the opaque client context echoed in events.
+	Context string
+}
+
+// EventSubscriptionRequest describes a subscription to create.
+type EventSubscriptionRequest struct {
+	// Destination is the delivery URL (required).
+	Destination string
+	// Protocol is the subscription protocol (defaults to "Redfish" when empty).
+	Protocol string
+	// Context is an opaque client context.
+	Context string
+	// RegistryPrefixes optionally filters the message-registry prefixes.
+	RegistryPrefixes []string
+}
+
+// EventSubscriber is implemented by providers that can read the event service
+// and manage event subscriptions.
+type EventSubscriber interface {
+	// EventService returns the event-service configuration.
+	EventService(ctx context.Context) (EventServiceInfo, error)
+	// EventSubscriptions lists the event subscriptions.
+	EventSubscriptions(ctx context.Context) ([]EventSubscription, error)
+	// EventSubscriptionCreate creates a subscription and returns its Id.
+	EventSubscriptionCreate(ctx context.Context, req EventSubscriptionRequest) (id string, err error)
+	// EventSubscriptionDelete deletes a subscription by Id.
+	EventSubscriptionDelete(ctx context.Context, id string) error
+	// SubmitTestEvent submits a test event (optionally for a specific MessageId).
+	SubmitTestEvent(ctx context.Context, messageID string) error
+	// SetEventService PATCHes event-service properties.
+	SetEventService(ctx context.Context, attrs map[string]any) error
+}

--- a/bmc/extended.go
+++ b/bmc/extended.go
@@ -1,0 +1,407 @@
+package bmc
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+)
+
+// This file provides the FromInterfaces dispatchers for the extended
+// vendor-capability interfaces (secure boot, thermal, power capping, storage
+// volumes, licensing, secure key lifecycle, networking, serial, events,
+// telemetry, jobs, certificates and SNMP).
+//
+// To avoid repeating the provider-iteration/timeout/metadata boilerplate that
+// the older hand-written *FromInterfaces functions carry, the dispatch is
+// centralised in two generics: runProviderRead (operations returning a value)
+// and runProviderAction (operations returning only an error). Each public
+// *FromInterfaces function below is a thin, type-safe binding over one of them.
+
+// runProviderRead invokes op on the first registered provider that implements
+// interface T, returning its result. It records provider attempts, the
+// successful provider and per-provider failures in the returned Metadata, and
+// applies the per-provider timeout — matching the behaviour of the original
+// hand-written *FromInterfaces helpers.
+func runProviderRead[T any, R any](
+	ctx context.Context,
+	timeout time.Duration,
+	providers []interface{},
+	ifaceName string,
+	op func(ctx context.Context, impl T) (R, error),
+) (result R, metadata Metadata, err error) {
+	metadata = newMetadata()
+
+	var matched bool
+	for _, elem := range providers {
+		if elem == nil {
+			continue
+		}
+
+		impl, ok := elem.(T)
+		if !ok {
+			continue
+		}
+		matched = true
+
+		name := getProviderName(elem)
+
+		select {
+		case <-ctx.Done():
+			return result, metadata, multierror.Append(err, ctx.Err())
+		default:
+			metadata.ProvidersAttempted = append(metadata.ProvidersAttempted, name)
+
+			callCtx, cancel := context.WithTimeout(ctx, timeout)
+			res, opErr := op(callCtx, impl)
+			cancel()
+
+			if opErr != nil {
+				err = multierror.Append(err, errors.WithMessagef(opErr, "provider: %v", name))
+				metadata.FailedProviderDetail[name] = opErr.Error()
+				continue
+			}
+
+			metadata.SuccessfulProvider = name
+
+			return res, metadata, nil
+		}
+	}
+
+	if !matched {
+		return result, metadata, multierror.Append(err, fmt.Errorf("no %s implementations found", ifaceName))
+	}
+
+	return result, metadata, multierror.Append(err, fmt.Errorf("failed to invoke %s", ifaceName))
+}
+
+// runProviderAction is runProviderRead for operations that return only an error.
+func runProviderAction[T any](
+	ctx context.Context,
+	timeout time.Duration,
+	providers []interface{},
+	ifaceName string,
+	op func(ctx context.Context, impl T) error,
+) (Metadata, error) {
+	_, metadata, err := runProviderRead(ctx, timeout, providers, ifaceName,
+		func(ctx context.Context, impl T) (struct{}, error) {
+			return struct{}{}, op(ctx, impl)
+		})
+
+	return metadata, err
+}
+
+// --- SecureBootManager ---
+
+func GetSecureBootFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) (SecureBootState, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "SecureBootManager",
+		func(ctx context.Context, p SecureBootManager) (SecureBootState, error) { return p.GetSecureBoot(ctx) })
+}
+
+func SetSecureBootFromInterfaces(ctx context.Context, timeout time.Duration, enabled bool, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "SecureBootManager",
+		func(ctx context.Context, p SecureBootManager) error { return p.SetSecureBoot(ctx, enabled) })
+}
+
+func ResetSecureBootKeysFromInterfaces(ctx context.Context, timeout time.Duration, resetType string, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "SecureBootManager",
+		func(ctx context.Context, p SecureBootManager) error { return p.ResetSecureBootKeys(ctx, resetType) })
+}
+
+// --- ThermalReader ---
+
+func ThermalFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) (ThermalReading, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "ThermalReader",
+		func(ctx context.Context, p ThermalReader) (ThermalReading, error) { return p.Thermal(ctx) })
+}
+
+// --- PowerReader / PowerCapSetter ---
+
+func ReadPowerFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) (PowerInfo, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "PowerReader",
+		func(ctx context.Context, p PowerReader) (PowerInfo, error) { return p.ReadPower(ctx) })
+}
+
+func SetPowerCapFromInterfaces(ctx context.Context, timeout time.Duration, limitWatts *float64, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "PowerCapSetter",
+		func(ctx context.Context, p PowerCapSetter) error { return p.SetPowerCap(ctx, limitWatts) })
+}
+
+// --- VolumeManager ---
+
+func StorageControllersFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) ([]StorageControllerInfo, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "VolumeManager",
+		func(ctx context.Context, p VolumeManager) ([]StorageControllerInfo, error) {
+			return p.StorageControllers(ctx)
+		})
+}
+
+func VolumesFromInterfaces(ctx context.Context, timeout time.Duration, storageID string, providers []interface{}) ([]VolumeInfo, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "VolumeManager",
+		func(ctx context.Context, p VolumeManager) ([]VolumeInfo, error) { return p.Volumes(ctx, storageID) })
+}
+
+func VolumeCreateFromInterfaces(ctx context.Context, timeout time.Duration, storageID string, req VolumeCreateRequest, providers []interface{}) (string, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "VolumeManager",
+		func(ctx context.Context, p VolumeManager) (string, error) { return p.VolumeCreate(ctx, storageID, req) })
+}
+
+func VolumeInitializeFromInterfaces(ctx context.Context, timeout time.Duration, storageID, volumeID, initType string, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "VolumeManager",
+		func(ctx context.Context, p VolumeManager) error {
+			return p.VolumeInitialize(ctx, storageID, volumeID, initType)
+		})
+}
+
+func VolumeUpdateFromInterfaces(ctx context.Context, timeout time.Duration, storageID, volumeID string, settings map[string]any, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "VolumeManager",
+		func(ctx context.Context, p VolumeManager) error {
+			return p.VolumeUpdate(ctx, storageID, volumeID, settings)
+		})
+}
+
+func VolumeDeleteFromInterfaces(ctx context.Context, timeout time.Duration, storageID, volumeID string, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "VolumeManager",
+		func(ctx context.Context, p VolumeManager) error { return p.VolumeDelete(ctx, storageID, volumeID) })
+}
+
+// --- LicenseManager ---
+
+func LicensesFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) ([]LicenseInfo, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "LicenseManager",
+		func(ctx context.Context, p LicenseManager) ([]LicenseInfo, error) { return p.Licenses(ctx) })
+}
+
+func LicenseInstallFromInterfaces(ctx context.Context, timeout time.Duration, license string, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "LicenseManager",
+		func(ctx context.Context, p LicenseManager) error { return p.LicenseInstall(ctx, license) })
+}
+
+func LicenseDeleteFromInterfaces(ctx context.Context, timeout time.Duration, licenseID string, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "LicenseManager",
+		func(ctx context.Context, p LicenseManager) error { return p.LicenseDelete(ctx, licenseID) })
+}
+
+// --- SecureKeyLifecycle ---
+
+func GetSecureKeyLifecycleFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) (SecureKeyLifecycleConfig, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "SecureKeyLifecycle",
+		func(ctx context.Context, p SecureKeyLifecycle) (SecureKeyLifecycleConfig, error) {
+			return p.GetSecureKeyLifecycle(ctx)
+		})
+}
+
+func SetSecureKeyRepoServersFromInterfaces(ctx context.Context, timeout time.Duration, servers []SecureKeyRepoServer, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "SecureKeyLifecycle",
+		func(ctx context.Context, p SecureKeyLifecycle) error { return p.SetSecureKeyRepoServers(ctx, servers) })
+}
+
+// --- NetworkInterfaceGetter / Setter ---
+
+func BMCNetworkInterfacesFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) ([]NetworkInterface, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "NetworkInterfaceGetter",
+		func(ctx context.Context, p NetworkInterfaceGetter) ([]NetworkInterface, error) {
+			return p.BMCNetworkInterfaces(ctx)
+		})
+}
+
+func ServerNetworkInterfacesFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) ([]NetworkInterface, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "NetworkInterfaceGetter",
+		func(ctx context.Context, p NetworkInterfaceGetter) ([]NetworkInterface, error) {
+			return p.ServerNetworkInterfaces(ctx)
+		})
+}
+
+func SetBMCNetworkInterfaceFromInterfaces(ctx context.Context, timeout time.Duration, id string, attrs map[string]any, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "NetworkInterfaceSetter",
+		func(ctx context.Context, p NetworkInterfaceSetter) error {
+			return p.SetBMCNetworkInterface(ctx, id, attrs)
+		})
+}
+
+func SetHostInterfaceEnabledFromInterfaces(ctx context.Context, timeout time.Duration, id string, enabled bool, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "NetworkInterfaceSetter",
+		func(ctx context.Context, p NetworkInterfaceSetter) error {
+			return p.SetHostInterfaceEnabled(ctx, id, enabled)
+		})
+}
+
+// --- NetworkProtocolGetter / Setter ---
+
+func NetworkProtocolsFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) ([]NetworkProtocol, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "NetworkProtocolGetter",
+		func(ctx context.Context, p NetworkProtocolGetter) ([]NetworkProtocol, error) {
+			return p.NetworkProtocols(ctx)
+		})
+}
+
+func SetNetworkProtocolsFromInterfaces(ctx context.Context, timeout time.Duration, attrs map[string]any, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "NetworkProtocolSetter",
+		func(ctx context.Context, p NetworkProtocolSetter) error { return p.SetNetworkProtocols(ctx, attrs) })
+}
+
+// --- SerialInterfaceGetter / Setter ---
+
+func SerialInterfacesFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) ([]SerialInterface, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "SerialInterfaceGetter",
+		func(ctx context.Context, p SerialInterfaceGetter) ([]SerialInterface, error) {
+			return p.SerialInterfaces(ctx)
+		})
+}
+
+func SetSerialInterfaceFromInterfaces(ctx context.Context, timeout time.Duration, id string, attrs map[string]any, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "SerialInterfaceSetter",
+		func(ctx context.Context, p SerialInterfaceSetter) error { return p.SetSerialInterface(ctx, id, attrs) })
+}
+
+// --- EventSubscriber ---
+
+func EventServiceFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) (EventServiceInfo, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "EventSubscriber",
+		func(ctx context.Context, p EventSubscriber) (EventServiceInfo, error) { return p.EventService(ctx) })
+}
+
+func EventSubscriptionsFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) ([]EventSubscription, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "EventSubscriber",
+		func(ctx context.Context, p EventSubscriber) ([]EventSubscription, error) {
+			return p.EventSubscriptions(ctx)
+		})
+}
+
+func EventSubscriptionCreateFromInterfaces(ctx context.Context, timeout time.Duration, req EventSubscriptionRequest, providers []interface{}) (string, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "EventSubscriber",
+		func(ctx context.Context, p EventSubscriber) (string, error) {
+			return p.EventSubscriptionCreate(ctx, req)
+		})
+}
+
+func EventSubscriptionDeleteFromInterfaces(ctx context.Context, timeout time.Duration, id string, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "EventSubscriber",
+		func(ctx context.Context, p EventSubscriber) error { return p.EventSubscriptionDelete(ctx, id) })
+}
+
+func SubmitTestEventFromInterfaces(ctx context.Context, timeout time.Duration, messageID string, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "EventSubscriber",
+		func(ctx context.Context, p EventSubscriber) error { return p.SubmitTestEvent(ctx, messageID) })
+}
+
+func SetEventServiceFromInterfaces(ctx context.Context, timeout time.Duration, attrs map[string]any, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "EventSubscriber",
+		func(ctx context.Context, p EventSubscriber) error { return p.SetEventService(ctx, attrs) })
+}
+
+// --- TelemetryReader ---
+
+func TelemetryServiceFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) (TelemetryServiceInfo, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "TelemetryReader",
+		func(ctx context.Context, p TelemetryReader) (TelemetryServiceInfo, error) {
+			return p.TelemetryService(ctx)
+		})
+}
+
+func MetricReportsFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) ([]string, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "TelemetryReader",
+		func(ctx context.Context, p TelemetryReader) ([]string, error) { return p.MetricReports(ctx) })
+}
+
+func MetricReportFromInterfaces(ctx context.Context, timeout time.Duration, id string, providers []interface{}) (MetricReportInfo, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "TelemetryReader",
+		func(ctx context.Context, p TelemetryReader) (MetricReportInfo, error) { return p.MetricReport(ctx, id) })
+}
+
+func MetricReportDefinitionsFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) ([]string, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "TelemetryReader",
+		func(ctx context.Context, p TelemetryReader) ([]string, error) { return p.MetricReportDefinitions(ctx) })
+}
+
+func MetricDefinitionsFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) ([]string, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "TelemetryReader",
+		func(ctx context.Context, p TelemetryReader) ([]string, error) { return p.MetricDefinitions(ctx) })
+}
+
+func SubmitTestMetricReportFromInterfaces(ctx context.Context, timeout time.Duration, reportName string, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "TelemetryReader",
+		func(ctx context.Context, p TelemetryReader) error { return p.SubmitTestMetricReport(ctx, reportName) })
+}
+
+// --- JobManager ---
+
+func JobServiceFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) (JobServiceInfo, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "JobManager",
+		func(ctx context.Context, p JobManager) (JobServiceInfo, error) { return p.JobService(ctx) })
+}
+
+func JobsFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) ([]JobInfo, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "JobManager",
+		func(ctx context.Context, p JobManager) ([]JobInfo, error) { return p.Jobs(ctx) })
+}
+
+func JobFromInterfaces(ctx context.Context, timeout time.Duration, id string, providers []interface{}) (JobInfo, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "JobManager",
+		func(ctx context.Context, p JobManager) (JobInfo, error) { return p.Job(ctx, id) })
+}
+
+func JobUpdateScheduleFromInterfaces(ctx context.Context, timeout time.Duration, id string, schedule map[string]any, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "JobManager",
+		func(ctx context.Context, p JobManager) error { return p.JobUpdateSchedule(ctx, id, schedule) })
+}
+
+// --- CertificateManager ---
+
+func CertificateLocationsFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) ([]string, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "CertificateManager",
+		func(ctx context.Context, p CertificateManager) ([]string, error) { return p.CertificateLocations(ctx) })
+}
+
+func CertificateFromInterfaces(ctx context.Context, timeout time.Duration, location string, providers []interface{}) (CertificateInfo, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "CertificateManager",
+		func(ctx context.Context, p CertificateManager) (CertificateInfo, error) {
+			return p.Certificate(ctx, location)
+		})
+}
+
+func GenerateCSRFromInterfaces(ctx context.Context, timeout time.Duration, req CSRRequest, providers []interface{}) (string, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "CertificateManager",
+		func(ctx context.Context, p CertificateManager) (string, error) { return p.GenerateCSR(ctx, req) })
+}
+
+func ReplaceCertificateFromInterfaces(ctx context.Context, timeout time.Duration, certificatePEM, targetURI string, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "CertificateManager",
+		func(ctx context.Context, p CertificateManager) error {
+			return p.ReplaceCertificate(ctx, certificatePEM, targetURI)
+		})
+}
+
+func RekeyCertificateFromInterfaces(ctx context.Context, timeout time.Duration, certURI string, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "CertificateManager",
+		func(ctx context.Context, p CertificateManager) error { return p.RekeyCertificate(ctx, certURI) })
+}
+
+func RenewCertificateFromInterfaces(ctx context.Context, timeout time.Duration, certURI string, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "CertificateManager",
+		func(ctx context.Context, p CertificateManager) error { return p.RenewCertificate(ctx, certURI) })
+}
+
+// --- SNMPConfigurer ---
+
+func SNMPFromInterfaces(ctx context.Context, timeout time.Duration, providers []interface{}) (SNMPConfig, Metadata, error) {
+	return runProviderRead(ctx, timeout, providers, "SNMPConfigurer",
+		func(ctx context.Context, p SNMPConfigurer) (SNMPConfig, error) { return p.SNMP(ctx) })
+}
+
+func SetSNMPAlertFilterFromInterfaces(ctx context.Context, timeout time.Duration, attrs map[string]any, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "SNMPConfigurer",
+		func(ctx context.Context, p SNMPConfigurer) error { return p.SetSNMPAlertFilter(ctx, attrs) })
+}
+
+func EnableSNMPv1TrapFromInterfaces(ctx context.Context, timeout time.Duration, enabled bool, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "SNMPConfigurer",
+		func(ctx context.Context, p SNMPConfigurer) error { return p.EnableSNMPv1Trap(ctx, enabled) })
+}
+
+func EnableSNMPv3TrapFromInterfaces(ctx context.Context, timeout time.Duration, enabled bool, providers []interface{}) (Metadata, error) {
+	return runProviderAction(ctx, timeout, providers, "SNMPConfigurer",
+		func(ctx context.Context, p SNMPConfigurer) error { return p.EnableSNMPv3Trap(ctx, enabled) })
+}

--- a/bmc/extended_test.go
+++ b/bmc/extended_test.go
@@ -1,0 +1,119 @@
+package bmc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeSecureBoot is a test provider implementing SecureBootManager (and Provider
+// for a stable name).
+type fakeSecureBoot struct {
+	name    string
+	state   SecureBootState
+	getErr  error
+	setErr  error
+	setSeen *bool
+}
+
+func (f *fakeSecureBoot) Name() string { return f.name }
+
+func (f *fakeSecureBoot) GetSecureBoot(_ context.Context) (SecureBootState, error) {
+	return f.state, f.getErr
+}
+
+func (f *fakeSecureBoot) SetSecureBoot(_ context.Context, _ bool) error {
+	if f.setSeen != nil {
+		*f.setSeen = true
+	}
+	return f.setErr
+}
+
+func (f *fakeSecureBoot) ResetSecureBootKeys(_ context.Context, _ string) error { return nil }
+
+// bareProvider implements Provider but none of the extended interfaces.
+type bareProvider struct{ name string }
+
+func (b *bareProvider) Name() string { return b.name }
+
+const testTimeout = 5 * time.Second
+
+func TestRunProviderRead_Success(t *testing.T) {
+	want := SecureBootState{Enabled: true, Mode: "SetupMode"}
+	providers := []interface{}{
+		&bareProvider{name: "bare"},
+		&fakeSecureBoot{name: "lenovo", state: want},
+	}
+
+	got, metadata, err := GetSecureBootFromInterfaces(context.Background(), testTimeout, providers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("state = %+v, want %+v", got, want)
+	}
+	if metadata.SuccessfulProvider != "lenovo" {
+		t.Errorf("SuccessfulProvider = %q, want %q", metadata.SuccessfulProvider, "lenovo")
+	}
+}
+
+func TestRunProviderRead_NoImplementations(t *testing.T) {
+	providers := []interface{}{&bareProvider{name: "bare"}, nil}
+
+	_, _, err := GetSecureBootFromInterfaces(context.Background(), testTimeout, providers)
+	if err == nil {
+		t.Fatal("expected an error when no provider implements the interface")
+	}
+	if !containsStr(err.Error(), "no SecureBootManager implementations found") {
+		t.Errorf("error = %q, want it to mention no implementations", err.Error())
+	}
+}
+
+func TestRunProviderRead_FailureRecorded(t *testing.T) {
+	providers := []interface{}{
+		&fakeSecureBoot{name: "lenovo", getErr: errors.New("boom")},
+	}
+
+	_, metadata, err := GetSecureBootFromInterfaces(context.Background(), testTimeout, providers)
+	if err == nil {
+		t.Fatal("expected an error when the provider call fails")
+	}
+	if detail := metadata.FailedProviderDetail["lenovo"]; detail == "" {
+		t.Error("expected FailedProviderDetail to record the failing provider")
+	}
+}
+
+func TestRunProviderAction_Success(t *testing.T) {
+	var seen bool
+	providers := []interface{}{&fakeSecureBoot{name: "lenovo", setSeen: &seen}}
+
+	metadata, err := SetSecureBootFromInterfaces(context.Background(), testTimeout, true, providers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !seen {
+		t.Error("expected SetSecureBoot to be invoked")
+	}
+	if metadata.SuccessfulProvider != "lenovo" {
+		t.Errorf("SuccessfulProvider = %q, want %q", metadata.SuccessfulProvider, "lenovo")
+	}
+}
+
+func TestRunProviderAction_Error(t *testing.T) {
+	providers := []interface{}{&fakeSecureBoot{name: "lenovo", setErr: errors.New("denied")}}
+
+	_, err := SetSecureBootFromInterfaces(context.Background(), testTimeout, true, providers)
+	if err == nil {
+		t.Fatal("expected an error when the action fails")
+	}
+}
+
+func containsStr(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/bmc/job.go
+++ b/bmc/job.go
@@ -1,0 +1,36 @@
+package bmc
+
+import "context"
+
+// JobServiceInfo describes the Redfish JobService configuration.
+type JobServiceInfo struct {
+	// ServiceEnabled reports whether the job service is enabled.
+	ServiceEnabled bool
+}
+
+// JobInfo describes a Redfish job.
+type JobInfo struct {
+	// ID is the Redfish Job Id.
+	ID string
+	// Name is the job name.
+	Name string
+	// JobState is the job state (e.g. "Scheduled", "Running", "Completed").
+	JobState string
+	// PercentComplete is the job completion percentage.
+	PercentComplete int
+	// StartTime is the scheduled/actual start time.
+	StartTime string
+}
+
+// JobManager is implemented by providers that can read jobs and update a job's
+// schedule.
+type JobManager interface {
+	// JobService returns the job-service configuration.
+	JobService(ctx context.Context) (JobServiceInfo, error)
+	// Jobs lists the jobs.
+	Jobs(ctx context.Context) ([]JobInfo, error)
+	// Job returns a job by Id.
+	Job(ctx context.Context, id string) (JobInfo, error)
+	// JobUpdateSchedule PATCHes a job's Schedule with the given properties.
+	JobUpdateSchedule(ctx context.Context, id string, schedule map[string]any) error
+}

--- a/bmc/license.go
+++ b/bmc/license.go
@@ -1,0 +1,29 @@
+package bmc
+
+import "context"
+
+// LicenseInfo describes an installed BMC license.
+type LicenseInfo struct {
+	// ID is the Redfish License resource Id.
+	ID string
+	// EntitlementID is the license entitlement identifier.
+	EntitlementID string
+	// LicenseType is the license type (e.g. "Production", "Trial").
+	LicenseType string
+	// State is the license status state (e.g. "Enabled").
+	State string
+	// Removable reports whether the license can be deleted.
+	Removable bool
+}
+
+// LicenseManager is implemented by providers that can read, install and delete
+// BMC licenses.
+type LicenseManager interface {
+	// Licenses returns the installed licenses.
+	Licenses(ctx context.Context) ([]LicenseInfo, error)
+	// LicenseInstall installs a license from its (typically base64-encoded)
+	// license string.
+	LicenseInstall(ctx context.Context, license string) error
+	// LicenseDelete removes an installed license by its Id.
+	LicenseDelete(ctx context.Context, licenseID string) error
+}

--- a/bmc/network.go
+++ b/bmc/network.go
@@ -1,0 +1,64 @@
+package bmc
+
+import "context"
+
+// NetworkInterface describes a BMC or server ethernet interface.
+type NetworkInterface struct {
+	// ID is the Redfish EthernetInterface Id.
+	ID string
+	// MACAddress is the interface MAC address.
+	MACAddress string
+	// HostName is the configured hostname (BMC interfaces).
+	HostName string
+	// IPv4Addresses are the configured IPv4 addresses.
+	IPv4Addresses []string
+	// IPv6Addresses are the configured IPv6 addresses.
+	IPv6Addresses []string
+	// Enabled reports whether the interface is enabled.
+	Enabled bool
+}
+
+// NetworkProtocol describes a manager network service (protocol) and its state.
+type NetworkProtocol struct {
+	// Name is the service name (e.g. "HTTPS", "SSH", "IPMI", "SNMP", "NTP").
+	Name string
+	// Enabled reports whether the service is enabled.
+	Enabled bool
+	// Port is the service port (0 when not reported).
+	Port int
+}
+
+// NetworkInterfaceGetter is implemented by providers that can read BMC and
+// server ethernet interfaces.
+type NetworkInterfaceGetter interface {
+	// BMCNetworkInterfaces returns the BMC (manager) ethernet interfaces.
+	BMCNetworkInterfaces(ctx context.Context) ([]NetworkInterface, error)
+	// ServerNetworkInterfaces returns the server (system) ethernet interfaces.
+	ServerNetworkInterfaces(ctx context.Context) ([]NetworkInterface, error)
+}
+
+// NetworkInterfaceSetter is implemented by providers that can configure BMC
+// network interfaces.
+type NetworkInterfaceSetter interface {
+	// SetBMCNetworkInterface PATCHes the BMC ethernet interface with id using the
+	// given Redfish attributes (e.g. {"HostName": "x", "IPv4StaticAddresses": [...],
+	// "VLAN": {...}}).
+	SetBMCNetworkInterface(ctx context.Context, id string, attrs map[string]any) error
+	// SetHostInterfaceEnabled enables or disables the host interface with id.
+	SetHostInterfaceEnabled(ctx context.Context, id string, enabled bool) error
+}
+
+// NetworkProtocolGetter is implemented by providers that can read the manager
+// network protocols/services.
+type NetworkProtocolGetter interface {
+	// NetworkProtocols returns the manager network services and their state.
+	NetworkProtocols(ctx context.Context) ([]NetworkProtocol, error)
+}
+
+// NetworkProtocolSetter is implemented by providers that can configure the
+// manager network protocols/services.
+type NetworkProtocolSetter interface {
+	// SetNetworkProtocols PATCHes ManagerNetworkProtocol with the given Redfish
+	// attributes (e.g. {"IPMI": {"ProtocolEnabled": false}}).
+	SetNetworkProtocols(ctx context.Context, attrs map[string]any) error
+}

--- a/bmc/power_cap.go
+++ b/bmc/power_cap.go
@@ -1,0 +1,41 @@
+package bmc
+
+import "context"
+
+// PowerSupplyInfo describes a single power supply.
+type PowerSupplyInfo struct {
+	// Name is the power supply name.
+	Name string
+	// Health is the power supply health (e.g. "OK", "Warning", "Critical").
+	Health string
+	// CapacityWatts is the maximum output capacity in watts.
+	CapacityWatts float64
+}
+
+// PowerInfo aggregates a device's power metrics and supplies.
+type PowerInfo struct {
+	// ConsumedWatts is the current power draw in watts.
+	ConsumedWatts float64
+	// CapacityWatts is the total power capacity in watts.
+	CapacityWatts float64
+	// LimitInWatts is the configured power cap in watts; nil means no cap is
+	// configured (power capping disabled).
+	LimitInWatts *float64
+	// PowerSupplies lists the device's power supplies.
+	PowerSupplies []PowerSupplyInfo
+}
+
+// PowerReader is implemented by providers that can read a device's power
+// metrics.
+type PowerReader interface {
+	// ReadPower returns the device's power metrics and supplies.
+	ReadPower(ctx context.Context) (PowerInfo, error)
+}
+
+// PowerCapSetter is implemented by providers that can set a chassis power limit
+// (power capping).
+type PowerCapSetter interface {
+	// SetPowerCap sets the power limit in watts. A nil limitWatts disables power
+	// capping.
+	SetPowerCap(ctx context.Context, limitWatts *float64) error
+}

--- a/bmc/secure_boot.go
+++ b/bmc/secure_boot.go
@@ -1,0 +1,28 @@
+package bmc
+
+import "context"
+
+// SecureBootState describes the UEFI Secure Boot state of a system.
+type SecureBootState struct {
+	// Enabled reports whether UEFI Secure Boot takes effect on the next boot.
+	Enabled bool
+	// CurrentBoot reports the Secure Boot state during the current boot cycle
+	// (e.g. "Enabled", "Disabled").
+	CurrentBoot string
+	// Mode reports the current UEFI Secure Boot mode (e.g. "UserMode",
+	// "SetupMode", "AuditMode", "DeployedMode").
+	Mode string
+}
+
+// SecureBootManager is implemented by providers that can read and manage UEFI
+// Secure Boot on a system.
+type SecureBootManager interface {
+	// GetSecureBoot returns the current Secure Boot state.
+	GetSecureBoot(ctx context.Context) (SecureBootState, error)
+	// SetSecureBoot enables or disables Secure Boot (applied on next boot).
+	SetSecureBoot(ctx context.Context, enabled bool) error
+	// ResetSecureBootKeys resets the Secure Boot key databases. resetType is a
+	// Redfish ResetKeysType, e.g. "ResetAllKeysToDefault", "DeleteAllKeys" or
+	// "DeletePK". This is destructive and may require a subsequent system reset.
+	ResetSecureBootKeys(ctx context.Context, resetType string) error
+}

--- a/bmc/secure_key_lifecycle.go
+++ b/bmc/secure_key_lifecycle.go
@@ -1,0 +1,28 @@
+package bmc
+
+import "context"
+
+// SecureKeyRepoServer is a key-repository (SKLM/TKLM) server endpoint.
+type SecureKeyRepoServer struct {
+	// HostName is a remote server address (IPv4, IPv6 or hostname).
+	HostName string
+	// Port is the remote server port (1-65535).
+	Port int
+}
+
+// SecureKeyLifecycleConfig is the Secure Key Lifecycle (SKLM) configuration.
+type SecureKeyLifecycleConfig struct {
+	// DeviceGroup is the SKLM device group name.
+	DeviceGroup string
+	// KeyRepoServers is the list of configured key-repository servers.
+	KeyRepoServers []SecureKeyRepoServer
+}
+
+// SecureKeyLifecycle is implemented by providers that can read and configure the
+// Secure Key Lifecycle service (key-repository servers).
+type SecureKeyLifecycle interface {
+	// GetSecureKeyLifecycle returns the current SKLM configuration.
+	GetSecureKeyLifecycle(ctx context.Context) (SecureKeyLifecycleConfig, error)
+	// SetSecureKeyRepoServers replaces the configured key-repository servers.
+	SetSecureKeyRepoServers(ctx context.Context, servers []SecureKeyRepoServer) error
+}

--- a/bmc/serial.go
+++ b/bmc/serial.go
@@ -1,0 +1,36 @@
+package bmc
+
+import "context"
+
+// SerialInterface describes a BMC serial interface.
+type SerialInterface struct {
+	// ID is the Redfish SerialInterface Id.
+	ID string
+	// Enabled reports whether the interface is enabled.
+	Enabled bool
+	// BitRate is the configured baud rate (e.g. "115200").
+	BitRate string
+	// FlowControl is the flow-control mode (e.g. "None", "Software", "Hardware").
+	FlowControl string
+	// Parity is the parity mode (e.g. "None", "Even", "Odd").
+	Parity string
+	// StopBits is the number of stop bits (e.g. "1", "2").
+	StopBits string
+	// DataBits is the number of data bits (e.g. "8").
+	DataBits string
+}
+
+// SerialInterfaceGetter is implemented by providers that can read BMC serial
+// interfaces.
+type SerialInterfaceGetter interface {
+	// SerialInterfaces returns the BMC serial interfaces.
+	SerialInterfaces(ctx context.Context) ([]SerialInterface, error)
+}
+
+// SerialInterfaceSetter is implemented by providers that can configure a BMC
+// serial interface.
+type SerialInterfaceSetter interface {
+	// SetSerialInterface PATCHes the serial interface with id using the given
+	// Redfish attributes (e.g. {"BitRate": "115200", "FlowControl": "None"}).
+	SetSerialInterface(ctx context.Context, id string, attrs map[string]any) error
+}

--- a/bmc/snmp.go
+++ b/bmc/snmp.go
@@ -1,0 +1,29 @@
+package bmc
+
+import "context"
+
+// SNMPConfig describes the BMC SNMP trap configuration.
+type SNMPConfig struct {
+	// V1TrapEnabled reports whether the SNMPv1 trap is enabled.
+	V1TrapEnabled bool
+	// V3TrapEnabled reports whether the SNMPv3 trap is enabled.
+	V3TrapEnabled bool
+	// TrapPort is the trap receiver port.
+	TrapPort int
+	// CommunityNames are the configured SNMPv1 community names.
+	CommunityNames []string
+}
+
+// SNMPConfigurer is implemented by providers that can read and configure SNMP
+// traps.
+type SNMPConfigurer interface {
+	// SNMP returns the SNMP trap configuration.
+	SNMP(ctx context.Context) (SNMPConfig, error)
+	// SetSNMPAlertFilter PATCHes the SNMP trap (SNMPTraps) properties with the
+	// given attributes (alert recipients, community names, addresses, ...).
+	SetSNMPAlertFilter(ctx context.Context, attrs map[string]any) error
+	// EnableSNMPv1Trap enables or disables the SNMPv1 trap.
+	EnableSNMPv1Trap(ctx context.Context, enabled bool) error
+	// EnableSNMPv3Trap enables or disables the SNMPv3 trap.
+	EnableSNMPv3Trap(ctx context.Context, enabled bool) error
+}

--- a/bmc/telemetry.go
+++ b/bmc/telemetry.go
@@ -1,0 +1,54 @@
+package bmc
+
+import "context"
+
+// TelemetryServiceInfo describes the Redfish TelemetryService configuration.
+type TelemetryServiceInfo struct {
+	// ServiceEnabled reports whether the telemetry service is enabled.
+	ServiceEnabled bool
+	// MaxReports is the maximum number of metric reports supported.
+	MaxReports int
+	// MinCollectionInterval is the minimum metric collection interval (ISO 8601).
+	MinCollectionInterval string
+}
+
+// MetricValue is a single metric reading within a metric report.
+type MetricValue struct {
+	// MetricID is the metric identifier (Redfish MetricId). XCC often leaves
+	// this empty and identifies the reading via MetricProperty instead.
+	MetricID string
+	// MetricProperty is the Redfish resource property the reading came from
+	// (e.g. "/redfish/v1/Chassis/1/Power#/PowerControl/0/PowerMetrics/MaxConsumedWatts").
+	MetricProperty string
+	// Value is the metric value (as reported, stringified).
+	Value string
+	// Timestamp is the reading timestamp.
+	Timestamp string
+}
+
+// MetricReportInfo is a metric report and its values.
+type MetricReportInfo struct {
+	// ID is the Redfish MetricReport Id.
+	ID string
+	// Name is the report name.
+	Name string
+	// Values are the report's metric values.
+	Values []MetricValue
+}
+
+// TelemetryReader is implemented by providers that can read telemetry-service
+// metric reports and definitions.
+type TelemetryReader interface {
+	// TelemetryService returns the telemetry-service configuration.
+	TelemetryService(ctx context.Context) (TelemetryServiceInfo, error)
+	// MetricReports lists the metric report Ids.
+	MetricReports(ctx context.Context) ([]string, error)
+	// MetricReport returns a metric report and its values by Id.
+	MetricReport(ctx context.Context, id string) (MetricReportInfo, error)
+	// MetricReportDefinitions lists the metric report definition Ids.
+	MetricReportDefinitions(ctx context.Context) ([]string, error)
+	// MetricDefinitions lists the metric definition Ids.
+	MetricDefinitions(ctx context.Context) ([]string, error)
+	// SubmitTestMetricReport submits a test metric report.
+	SubmitTestMetricReport(ctx context.Context, reportName string) error
+}

--- a/bmc/thermal.go
+++ b/bmc/thermal.go
@@ -1,0 +1,37 @@
+package bmc
+
+import "context"
+
+// TemperatureReading is a single temperature sensor reading.
+type TemperatureReading struct {
+	// Name is the sensor name (e.g. "Ambient Temp").
+	Name string
+	// ReadingCelsius is the current temperature in degrees Celsius.
+	ReadingCelsius float64
+	// Health is the sensor health (e.g. "OK", "Warning", "Critical").
+	Health string
+}
+
+// FanReading is a single fan reading.
+type FanReading struct {
+	// Name is the fan name (e.g. "Fan 1 Tach").
+	Name string
+	// Reading is the current fan reading (RPM, unless the device reports
+	// another unit).
+	Reading int
+	// Health is the fan health (e.g. "OK", "Warning", "Critical").
+	Health string
+}
+
+// ThermalReading aggregates the thermal sensors of a device.
+type ThermalReading struct {
+	Temperatures []TemperatureReading
+	Fans         []FanReading
+}
+
+// ThermalReader is implemented by providers that can read a device's thermal
+// sensors (temperatures and fans).
+type ThermalReader interface {
+	// Thermal returns the device's temperature and fan readings.
+	Thermal(ctx context.Context) (ThermalReading, error)
+}

--- a/bmc/volume.go
+++ b/bmc/volume.go
@@ -1,0 +1,66 @@
+package bmc
+
+import "context"
+
+// StorageControllerInfo describes a storage controller.
+type StorageControllerInfo struct {
+	// ID is the Redfish Storage resource Id (used to address volumes/drives).
+	ID string
+	// Name is the controller name.
+	Name string
+	// Model is the controller model.
+	Model string
+	// Health is the controller health (e.g. "OK", "Warning", "Critical").
+	Health string
+	// DriveCount is the number of drives managed by the controller.
+	DriveCount int
+}
+
+// VolumeInfo describes a storage volume.
+type VolumeInfo struct {
+	// ID is the Redfish Volume resource Id.
+	ID string
+	// Name is the volume name.
+	Name string
+	// RAIDType is the volume RAID type (e.g. "RAID0", "RAID1").
+	RAIDType string
+	// CapacityBytes is the volume capacity in bytes.
+	CapacityBytes int64
+	// Health is the volume health (e.g. "OK", "Warning", "Critical").
+	Health string
+}
+
+// VolumeCreateRequest describes a volume to create on a storage controller.
+type VolumeCreateRequest struct {
+	// Name is the requested volume name.
+	Name string
+	// RAIDType is the requested RAID type (e.g. "RAID0", "RAID1", "RAID5").
+	RAIDType string
+	// CapacityBytes is the requested capacity in bytes. Zero lets the
+	// controller choose the maximum available capacity.
+	CapacityBytes int64
+	// Drives is the list of member drive Redfish @odata.id paths.
+	Drives []string
+}
+
+// VolumeManager is implemented by providers that can read and manage storage
+// volumes on a controller.
+//
+// Volumes and controllers are addressed by their Redfish resource Id within the
+// system's Storage collection.
+type VolumeManager interface {
+	// StorageControllers lists the storage controllers of the system.
+	StorageControllers(ctx context.Context) ([]StorageControllerInfo, error)
+	// Volumes lists the volumes managed by the given storage controller.
+	Volumes(ctx context.Context, storageID string) ([]VolumeInfo, error)
+	// VolumeCreate creates a volume on the given storage controller and returns
+	// the new volume Id (or a task Id when the operation is asynchronous).
+	VolumeCreate(ctx context.Context, storageID string, req VolumeCreateRequest) (volumeID string, err error)
+	// VolumeInitialize initializes a volume. initType is a Redfish
+	// InitializeType such as "Fast" or "Slow".
+	VolumeInitialize(ctx context.Context, storageID, volumeID, initType string) error
+	// VolumeUpdate updates volume settings via a PATCH of the given attributes.
+	VolumeUpdate(ctx context.Context, storageID, volumeID string, settings map[string]any) error
+	// VolumeDelete deletes a volume.
+	VolumeDelete(ctx context.Context, storageID, volumeID string) error
+}

--- a/client.go
+++ b/client.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bmc-toolbox/bmclib/v2/providers/homeassistant"
 	"github.com/bmc-toolbox/bmclib/v2/providers/intelamt"
 	"github.com/bmc-toolbox/bmclib/v2/providers/ipmitool"
+	"github.com/bmc-toolbox/bmclib/v2/providers/lenovo"
 	"github.com/bmc-toolbox/bmclib/v2/providers/openbmc"
 	"github.com/bmc-toolbox/bmclib/v2/providers/redfish"
 	"github.com/bmc-toolbox/bmclib/v2/providers/rpc"
@@ -70,6 +71,7 @@ type providerConfig struct {
 	gofish        redfish.Config
 	intelamt      intelamt.Config
 	dell          dell.Config
+	lenovo        lenovo.Config
 	supermicro    supermicro.Config
 	rpc           rpc.Provider
 	openbmc       openbmc.Config
@@ -101,6 +103,10 @@ func NewClient(host, user, pass string, opts ...Option) *Client {
 				Port:       16992,
 			},
 			dell: dell.Config{
+				Port:                  "443",
+				VersionsNotCompatible: []string{},
+			},
+			lenovo: lenovo.Config{
 				Port:                  "443",
 				VersionsNotCompatible: []string{},
 			},
@@ -250,6 +256,22 @@ func (c *Client) registerDellProvider() {
 	c.Registry.Register(dell.ProviderName, redfish.ProviderProtocol, dell.Features, nil, driverGoFishDell)
 }
 
+// register Lenovo XCC gofish provider
+func (c *Client) registerLenovoProvider() {
+	lenovoHTTPClient := *c.httpClient
+	lenovoHTTPClient.Transport = c.httpClient.Transport.(*http.Transport).Clone()
+	lenovoOpts := []lenovo.Option{
+		lenovo.WithHTTPClient(&lenovoHTTPClient),
+		lenovo.WithVersionsNotCompatible(c.providerConfig.lenovo.VersionsNotCompatible),
+		lenovo.WithUseBasicAuth(c.providerConfig.lenovo.UseBasicAuth),
+		lenovo.WithPort(c.providerConfig.lenovo.Port),
+		lenovo.WithEtagMatchDisabled(c.providerConfig.lenovo.DisableEtagMatch),
+		lenovo.WithSystemName(c.providerConfig.lenovo.SystemName),
+	}
+	driverLenovo := lenovo.New(c.Auth.Host, c.Auth.User, c.Auth.Pass, c.Logger, lenovoOpts...)
+	c.Registry.Register(lenovo.ProviderName, lenovo.ProviderProtocol, lenovo.Features, nil, driverLenovo)
+}
+
 // register supermicro vendorapi provider
 func (c *Client) registerSupermicroProvider() {
 	smcHttpClient := *c.httpClient
@@ -314,6 +336,7 @@ func (c *Client) registerProviders() {
 	c.registerGofishProvider()
 	c.registerIntelAMTProvider()
 	c.registerDellProvider()
+	c.registerLenovoProvider()
 	c.registerSupermicroProvider()
 	c.registerOpenBMCProvider()
 }

--- a/client_features.go
+++ b/client_features.go
@@ -1,0 +1,650 @@
+package bmclib
+
+import (
+	"context"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+// This file exposes the high-level bmclib.Client methods for the extended
+// vendor-capability interfaces. Each method resolves the registered providers,
+// dispatches to the corresponding bmc.*FromInterfaces helper using the
+// per-provider timeout, stores the returned metadata and records span
+// attributes — the same contract as the core Client methods (GetPowerState,
+// SetBootDevice, ...).
+
+// --- Secure Boot ---
+
+// GetSecureBoot returns the UEFI Secure Boot state.
+func (c *Client) GetSecureBoot(ctx context.Context) (bmc.SecureBootState, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "GetSecureBoot")
+	defer span.End()
+
+	state, metadata, err := bmc.GetSecureBootFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return state, err
+}
+
+// SetSecureBoot enables or disables UEFI Secure Boot (applied on next boot).
+func (c *Client) SetSecureBoot(ctx context.Context, enabled bool) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "SetSecureBoot")
+	defer span.End()
+
+	metadata, err := bmc.SetSecureBootFromInterfaces(ctx, c.perProviderTimeout(ctx), enabled, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// ResetSecureBootKeys resets the Secure Boot key databases (destructive).
+func (c *Client) ResetSecureBootKeys(ctx context.Context, resetType string) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "ResetSecureBootKeys")
+	defer span.End()
+
+	metadata, err := bmc.ResetSecureBootKeysFromInterfaces(ctx, c.perProviderTimeout(ctx), resetType, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// --- Thermal / Power ---
+
+// GetThermal returns the device's temperature and fan readings.
+func (c *Client) GetThermal(ctx context.Context) (bmc.ThermalReading, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "GetThermal")
+	defer span.End()
+
+	reading, metadata, err := bmc.ThermalFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return reading, err
+}
+
+// ReadPower returns the device's power metrics and supplies.
+func (c *Client) ReadPower(ctx context.Context) (bmc.PowerInfo, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "ReadPower")
+	defer span.End()
+
+	info, metadata, err := bmc.ReadPowerFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return info, err
+}
+
+// SetPowerCap sets the chassis power limit in watts; a nil limit disables capping.
+func (c *Client) SetPowerCap(ctx context.Context, limitWatts *float64) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "SetPowerCap")
+	defer span.End()
+
+	metadata, err := bmc.SetPowerCapFromInterfaces(ctx, c.perProviderTimeout(ctx), limitWatts, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// --- Storage volumes ---
+
+// StorageControllers lists the system's storage controllers.
+func (c *Client) StorageControllers(ctx context.Context) ([]bmc.StorageControllerInfo, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "StorageControllers")
+	defer span.End()
+
+	controllers, metadata, err := bmc.StorageControllersFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return controllers, err
+}
+
+// Volumes lists the volumes managed by a storage controller.
+func (c *Client) Volumes(ctx context.Context, storageID string) ([]bmc.VolumeInfo, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "Volumes")
+	defer span.End()
+
+	volumes, metadata, err := bmc.VolumesFromInterfaces(ctx, c.perProviderTimeout(ctx), storageID, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return volumes, err
+}
+
+// VolumeCreate creates a volume on a storage controller and returns its Id.
+func (c *Client) VolumeCreate(ctx context.Context, storageID string, req bmc.VolumeCreateRequest) (string, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "VolumeCreate")
+	defer span.End()
+
+	id, metadata, err := bmc.VolumeCreateFromInterfaces(ctx, c.perProviderTimeout(ctx), storageID, req, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return id, err
+}
+
+// VolumeInitialize initializes a volume.
+func (c *Client) VolumeInitialize(ctx context.Context, storageID, volumeID, initType string) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "VolumeInitialize")
+	defer span.End()
+
+	metadata, err := bmc.VolumeInitializeFromInterfaces(ctx, c.perProviderTimeout(ctx), storageID, volumeID, initType, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// VolumeUpdate updates volume settings.
+func (c *Client) VolumeUpdate(ctx context.Context, storageID, volumeID string, settings map[string]any) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "VolumeUpdate")
+	defer span.End()
+
+	metadata, err := bmc.VolumeUpdateFromInterfaces(ctx, c.perProviderTimeout(ctx), storageID, volumeID, settings, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// VolumeDelete deletes a volume.
+func (c *Client) VolumeDelete(ctx context.Context, storageID, volumeID string) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "VolumeDelete")
+	defer span.End()
+
+	metadata, err := bmc.VolumeDeleteFromInterfaces(ctx, c.perProviderTimeout(ctx), storageID, volumeID, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// --- Licenses ---
+
+// Licenses returns the installed BMC licenses.
+func (c *Client) Licenses(ctx context.Context) ([]bmc.LicenseInfo, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "Licenses")
+	defer span.End()
+
+	licenses, metadata, err := bmc.LicensesFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return licenses, err
+}
+
+// LicenseInstall installs a license from its license string.
+func (c *Client) LicenseInstall(ctx context.Context, license string) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "LicenseInstall")
+	defer span.End()
+
+	metadata, err := bmc.LicenseInstallFromInterfaces(ctx, c.perProviderTimeout(ctx), license, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// LicenseDelete removes an installed license by Id.
+func (c *Client) LicenseDelete(ctx context.Context, licenseID string) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "LicenseDelete")
+	defer span.End()
+
+	metadata, err := bmc.LicenseDeleteFromInterfaces(ctx, c.perProviderTimeout(ctx), licenseID, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// --- Secure Key Lifecycle ---
+
+// GetSecureKeyLifecycle returns the Secure Key Lifecycle configuration.
+func (c *Client) GetSecureKeyLifecycle(ctx context.Context) (bmc.SecureKeyLifecycleConfig, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "GetSecureKeyLifecycle")
+	defer span.End()
+
+	cfg, metadata, err := bmc.GetSecureKeyLifecycleFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return cfg, err
+}
+
+// SetSecureKeyRepoServers replaces the configured key-repository servers.
+func (c *Client) SetSecureKeyRepoServers(ctx context.Context, servers []bmc.SecureKeyRepoServer) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "SetSecureKeyRepoServers")
+	defer span.End()
+
+	metadata, err := bmc.SetSecureKeyRepoServersFromInterfaces(ctx, c.perProviderTimeout(ctx), servers, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// --- Network interfaces & protocols ---
+
+// BMCNetworkInterfaces returns the BMC (manager) ethernet interfaces.
+func (c *Client) BMCNetworkInterfaces(ctx context.Context) ([]bmc.NetworkInterface, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "BMCNetworkInterfaces")
+	defer span.End()
+
+	ifaces, metadata, err := bmc.BMCNetworkInterfacesFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return ifaces, err
+}
+
+// ServerNetworkInterfaces returns the server (system) ethernet interfaces.
+func (c *Client) ServerNetworkInterfaces(ctx context.Context) ([]bmc.NetworkInterface, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "ServerNetworkInterfaces")
+	defer span.End()
+
+	ifaces, metadata, err := bmc.ServerNetworkInterfacesFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return ifaces, err
+}
+
+// SetBMCNetworkInterface PATCHes a BMC ethernet interface.
+func (c *Client) SetBMCNetworkInterface(ctx context.Context, id string, attrs map[string]any) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "SetBMCNetworkInterface")
+	defer span.End()
+
+	metadata, err := bmc.SetBMCNetworkInterfaceFromInterfaces(ctx, c.perProviderTimeout(ctx), id, attrs, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// SetHostInterfaceEnabled enables or disables a host interface.
+func (c *Client) SetHostInterfaceEnabled(ctx context.Context, id string, enabled bool) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "SetHostInterfaceEnabled")
+	defer span.End()
+
+	metadata, err := bmc.SetHostInterfaceEnabledFromInterfaces(ctx, c.perProviderTimeout(ctx), id, enabled, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// NetworkProtocols returns the manager network services and their state.
+func (c *Client) NetworkProtocols(ctx context.Context) ([]bmc.NetworkProtocol, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "NetworkProtocols")
+	defer span.End()
+
+	protos, metadata, err := bmc.NetworkProtocolsFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return protos, err
+}
+
+// SetNetworkProtocols PATCHes the manager network protocols.
+func (c *Client) SetNetworkProtocols(ctx context.Context, attrs map[string]any) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "SetNetworkProtocols")
+	defer span.End()
+
+	metadata, err := bmc.SetNetworkProtocolsFromInterfaces(ctx, c.perProviderTimeout(ctx), attrs, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// --- Serial interfaces ---
+
+// SerialInterfaces returns the BMC serial interfaces.
+func (c *Client) SerialInterfaces(ctx context.Context) ([]bmc.SerialInterface, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "SerialInterfaces")
+	defer span.End()
+
+	ifaces, metadata, err := bmc.SerialInterfacesFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return ifaces, err
+}
+
+// SetSerialInterface PATCHes a BMC serial interface.
+func (c *Client) SetSerialInterface(ctx context.Context, id string, attrs map[string]any) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "SetSerialInterface")
+	defer span.End()
+
+	metadata, err := bmc.SetSerialInterfaceFromInterfaces(ctx, c.perProviderTimeout(ctx), id, attrs, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// --- Events ---
+
+// EventService returns the event-service configuration.
+func (c *Client) EventService(ctx context.Context) (bmc.EventServiceInfo, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "EventService")
+	defer span.End()
+
+	info, metadata, err := bmc.EventServiceFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return info, err
+}
+
+// EventSubscriptions lists the event subscriptions.
+func (c *Client) EventSubscriptions(ctx context.Context) ([]bmc.EventSubscription, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "EventSubscriptions")
+	defer span.End()
+
+	subs, metadata, err := bmc.EventSubscriptionsFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return subs, err
+}
+
+// EventSubscriptionCreate creates an event subscription and returns its Id.
+func (c *Client) EventSubscriptionCreate(ctx context.Context, req bmc.EventSubscriptionRequest) (string, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "EventSubscriptionCreate")
+	defer span.End()
+
+	id, metadata, err := bmc.EventSubscriptionCreateFromInterfaces(ctx, c.perProviderTimeout(ctx), req, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return id, err
+}
+
+// EventSubscriptionDelete deletes an event subscription by Id.
+func (c *Client) EventSubscriptionDelete(ctx context.Context, id string) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "EventSubscriptionDelete")
+	defer span.End()
+
+	metadata, err := bmc.EventSubscriptionDeleteFromInterfaces(ctx, c.perProviderTimeout(ctx), id, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// SubmitTestEvent submits a test event (optionally for a specific MessageId).
+func (c *Client) SubmitTestEvent(ctx context.Context, messageID string) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "SubmitTestEvent")
+	defer span.End()
+
+	metadata, err := bmc.SubmitTestEventFromInterfaces(ctx, c.perProviderTimeout(ctx), messageID, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// SetEventService PATCHes event-service properties.
+func (c *Client) SetEventService(ctx context.Context, attrs map[string]any) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "SetEventService")
+	defer span.End()
+
+	metadata, err := bmc.SetEventServiceFromInterfaces(ctx, c.perProviderTimeout(ctx), attrs, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// --- Telemetry ---
+
+// TelemetryService returns the telemetry-service configuration.
+func (c *Client) TelemetryService(ctx context.Context) (bmc.TelemetryServiceInfo, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "TelemetryService")
+	defer span.End()
+
+	info, metadata, err := bmc.TelemetryServiceFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return info, err
+}
+
+// MetricReports lists the metric report Ids.
+func (c *Client) MetricReports(ctx context.Context) ([]string, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "MetricReports")
+	defer span.End()
+
+	reports, metadata, err := bmc.MetricReportsFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return reports, err
+}
+
+// MetricReport returns a metric report and its values by Id.
+func (c *Client) MetricReport(ctx context.Context, id string) (bmc.MetricReportInfo, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "MetricReport")
+	defer span.End()
+
+	report, metadata, err := bmc.MetricReportFromInterfaces(ctx, c.perProviderTimeout(ctx), id, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return report, err
+}
+
+// MetricReportDefinitions lists the metric report definition Ids.
+func (c *Client) MetricReportDefinitions(ctx context.Context) ([]string, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "MetricReportDefinitions")
+	defer span.End()
+
+	defs, metadata, err := bmc.MetricReportDefinitionsFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return defs, err
+}
+
+// MetricDefinitions lists the metric definition Ids.
+func (c *Client) MetricDefinitions(ctx context.Context) ([]string, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "MetricDefinitions")
+	defer span.End()
+
+	defs, metadata, err := bmc.MetricDefinitionsFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return defs, err
+}
+
+// SubmitTestMetricReport submits a test metric report.
+func (c *Client) SubmitTestMetricReport(ctx context.Context, reportName string) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "SubmitTestMetricReport")
+	defer span.End()
+
+	metadata, err := bmc.SubmitTestMetricReportFromInterfaces(ctx, c.perProviderTimeout(ctx), reportName, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// --- Jobs ---
+
+// JobService returns the job-service configuration.
+func (c *Client) JobService(ctx context.Context) (bmc.JobServiceInfo, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "JobService")
+	defer span.End()
+
+	info, metadata, err := bmc.JobServiceFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return info, err
+}
+
+// Jobs lists the jobs.
+func (c *Client) Jobs(ctx context.Context) ([]bmc.JobInfo, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "Jobs")
+	defer span.End()
+
+	jobs, metadata, err := bmc.JobsFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return jobs, err
+}
+
+// Job returns a job by Id.
+func (c *Client) Job(ctx context.Context, id string) (bmc.JobInfo, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "Job")
+	defer span.End()
+
+	job, metadata, err := bmc.JobFromInterfaces(ctx, c.perProviderTimeout(ctx), id, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return job, err
+}
+
+// JobUpdateSchedule updates a job's schedule.
+func (c *Client) JobUpdateSchedule(ctx context.Context, id string, schedule map[string]any) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "JobUpdateSchedule")
+	defer span.End()
+
+	metadata, err := bmc.JobUpdateScheduleFromInterfaces(ctx, c.perProviderTimeout(ctx), id, schedule, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// --- Certificates ---
+
+// CertificateLocations returns the @odata.id locations of installed certificates.
+func (c *Client) CertificateLocations(ctx context.Context) ([]string, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "CertificateLocations")
+	defer span.End()
+
+	locs, metadata, err := bmc.CertificateLocationsFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return locs, err
+}
+
+// Certificate returns a certificate's properties by its @odata.id location.
+func (c *Client) Certificate(ctx context.Context, location string) (bmc.CertificateInfo, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "Certificate")
+	defer span.End()
+
+	cert, metadata, err := bmc.CertificateFromInterfaces(ctx, c.perProviderTimeout(ctx), location, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return cert, err
+}
+
+// GenerateCSR generates a certificate-signing-request and returns the PEM CSR.
+func (c *Client) GenerateCSR(ctx context.Context, req bmc.CSRRequest) (string, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "GenerateCSR")
+	defer span.End()
+
+	csr, metadata, err := bmc.GenerateCSRFromInterfaces(ctx, c.perProviderTimeout(ctx), req, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return csr, err
+}
+
+// ReplaceCertificate replaces the certificate at targetURI with the given PEM.
+func (c *Client) ReplaceCertificate(ctx context.Context, certificatePEM, targetURI string) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "ReplaceCertificate")
+	defer span.End()
+
+	metadata, err := bmc.ReplaceCertificateFromInterfaces(ctx, c.perProviderTimeout(ctx), certificatePEM, targetURI, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// RekeyCertificate generates a new key pair and CSR for the certificate at certURI.
+func (c *Client) RekeyCertificate(ctx context.Context, certURI string) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "RekeyCertificate")
+	defer span.End()
+
+	metadata, err := bmc.RekeyCertificateFromInterfaces(ctx, c.perProviderTimeout(ctx), certURI, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// RenewCertificate generates a CSR using the existing key for the certificate at certURI.
+func (c *Client) RenewCertificate(ctx context.Context, certURI string) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "RenewCertificate")
+	defer span.End()
+
+	metadata, err := bmc.RenewCertificateFromInterfaces(ctx, c.perProviderTimeout(ctx), certURI, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// --- SNMP ---
+
+// SNMP returns the SNMP trap configuration.
+func (c *Client) SNMP(ctx context.Context) (bmc.SNMPConfig, error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "SNMP")
+	defer span.End()
+
+	cfg, metadata, err := bmc.SNMPFromInterfaces(ctx, c.perProviderTimeout(ctx), c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return cfg, err
+}
+
+// SetSNMPAlertFilter PATCHes the SNMP trap (SNMPTraps) properties.
+func (c *Client) SetSNMPAlertFilter(ctx context.Context, attrs map[string]any) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "SetSNMPAlertFilter")
+	defer span.End()
+
+	metadata, err := bmc.SetSNMPAlertFilterFromInterfaces(ctx, c.perProviderTimeout(ctx), attrs, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// EnableSNMPv1Trap enables or disables the SNMPv1 trap.
+func (c *Client) EnableSNMPv1Trap(ctx context.Context, enabled bool) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "EnableSNMPv1Trap")
+	defer span.End()
+
+	metadata, err := bmc.EnableSNMPv1TrapFromInterfaces(ctx, c.perProviderTimeout(ctx), enabled, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// EnableSNMPv3Trap enables or disables the SNMPv3 trap.
+func (c *Client) EnableSNMPv3Trap(ctx context.Context, enabled bool) error {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "EnableSNMPv3Trap")
+	defer span.End()
+
+	metadata, err := bmc.EnableSNMPv3TrapFromInterfaces(ctx, c.perProviderTimeout(ctx), enabled, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}

--- a/client_features_test.go
+++ b/client_features_test.go
@@ -1,0 +1,62 @@
+package bmclib
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+	"github.com/jacobweinstock/registrar"
+)
+
+// fakeExtendedProvider is a registry driver implementing a couple of the
+// extended interfaces, used to verify the Client-level wiring (dispatch +
+// metadata storage).
+type fakeExtendedProvider struct {
+	name string
+	snmp bmc.SNMPConfig
+}
+
+func (f *fakeExtendedProvider) Name() string { return f.name }
+
+func (f *fakeExtendedProvider) SNMP(_ context.Context) (bmc.SNMPConfig, error) {
+	return f.snmp, nil
+}
+
+func (f *fakeExtendedProvider) SetSNMPAlertFilter(_ context.Context, _ map[string]any) error {
+	return nil
+}
+
+func (f *fakeExtendedProvider) EnableSNMPv1Trap(_ context.Context, _ bool) error { return nil }
+
+func (f *fakeExtendedProvider) EnableSNMPv3Trap(_ context.Context, _ bool) error { return nil }
+
+func TestClientSNMPWiring(t *testing.T) {
+	want := bmc.SNMPConfig{V1TrapEnabled: true, TrapPort: 162, CommunityNames: []string{"public"}}
+
+	registry := registrar.NewRegistry()
+	registry.Register("fake", "fake", nil, nil, &fakeExtendedProvider{name: "fake", snmp: want})
+
+	cl := NewClient("", "", "", WithRegistry(registry))
+
+	got, err := cl.SNMP(context.Background())
+	if err != nil {
+		t.Fatalf("SNMP: %v", err)
+	}
+	if got.TrapPort != want.TrapPort || !got.V1TrapEnabled {
+		t.Errorf("SNMP = %+v, want %+v", got, want)
+	}
+	if md := cl.GetMetadata(); md.SuccessfulProvider != "fake" {
+		t.Errorf("metadata SuccessfulProvider = %q, want %q", md.SuccessfulProvider, "fake")
+	}
+}
+
+func TestClientSNMPNoProvider(t *testing.T) {
+	registry := registrar.NewRegistry()
+	registry.Register("bare", "bare", nil, nil, &testProvider{PName: "bare"})
+
+	cl := NewClient("", "", "", WithRegistry(registry))
+
+	if _, err := cl.SNMP(context.Background()); err == nil {
+		t.Fatal("expected an error when no provider implements SNMPConfigurer")
+	}
+}

--- a/examples/lenovo-smoketest/HARDWARE-TEST-PLAN.md
+++ b/examples/lenovo-smoketest/HARDWARE-TEST-PLAN.md
@@ -1,0 +1,752 @@
+# Lenovo XCC provider — per-feature hardware test plan
+
+This document is the **per-feature test catalog** for validating the bmclib
+`lenovo` provider against a real Lenovo XClarity Controller (XCC). It is the
+companion to [`RUNBOOK.md`](./RUNBOOK.md): the runbook describes *how to drive
+the `lenovo-smoketest` harness*; this plan defines *what to verify for every one
+of the 44 advertised features*, including the mutations the harness does not yet
+flag.
+
+All unit tests run against fixtures. **Hardware is the only place the XCC
+firmware/OEM variance is actually exercised** — that is what this plan is for.
+
+---
+
+## How to use this document
+
+- Each feature has a test case `TC-<area>-<n>`.
+- **Driver** column says how to run it:
+  - `harness:-flag` → covered by `lenovo-smoketest` (see RUNBOOK §2/§3).
+  - `manual:curl` / `manual:go` → not in the harness; run the raw Redfish call
+    or a small Go snippet (templates in [Appendix A](#appendix-a--manual-call-templates)).
+- **Independent verification** = a second, provider-independent way to confirm
+  the change really took effect (XCC web UI path, or a raw Redfish GET).
+- **Risk tier**:
+  - 🟢 **R0 read-only** — safe on any box, including production.
+  - 🟡 **R1 reversible write** — changes config; reversible; lab box only.
+  - 🟠 **R2 disruptive** — reboots/resets host or BMC, or interrupts I/O.
+  - 🔴 **R3 destructive / high-risk** — data loss or bricking potential
+    (firmware, volume delete/init, factory reset). Dedicated lab box only,
+    with a recovery plan.
+
+A test **PASSES** when: the call returns no error, the returned/affected state
+matches **Expected**, AND the **Independent verification** confirms it.
+
+> **Instance IDs** below (`Systems/1`, `Managers/1`, `Chassis/1`,
+> `Storage/RAID_Slot1`, …) are the *typical* XCC values used in the fixtures.
+> On real hardware, always discover the actual IDs from the parent collection
+> (`GET …/Systems`, `…/Managers`, etc.) before hand-running a `manual:curl`
+> case. Pass `-v` to the harness to see the live URIs.
+
+---
+
+## Prerequisites
+
+1. A lab Lenovo server with XCC reachable over HTTPS (default port 443).
+2. Credentials with **Supervisor**/admin privilege (user create, BMC reset,
+   firmware, factory reset all require it).
+3. A second host the **XCC itself** can reach over HTTP/HTTPS/NFS for:
+   - a bootable ISO (virtual media tests),
+   - the SNMP/syslog trap receiver (event tests),
+   - the EventService subscription destination (event subscription tests).
+4. A genuine Lenovo firmware payload (`lnvgy_fw_*.uxz`) for the firmware test.
+5. `curl` with `-k` (XCC ships a self-signed cert by default) for independent
+   verification and `manual:curl` cases. Export once:
+   ```bash
+   export XCC=https://<xcc-ip>
+   export CURL='curl -sk -u <user>:<pass>'      # XCC supports HTTP Basic
+   ```
+6. Run the **read-only sweep first** (RUNBOOK §1) and capture it with `-json`.
+   Do not proceed to writes until the read sweep is `0 FAIL`.
+7. To clarify exact paths/fields/AllowableValues/OEM structures before testing,
+   dump every resource the provider touches (read-only):
+   ```bash
+   ./dump-xcc.sh <host> <user> <pass> xcc-dump
+   ```
+   Produces one JSON per resource + `_index.tsv` of HTTP codes (so absent
+   resources like LicenseService show up as 404). With `jq` installed it also
+   expands collection members and resolves the **BIOS attribute registry**
+   (every valid `-set-bios` key, its type and allowable values).
+
+---
+
+## Coverage matrix (44 features)
+
+| # | Feature (registry) | Test case | Driver | Risk |
+|---|--------------------|-----------|--------|------|
+| 1 | *(connection: Compatible/Open/Close)* | TC-FND-1 | harness (always) | 🟢 |
+| 2 | *(ServiceRoot)* | TC-FND-2 | harness `serviceroot.read` | 🟢 |
+| 3 | `PowerState` | TC-PWR-1 | harness `power.state` | 🟢 |
+| 4 | `PowerSet` | TC-PWR-2 | harness `-power` | 🟠 |
+| 5 | `BootProgress` | TC-PWR-3 | harness `boot.progress` | 🟢 |
+| 6 | `BootDeviceSet` (+ override read) | TC-PWR-4 | harness `-bootdev` | 🟡 |
+| 7 | `GetBiosConfiguration` | TC-BIO-1 | harness `bios.read` | 🟢 |
+| 8 | `SetBiosConfiguration` | TC-BIO-2 | harness `-set-bios` | 🟡 |
+| 9 | `ResetBiosConfiguration` | TC-BIO-3 | harness `-reset-bios` | 🟡 |
+| 10 | `SecureBoot` (get) | TC-SEC-1 | harness `secureboot.read` | 🟢 |
+| 11 | `SecureBoot` (set) | TC-SEC-2 | harness `-secureboot` | 🟡 |
+| 12 | `SecureBoot` (ResetKeys) | TC-SEC-3 | manual:go | 🟡 |
+| 13 | `ThermalRead` | TC-ENV-1 | harness `thermal.read` | 🟢 |
+| 14 | `PowerRead` | TC-ENV-2 | harness `power.metrics` | 🟢 |
+| 15 | `PowerCap` | TC-ENV-3 | harness `-powercap` | 🟡 |
+| 16 | `InventoryRead` | TC-INV-1 | harness `inventory.read` | 🟢 |
+| 17 | `VolumeRead` (controllers/volumes) | TC-STO-1 | harness `storage.*` | 🟢 |
+| 18 | `VolumeManagement` (create) | TC-STO-2 | manual:go | 🔴 |
+| 19 | `VolumeManagement` (initialize) | TC-STO-3 | manual:go | 🔴 |
+| 20 | `VolumeManagement` (update) | TC-STO-4 | manual:go | 🟡 |
+| 21 | `VolumeManagement` (delete) | TC-STO-5 | manual:go | 🔴 |
+| 22 | `FirmwareUpload` + `FirmwareInstall*` | TC-FW-1 | harness `-firmware` | 🔴 |
+| 23 | `FirmwareInstallSteps` | TC-FW-2 | harness `firmware.steps` | 🟢 |
+| 24 | `FirmwareInstallStatus` / `FirmwareTaskStatus` | TC-FW-3 | harness (firmware poll) | 🟢 |
+| 25 | `FirmwareInstallUploaded` / UploadInitiate | TC-FW-4 | manual:go | 🔴 |
+| 26 | `SimpleUpdate` (URI install) | TC-FW-5 | manual:go | 🔴 |
+| 27 | `VirtualMedia` (insert/eject) | TC-VM-1 | harness `-vmedia-url`/`-vmedia-eject` | 🟡 |
+| 28 | `UnmountFloppyImage` (+ Mount=unsupported) | TC-VM-2 | manual:go | 🟡 |
+| 29 | `UserRead` | TC-USR-1 | harness `users.read` | 🟢 |
+| 30 | `UserCreate` | TC-USR-2 | manual:go | 🟡 |
+| 31 | `UserUpdate` | TC-USR-3 | manual:go | 🟡 |
+| 32 | `UserDelete` | TC-USR-4 | manual:go | 🟡 |
+| 33 | *(Roles read / RoleCreate)* | TC-USR-5 | manual:go | 🟡 |
+| 34 | `GetSystemEventLog` | TC-LOG-1 | harness `sel.read` | 🟢 |
+| 35 | `GetSystemEventLogRaw` | TC-LOG-2 | manual:go | 🟢 |
+| 36 | `ClearSystemEventLog` | TC-LOG-3 | harness `-clear-sel` | 🟡 |
+| 37 | *(EventLog / audit log read)* | TC-LOG-4 | harness `log.audit` | 🟢 |
+| 38 | `BmcReset` | TC-BMC-1 | harness `-bmc-reset` | 🟠 |
+| 39 | *(ResetToFactoryDefaults)* | TC-BMC-2 | manual:go | 🔴 |
+| 40 | *(UpdateManager)* | TC-BMC-3 | manual:go | 🟡 |
+| 41 | `LicenseManagement` (read) | TC-BMC-4 | harness `license.read` | 🟢 |
+| 42 | `LicenseManagement` (install/delete) | TC-BMC-5 | manual:go | 🟡 |
+| 43 | `SecureKeyLifecycle` (get) | TC-BMC-6 | harness `sklm.read` | 🟢 |
+| 44 | `SecureKeyLifecycle` (set servers) | TC-BMC-7 | manual:go | 🟡 |
+| 45 | `NetworkInterfaceRead` (BMC/server) | TC-NET-1 | harness `network.bmc`/`network.server` | 🟢 |
+| 46 | `NetworkInterfaceSet` (NIC) | TC-NET-2 | manual:go | 🟠 |
+| 47 | `NetworkInterfaceSet` (host iface) | TC-NET-3 | manual:go | 🟡 |
+| 48 | `NetworkProtocolRead` | TC-NET-4 | harness `network.protocols` | 🟢 |
+| 49 | `NetworkProtocolSet` | TC-NET-5 | manual:go | 🟠 |
+| 50 | `SerialRead` | TC-SER-1 | harness `serial.read` | 🟢 |
+| 51 | `SerialSet` | TC-SER-2 | manual:go | 🟡 |
+| 52 | `EventSubscription` (service/list read) | TC-EVT-1 | harness `event.*` | 🟢 |
+| 53 | `EventSubscription` (create/delete) | TC-EVT-2 | manual:go | 🟡 |
+| 54 | `EventSubscription` (SubmitTestEvent) | TC-EVT-3 | manual:go | 🟡 |
+| 55 | `EventSubscription` (SetEventService) | TC-EVT-4 | manual:go | 🟡 |
+| 56 | `Telemetry` (service/reports/defs read) | TC-TEL-1 | harness `telemetry.*` | 🟢 |
+| 57 | `Telemetry` (single report/def read) | TC-TEL-2 | manual:go | 🟢 |
+| 58 | `Telemetry` (SubmitTestMetricReport) | TC-TEL-3 | manual:go | 🟡 |
+| 59 | `JobManagement` (service/list read) | TC-JOB-1 | harness `job.*` | 🟢 |
+| 60 | `JobManagement` (single read) | TC-JOB-2 | manual:go | 🟢 |
+| 61 | `JobManagement` (update schedule) | TC-JOB-3 | manual:go | 🟡 |
+| 62 | `CertificateManagement` (locations/read) | TC-CRT-1 | harness `cert.*` | 🟢 |
+| 63 | `CertificateManagement` (GenerateCSR) | TC-CRT-2 | manual:go | 🟢 |
+| 64 | `CertificateManagement` (ReplaceCertificate) | TC-CRT-3 | manual:go | 🟠 |
+| 65 | `CertificateManagement` (Rekey/Renew) | TC-CRT-4 | manual:go | 🟠 |
+| 66 | `SNMP` (read) | TC-SNM-1 | harness `snmp.read` | 🟢 |
+| 67 | `SNMP` (v1/v3 trap enable) | TC-SNM-2 | harness `-snmp-v1-trap`/`-snmp-v3-trap` | 🟡 |
+| 68 | `SNMP` (SetSNMPAlertFilter) | TC-SNM-3 | manual:go | 🟡 |
+
+> The 44 *registry features* map to more test cases than 44 because several
+> features (firmware, volumes, certificates, events, SNMP, secure boot) bundle
+> multiple distinct provider methods that each need their own hardware check.
+
+---
+
+## TC-FND — Foundation
+
+### TC-FND-1 — Vendor compatibility + session lifecycle 🟢
+- **Methods:** `Compatible`, `Open`, `Close`
+- **Driver:** harness (runs unconditionally; the first two report lines)
+- **Procedure:** `go run ./examples/lenovo-smoketest -host $H -user $U -pass $P`
+- **Expected:** `connection.compatible PASS` (device identifies as Lenovo XCC) and
+  `connection.open PASS` (session established). With `-basic`, repeat to confirm
+  HTTP Basic auth also works.
+- **Independent verification:** `$CURL $XCC/redfish/v1/ | jq '.Vendor,.Product'`
+  → contains `Lenovo`. Check the XCC active-session count does **not** climb
+  after repeated runs (session is released on Close — XCC caps at 16).
+- **Pass criteria:** both PASS; non-Lenovo box correctly reported NOT compatible.
+
+### TC-FND-2 — Service root 🟢
+- **Method:** `ServiceRoot`
+- **Driver:** harness `serviceroot.read`
+- **Expected:** `vendor="Lenovo" product=<model> redfish=<>=1.15.0>`.
+- **Independent verification:** `$CURL $XCC/redfish/v1/ | jq '.RedfishVersion'`.
+
+---
+
+## TC-PWR — Power & boot
+
+### TC-PWR-1 — Power state read 🟢
+- **Method:** `PowerStateGet` — **Driver:** harness `power.state`
+- **Expected:** `state=on` / `off` matching the box.
+- **Verify:** XCC UI → *Power* tile; or `$CURL $XCC/redfish/v1/Systems/1 | jq .PowerState`.
+
+### TC-PWR-2 — Power set 🟠
+- **Method:** `PowerSet(state)` — **Driver:** `harness -allow-writes -power <on|off|soft|cycle|reset>`
+- **Procedure:** test each transition on a lab box; allow the host to settle
+  between states. Note: `on` is a no-op (returns ok) when already on.
+- **Expected:** `power.set PASS`; host changes state.
+- **Verify:** observe POST to `…/Systems/1/Actions/ComputerSystem.Reset` (`-v`);
+  confirm physical/UI power state after each call. Map: on→`On`, off→`ForceOff`,
+  soft→`GracefulShutdown`, cycle→`ForceRestart`/`PowerCycle`, reset→`ForceRestart`.
+- **Risk:** abrupt off/cycle/reset interrupt the OS.
+
+### TC-PWR-3 — Boot progress 🟢
+- **Method:** `GetBootProgress` — **Driver:** harness `boot.progress`
+- **Note:** requires RedfishVersion ≥ 1.13.0 (XCC reports 1.15.0). WARN if the
+  model omits `BootProgress`.
+- **Expected:** `lastState=<SystemHardwareInitializationComplete|OSRunning|…>`.
+
+### TC-PWR-4 — Boot device override 🟡
+- **Methods:** `BootDeviceOverrideGet`, `BootDeviceSet`
+- **Driver:** read = harness `boot.override`; write = `harness -allow-writes -bootdev <pxe|disk|cdrom|bios> [-bootdev-efi]`
+- **Procedure:** set one-time legacy PXE, re-read; set one-time UEFI cdrom, re-read.
+- **⚠️ XCC allows ONE-TIME only:** `BootSourceOverrideEnabled@Redfish.AllowableValues`
+  is `{Once, Disabled}` — `Continuous` is rejected (PropertyValueNotInList).
+  The provider rejects `-bootdev-persistent` up front with a clear error;
+  persistent boot is managed via the `BootOrder`, not the override.
+  (`-bootdev` also accepts CD/DVD/USBStick aliases → cdrom/usb.)
+- **Expected:** `boot.set PASS`; subsequent `boot.override` reflects device and
+  `efi`, with `persistent=false`.
+- **Verify:** XCC UI → *Server Configuration → Boot Options*; or
+  `$CURL $XCC/redfish/v1/Systems/1 | jq .Boot` →
+  `BootSourceOverrideTarget/Enabled/Mode`. Reboot once to confirm a one-time
+  override clears itself.
+
+---
+
+## TC-BIO — BIOS
+
+### TC-BIO-1 — BIOS read 🟢
+- **Method:** `GetBiosConfiguration` — **Driver:** harness `bios.read`
+- **Expected:** `N attributes` (N > 0).
+- **Verify:** `$CURL $XCC/redfish/v1/Systems/1/Bios | jq '.Attributes|length'`.
+
+### TC-BIO-2 — BIOS set 🟡
+- **Method:** `SetBiosConfiguration(map)` — **Driver:** `harness -allow-writes -set-bios "Key=Value,..."`
+- **⚠️ Use a real attribute name from THIS box's registry.** Read TC-BIO-1 first
+  and copy exact attribute keys — names are model/firmware-specific. On a
+  ThinkSystem SR630 V2 the AMI-style `QuietBoot` does **not** exist and XCC
+  returns `Base.1.11.PropertyUnknown`; `BootModes_SystemBootMode=UEFIMode` is
+  valid there. Don't copy the example key blindly.
+- **Apply-time note (provider fix):** XCC's BIOS settings resource **rejects**
+  the `@Redfish.SettingsApplyTime`/`ApplyTime` annotation that the shared
+  redfishwrapper sends. The lenovo provider overrides `SetBiosConfiguration` to
+  PATCH `Attributes` only (no apply-time); XCC stages the change for the next
+  host reset implicitly. (Hardware-discovered 2026-06-09 on SR630 V2.)
+- **Expected:** `bios.set PASS` (provider GETs the settings target for the ETag,
+  then PATCHes Attributes only).
+- **Verify:** `$CURL $XCC/redfish/v1/Systems/1/Bios | jq '."@Redfish.Settings".SettingsObject."@odata.id"'`
+  to find the settings target, GET it for pending `Attributes`; after a host
+  reboot confirm the active value changed.
+
+### TC-BIO-3 — BIOS reset to defaults 🟡
+- **Method:** `ResetBiosConfiguration` — **Driver:** `harness -allow-writes -reset-bios`
+- **Expected:** `bios.reset PASS` (POST `…/Bios/Actions/Bios.ResetBios`).
+- **Verify:** UI shows a pending "restore defaults" on next boot; reboot and spot
+  check a previously-changed attribute returned to default.
+
+---
+
+## TC-SEC — Secure boot
+
+### TC-SEC-1 — Secure boot read 🟢
+- **Method:** `GetSecureBoot` — **Driver:** harness `secureboot.read`
+- **Expected:** `enabled=<bool> mode=<> current=<>`.
+- **Verify:** `$CURL $XCC/redfish/v1/Systems/1/SecureBoot | jq`.
+
+### TC-SEC-2 — Secure boot enable/disable 🟡
+- **Method:** `SetSecureBoot(bool)` — **Driver:** `harness -allow-writes -secureboot <enable|disable>`
+- **Expected:** `secureboot.set PASS`; re-read shows new `enabled`.
+- **Verify:** UI → *Security → Secure Boot*; effective after host reboot.
+
+### TC-SEC-3 — Reset secure-boot keys 🟡 *(not in harness)*
+- **Method:** `ResetSecureBootKeys(resetType)` — **Driver:** `manual:go`
+- **Procedure:** call with `resetType="ResetAllKeysToDefault"` (also valid:
+  `DeleteAllKeys`, `DeletePK`). See [Appendix A](#appendix-a--manual-call-templates).
+- **Expected:** no error; POST to `…/SecureBoot/Actions/SecureBoot.ResetKeys`.
+- **Verify:** re-read secure boot; UI key store reflects the reset.
+
+---
+
+## TC-ENV — Thermal & power metrics
+
+### TC-ENV-1 — Thermal read 🟢
+- **Method:** `Thermal` — **Driver:** harness `thermal.read`
+- **Expected:** `N temps, M fans` (both > 0 on a powered box).
+- **Verify:** `$CURL $XCC/redfish/v1/Chassis/1/Thermal | jq '.Temperatures|length,.Fans|length'`.
+
+### TC-ENV-2 — Power metrics 🟢
+- **Method:** `ReadPower` — **Driver:** harness `power.metrics`
+- **Expected:** `consumed=<W> capacity=<W> supplies=<N>`.
+- **Verify:** `$CURL $XCC/redfish/v1/Chassis/1/Power | jq '.PowerControl,.PowerSupplies|length'`.
+
+### TC-ENV-3 — Power cap set/clear 🟡
+- **Method:** `SetPowerCap(*float64)` — **Driver:** `harness -allow-writes -powercap <watts|off>`
+- **Procedure:** set a cap above current draw (e.g. `-powercap 1200`), re-read
+  `power.metrics`, then `-powercap off` to disable.
+- **Expected:** `power.cap PASS`; cap reflected then cleared.
+- **Verify:** `$CURL $XCC/redfish/v1/Chassis/1/Power | jq '.PowerControl[0].PowerLimit'`;
+  UI → *Power → Power Capping*.
+
+---
+
+## TC-INV — Inventory
+
+### TC-INV-1 — Hardware inventory 🟢
+- **Method:** `Inventory` (delegates to redfishwrapper) — **Driver:** harness `inventory.read`
+- **Expected:** `vendor="Lenovo" model=<> cpus>0 dimms>0 drives>=0 nics>0`.
+- **Note:** record the XCC **firmware version + model** from this line for the
+  release-gate evidence.
+- **Verify:** spot-check counts against UI → *Inventory*. If `WithFailInventoryOnError`
+  is set, a single component error fails the whole read — test both modes.
+
+---
+
+## TC-STO — Storage & volumes
+
+### TC-STO-1 — Storage controllers + volumes read 🟢
+- **Methods:** `StorageControllers`, `Volumes(storageID)` — **Driver:** harness `storage.controllers` / `storage.volumes`
+- **Expected:** `N controllers`; for the first controller, `M volumes`.
+- **Verify:** `$CURL $XCC/redfish/v1/Systems/1/Storage | jq '.Members'` then a
+  controller's `/Volumes`.
+
+> ⚠️ **TC-STO-2..5 are 🔴 destructive RAID operations.** Run only on a lab box
+> with **no data you care about**. Always capture controller + volume state
+> before and after, and have the RAID layout documented for restore.
+
+### TC-STO-2 — Volume create 🔴 *(not in harness)*
+- **Method:** `VolumeCreate(storageID, VolumeCreateRequest)` — **Driver:** `manual:go`
+- **Procedure:** build a `bmc.VolumeCreateRequest` (RAID type, drive IDs, capacity)
+  from drives discovered in TC-STO-1; call `VolumeCreate`.
+- **Expected:** returns a non-empty volume ID (from `Location` header or body `Id`).
+- **Verify:** `GET …/Storage/<ctrl>/Volumes` lists the new volume; UI → *Storage*.
+
+### TC-STO-3 — Volume initialize 🔴 *(not in harness)*
+- **Method:** `VolumeInitialize(storageID, volumeID, initType)` — `initType` ∈ `Fast|Slow`
+- **Expected:** no error; POST `…/Volumes/<id>/Actions/Volume.Initialize` with only `InitializeType`.
+- **Verify:** volume `Status`/operation shows initializing → OK in UI.
+
+### TC-STO-4 — Volume update 🟡 *(not in harness)*
+- **Method:** `VolumeUpdate(storageID, volumeID, settings map)`
+- **Procedure:** PATCH a benign property (e.g. volume name / write-cache policy).
+- **Verify:** re-read the volume; property changed.
+
+### TC-STO-5 — Volume delete 🔴 *(not in harness)*
+- **Method:** `VolumeDelete(storageID, volumeID)`
+- **Expected:** no error; volume gone from the collection.
+- **Verify:** `GET …/Volumes` no longer lists it; UI confirms.
+
+---
+
+## TC-FW — Firmware (🔴 dedicated lab box only)
+
+### TC-FW-1 — Push-protocol firmware install 🔴
+- **Methods:** `FirmwareInstall` (claim → push `/mfwupdate` or `/fwupdate` → poll Task → release)
+- **Driver:** `harness -allow-writes -firmware <file> -firmware-component <id> -firmware-applytime <Immediate|OnReset|OnStartUpdateRequest> -timeout 30m`
+- **Procedure:** see RUNBOOK §3. Use a real `lnvgy_fw_*.uxz`; prefer a backup
+  target (`-firmware-component BMC-Backup`) for the first run.
+- **Expected:** `firmware.install PASS` (pushed; taskID=…) then `firmware.task PASS`
+  (task completed). The harness **polls the Task resource, never the
+  TaskMonitor URI** (a GET on TaskMonitor deletes a finished task on XCC).
+- **Verify:** UI → *Firmware Update* shows the new version after apply;
+  `HttpPushUriTargetsBusy` returns to `false` (claim released). Confirm a second
+  install can start (busy flag not stuck).
+- **Pass criteria:** task reaches `Complete`; version updated; busy released even
+  on a failed/aborted push.
+
+### TC-FW-2 — Install step plan (read) 🟢
+- **Method:** `FirmwareInstallSteps(component)` — **Driver:** harness `firmware.steps`
+- **Expected:** `N install steps` (the ordered plan: upload → install status …).
+
+### TC-FW-3 — Task status polling 🟢
+- **Methods:** `FirmwareTaskStatus`, `FirmwareInstallStatus`
+- **Driver:** exercised inside TC-FW-1's poll loop; can also be called standalone
+  against a known task ID.
+- **Expected:** maps XCC task state → `initializing|running|complete|failed`.
+- **Verify:** cross-check against `$CURL $XCC/redfish/v1/TaskService/Tasks/<id>`.
+
+### TC-FW-4 — Upload-then-install (two-phase) 🔴 *(not in harness)*
+- **Methods:** `FirmwareUpload` / `FirmwareInstallUploadAndInitiate` → `FirmwareInstallUploaded(component, uploadTaskID)`
+- **Driver:** `manual:go` — upload returns a task id; pass it to the uploaded-install call.
+- **Use when:** validating `OnStartUpdateRequest` apply-time / staged installs.
+
+### TC-FW-5 — SimpleUpdate (install from URI) 🔴 *(not in harness)*
+- **Method:** `SimpleUpdate(imageURI, transferProtocol)` — **Driver:** `manual:go`
+- **Procedure:** host the image on a reachable HTTP/TFTP server; call with the
+  URI and protocol (`HTTP`/`HTTPS`/`TFTP`).
+- **Expected:** POST `…/UpdateService/Actions/UpdateService.SimpleUpdate`; task id returned.
+- **Verify:** poll the task (TC-FW-3) to completion; version updated.
+
+---
+
+## TC-VM — Virtual media
+
+### TC-VM-1 — Insert / eject virtual media 🟡
+- **Method:** `SetVirtualMedia(kind, url)` (insert) / `SetVirtualMedia(kind, "")` (eject)
+- **Driver:** `harness -allow-writes -vmedia-url <http://host/boot.iso> -vmedia-kind CD`
+  then `harness -allow-writes -vmedia-eject -vmedia-kind CD`
+- **Critical hardware note:** real XCC slots (EXT1-4/Remote1-4/RDOC1-2) **do NOT
+  expose the Redfish `InsertMedia`/`EjectMedia` actions** — the provider inserts
+  via **PATCH** on the VirtualMedia resource (`Image/Inserted/WriteProtected/
+  TransferProtocolType`). This is the single most important XCC-variance test.
+- **Procedure:**
+  1. Insert ISO → confirm exactly **one** slot occupied.
+  2. Insert again (same kind) → must **replace**, not create a second mount.
+  3. Eject → slot cleared.
+- **Expected:** each call PASS; re-mount does not accumulate mounts.
+- **Verify:** `$CURL $XCC/redfish/v1/Managers/1/VirtualMedia/<slot> | jq '.Image,.Inserted'`;
+  UI → *Remote Console → Mount Media*. Optionally boot the host from the mounted ISO.
+
+### TC-VM-2 — Floppy mount/unmount 🟡 *(mount = unsupported by design)*
+- **Methods:** `MountFloppyImage` (returns "unsupported"), `UnmountFloppyImage`
+- **Driver:** `manual:go`
+- **Expected:** `MountFloppyImage` returns the explicit *unsupported* error (XCC
+  has no raw floppy upload in its Redfish API — by design, not a bug);
+  `UnmountFloppyImage` ejects the Floppy slot (idempotent if none inserted).
+- **Verify:** Floppy slot `Inserted=false` after unmount.
+
+---
+
+## TC-USR — Users, accounts, roles
+
+### TC-USR-1 — User read 🟢
+- **Method:** `UserRead` — **Driver:** harness `users.read`
+- **Expected:** `N accounts` (includes the built-in USERID/Administrator).
+- **Verify:** `$CURL $XCC/redfish/v1/AccountService/Accounts | jq '.Members|length'`.
+
+### TC-USR-2 — User create 🟡 *(not in harness)*
+- **Method:** `UserCreate(user, pass, role)` — **Driver:** `manual:go`
+- **Procedure:** create `smoketest` with role `Administrator` (or `Operator`).
+  Provider tries Redfish `CreateAccount` first, then falls back to PATCH of an
+  empty slot (Intel-Purley style) — both paths should be exercised if possible.
+- **Expected:** no error; new account appears.
+- **Verify:** `GET …/Accounts`; **log in as the new user** to confirm the
+  password/role actually work (don't trust the POST alone).
+
+### TC-USR-3 — User update 🟡 *(not in harness)*
+- **Method:** `UserUpdate(user, pass, role)`
+- **Procedure:** change the `smoketest` user's password and role.
+- **Verify:** log in with the new password; confirm new privilege.
+
+### TC-USR-4 — User delete 🟡 *(not in harness)*
+- **Method:** `UserDelete(user)`
+- **Expected:** account removed; login as that user now fails.
+- **Verify:** `GET …/Accounts` no longer lists it. **Clean up the test user here.**
+
+### TC-USR-5 — Roles read + custom role create 🟡 *(not in harness)*
+- **Methods:** `Roles`, `RoleCreate(roleID, privileges)`
+- **Expected:** `Roles` lists predefined roles; `RoleCreate` POSTs a custom role
+  to `…/AccountService/Roles`.
+- **Verify:** `GET …/AccountService/Roles` lists the new role with the privileges.
+- **Note (DEFERRED):** AccountService lockout/LDAP read+PATCH is **not
+  implemented** (OpenSpec task 2.3, no spec scenario) — out of scope for this gate.
+
+---
+
+## TC-LOG — Logs & SEL
+
+### TC-LOG-1 — SEL read (parsed) 🟢
+- **Method:** `GetSystemEventLog` — **Driver:** harness `sel.read`
+- **Note:** aggregates **all** manager log services (Sel + AuditLog) → may return
+  more than just SEL rows.
+- **Verify:** `$CURL $XCC/redfish/v1/Managers/1/LogServices/Sel/Entries | jq '.Members|length'`.
+
+### TC-LOG-2 — SEL read (raw) 🟢 *(not in harness)*
+- **Method:** `GetSystemEventLogRaw` — **Driver:** `manual:go`
+- **Expected:** raw entries payload returned.
+
+### TC-LOG-3 — SEL clear 🟡
+- **Method:** `ClearSystemEventLog` — **Driver:** `harness -allow-writes -clear-sel`
+- **Caveat:** SEL get reads via *Managers* path; clear acts via *Chassis*
+  `…/LogServices/Sel/Actions/LogService.ClearLog` (wrapper design).
+- **Expected:** `sel.clear PASS`.
+- **Verify:** re-read SEL → entry count drops (UI → *Event Log*).
+
+### TC-LOG-4 — Audit / OEM log services read 🟢
+- **Method:** `EventLog(ctx, logServiceID)` — **Driver:** harness `log.audit`
+  (`lenovo.LogServiceAudit`)
+- **Other IDs:** `LogServiceActive`, `LogServicePlatform`, `LogServiceMaintenance`,
+  `LogServiceServiceAdvisor`, `LogServiceDiagnostic` — run `manual:go` for each
+  the model exposes.
+
+---
+
+## TC-BMC — BMC management
+
+### TC-BMC-1 — BMC reset 🟠
+- **Method:** `BmcReset(resetType)` — **Driver:** `harness -allow-writes -bmc-reset <GracefulRestart|ForceRestart>`
+- **Expected:** `bmc.reset PASS`; **the session drops** as the BMC restarts.
+- **Verify:** XCC pings back after ~1–3 min; web UI reachable again. Host power
+  state is unaffected.
+
+### TC-BMC-2 — Reset to factory defaults 🔴 *(not in harness)*
+- **Method:** `ResetToFactoryDefaults(resetType)` — `resetType` default `ResetAll`
+- **Driver:** `manual:go` — **last test on the box**; wipes BMC config (network,
+  users, certs). Have console/physical access to re-IP afterward.
+- **Verify:** BMC returns to defaults (DHCP/default creds per the chosen scope).
+
+### TC-BMC-3 — Update manager config 🟡 *(not in harness)*
+- **Method:** `UpdateManager(properties map)`
+- **Procedure:** PATCH a benign OEM/timezone property (e.g. `DateTimeLocalOffset`).
+- **Verify:** `GET …/Managers/1` shows the new value; UI → *BMC Configuration*.
+
+### TC-BMC-4 — License read 🟢
+- **Method:** `Licenses` — **Driver:** harness `license.read`
+- **Verify:** `$CURL $XCC/redfish/v1/LicenseService/Licenses | jq '.Members'`.
+- **Hardware finding (2026-06-09, SR630 V2):** this firmware returned **404
+  RequestUriNotFound** for `/redfish/v1/LicenseService/Licenses`. The provider
+  now treats an absent LicenseService (404) as **"no licenses"** — `Licenses`
+  returns an empty slice with no error, so `license.read` reports **PASS
+  (0 licenses)** instead of WARN. Other errors still propagate. FOLLOW-UP
+  (deferred): confirm whether such models expose licenses under a different path
+  (e.g. `Managers/<id>/Oem/Lenovo`) and read from there instead of stubbing.
+
+### TC-BMC-5 — License install / delete 🟡 *(not in harness)*
+- **Methods:** `LicenseInstall(string)`, `LicenseDelete(id)` — **Driver:** `manual:go`
+- **Procedure:** install a valid XCC license string (e.g. XCC Advanced trial),
+  confirm, then delete it.
+- **Expected:** install adds a license member; delete removes it.
+- **Verify:** UI → *BMC Configuration → License* before/after.
+
+### TC-BMC-6 — SKLM read 🟢
+- **Method:** `GetSecureKeyLifecycle` — **Driver:** harness `sklm.read`
+- **Expected:** `deviceGroup=<> keyServers=<N>` (WARN if SKLM not licensed/present).
+
+### TC-BMC-7 — SKLM set key-repo servers 🟡 *(not in harness)*
+- **Method:** `SetSecureKeyRepoServers([]SecureKeyRepoServer)` — **Driver:** `manual:go`
+- **Procedure:** PATCH a test `HostName`/`Port` list to
+  `…/Managers/1/Oem/Lenovo/SecureKeyLifecycleService`.
+- **Verify:** re-read SKLM config shows the servers.
+
+---
+
+## TC-NET — Network & TC-SER — Serial
+
+### TC-NET-1 — NIC read (BMC + server) 🟢
+- **Methods:** `BMCNetworkInterfaces`, `ServerNetworkInterfaces` — **Driver:** harness `network.bmc`/`network.server`
+- **Verify:** `$CURL $XCC/redfish/v1/Managers/1/EthernetInterfaces` and
+  `…/Systems/1/EthernetInterfaces`.
+
+### TC-NET-2 — BMC NIC set 🟠 *(not in harness)*
+- **Method:** `SetBMCNetworkInterface(id, attrs)` — **Driver:** `manual:go`
+- **⚠️ Self-lockout risk:** changing the BMC IP/VLAN can cut your connection.
+  Test a non-management property first, or have console access.
+- **Verify:** re-read the interface; UI → *Network*.
+
+### TC-NET-3 — Host interface enable 🟡 *(not in harness)*
+- **Method:** `SetHostInterfaceEnabled(id, enabled)`
+- **Verify:** `GET …/Managers/1/HostInterfaces/<id>` → `InterfaceEnabled`.
+
+### TC-NET-4 — Network protocols read 🟢
+- **Method:** `NetworkProtocols` — **Driver:** harness `network.protocols`
+- **Expected:** services list (HTTP/HTTPS/SSH/IPMI/SNMP/NTP/KVMIP/VirtualMedia/SSDP/Telnet) with port + enabled.
+- **Verify:** `$CURL $XCC/redfish/v1/Managers/1/NetworkProtocol | jq`.
+
+### TC-NET-5 — Network protocols set 🟠 *(not in harness)*
+- **Method:** `SetNetworkProtocols(attrs)` — **Driver:** `manual:go`
+- **⚠️** Disabling HTTPS/SSH can lock you out. Toggle a low-risk one (e.g. SSDP)
+  and revert.
+- **Verify:** re-read protocols; the toggled service changed.
+
+### TC-SER-1 — Serial read 🟢
+- **Method:** `SerialInterfaces` — **Driver:** harness `serial.read`
+- **Verify:** `$CURL $XCC/redfish/v1/Managers/1/SerialInterfaces | jq '.Members'`.
+
+### TC-SER-2 — Serial set 🟡 *(not in harness)*
+- **Method:** `SetSerialInterface(id, attrs)` — **Driver:** `manual:go`
+- **Procedure:** PATCH `BitRate`/`Parity` on a serial interface and revert.
+- **Verify:** re-read shows the new value.
+
+---
+
+## TC-EVT — Events & TC-TEL — Telemetry
+
+### TC-EVT-1 — Event service + subscriptions read 🟢
+- **Methods:** `EventService`, `EventSubscriptions` — **Driver:** harness `event.service`/`event.subscriptions`
+- **Verify:** `$CURL $XCC/redfish/v1/EventService` and `…/EventService/Subscriptions`.
+
+### TC-EVT-2 — Subscription create / delete 🟡 *(not in harness)*
+- **Methods:** `EventSubscriptionCreate(req)`, `EventSubscriptionDelete(id)` — **Driver:** `manual:go`
+- **Procedure:** create a subscription with `Destination` = a reachable HTTP
+  listener you control; capture the returned id; delete it.
+- **Expected:** create returns a non-empty id (from `Location`); delete removes it.
+- **Verify:** `GET …/EventService/Subscriptions` before/after; if you also run
+  TC-EVT-3, confirm your listener receives the test event.
+
+### TC-EVT-3 — Submit test event 🟡 *(not in harness)*
+- **Method:** `SubmitTestEvent(messageID)` — **Driver:** `manual:go`
+- **Verify:** the subscribed destination receives the event payload.
+
+### TC-EVT-4 — Set event service 🟡 *(not in harness)*
+- **Method:** `SetEventService(attrs)` — PATCH e.g. `ServiceEnabled` / delivery-retry.
+- **Verify:** re-read EventService.
+
+### TC-TEL-1 — Telemetry service + reports + definitions read 🟢
+- **Methods:** `TelemetryService`, `MetricReports`, `MetricReportDefinitions`, `MetricDefinitions`
+- **Driver:** harness `telemetry.service`/`telemetry.reports`/`telemetry.definitions`
+- **Expected:** WARN acceptable if the model has no TelemetryService.
+
+### TC-TEL-2 — Single metric report / definition read 🟢 *(not in harness)*
+- **Methods:** `MetricReport(id)`, `MetricReportDefinitions` (then `MetricReport` per id)
+- **Verify:** `$CURL $XCC/redfish/v1/TelemetryService/MetricReports/<id>`.
+
+### TC-TEL-3 — Submit test metric report 🟡 *(not in harness)*
+- **Method:** `SubmitTestMetricReport(reportName)` — **Driver:** `manual:go`
+- **Verify:** POST `…/TelemetryService.SubmitTestMetricReport` succeeds; report appears.
+
+---
+
+## TC-JOB — Jobs
+
+### TC-JOB-1 — Job service + list read 🟢
+- **Methods:** `JobService`, `Jobs` — **Driver:** harness `job.service`/`job.list`
+
+### TC-JOB-2 — Single job read 🟢 *(not in harness)*
+- **Method:** `Job(id)` — read a real job id from TC-JOB-1.
+
+### TC-JOB-3 — Update job schedule 🟡 *(not in harness)*
+- **Method:** `JobUpdateSchedule(id, schedule)` — **Driver:** `manual:go`
+- **Verify:** re-read the job; schedule changed.
+
+---
+
+## TC-CRT — Certificates
+
+### TC-CRT-1 — Certificate locations + read 🟢
+- **Methods:** `CertificateLocations`, `Certificate(location)` — **Driver:** harness `cert.locations`/`cert.read`
+- **Verify:** `$CURL $XCC/redfish/v1/CertificateService/CertificateLocations`.
+
+### TC-CRT-2 — Generate CSR 🟢 *(not in harness)*
+- **Method:** `GenerateCSR(CSRRequest)` — **Driver:** `manual:go`
+- **Expected:** returns a PEM CSR string.
+- **Verify:** `openssl req -in csr.pem -noout -text` parses the subject you sent.
+
+### TC-CRT-3 — Replace certificate 🟠 *(not in harness)*
+- **Method:** `ReplaceCertificate(certificatePEM, targetURI)`
+- **⚠️** Replacing the HTTPS cert resets TLS — the browser/clients will see the
+  new cert; an invalid PEM can break HTTPS access. Test with a valid signed cert.
+- **Verify:** browser shows the new cert; `openssl s_client -connect <xcc>:443`.
+
+### TC-CRT-4 — Rekey / renew certificate 🟠 *(not in harness)*
+- **Methods:** `RekeyCertificate(certURI)`, `RenewCertificate(certURI)`
+- **Verify:** new cert serial/validity on the HTTPS endpoint.
+
+---
+
+## TC-SNM — SNMP
+
+### TC-SNM-1 — SNMP read 🟢
+- **Method:** `SNMP` — **Driver:** harness `snmp.read`
+- **Expected:** `v1Trap=<> v3Trap=<> port=<>`.
+
+### TC-SNM-2 — Enable/disable v1 / v3 trap 🟡
+- **Methods:** `EnableSNMPv1Trap(bool)`, `EnableSNMPv3Trap(bool)`
+- **Driver:** `harness -allow-writes -snmp-v1-trap <enable|disable>` / `-snmp-v3-trap …`
+- **Verify:** re-read SNMP; UI → *BMC Configuration → SNMP*; a configured trap
+  receiver gets a test trap if you also fire one.
+
+### TC-SNM-3 — Set SNMP alert filter 🟡 *(not in harness)*
+- **Method:** `SetSNMPAlertFilter(attrs)` — **Driver:** `manual:go`
+- **Verify:** re-read; PATCH applied to `…/NetworkProtocol/Oem/Lenovo/SNMP`.
+
+---
+
+## Appendix A — manual-call templates
+
+For `manual:go` cases, drop a throwaway `main()` next to the harness (or extend
+it with a new flag). Skeleton — connect like the harness, then call the method:
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "time"
+
+    "github.com/bmc-toolbox/bmclib/v2/bmc"
+    "github.com/bmc-toolbox/bmclib/v2/providers/lenovo"
+    logrusr "github.com/bombsimon/logrusr/v2"
+    "github.com/sirupsen/logrus"
+)
+
+func main() {
+    ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+    defer cancel()
+
+    logger := logrusr.New(logrus.New())
+    c := lenovo.New("<host>", "<user>", "<pass>", logger, lenovo.WithPort("443"))
+    if !c.Compatible(ctx) { panic("not a Lenovo XCC") }
+    if err := c.Open(ctx); err != nil { panic(err) }
+    defer c.Close(ctx)
+
+    // --- pick the call under test, e.g.: ---
+
+    // TC-SEC-3
+    // err := c.ResetSecureBootKeys(ctx, "ResetAllKeysToDefault")
+
+    // TC-USR-2 / 3 / 4
+    // err := c.UserCreate(ctx, "smoketest", "S3cret!Passw0rd", "Administrator")
+    // err := c.UserUpdate(ctx, "smoketest", "New!Passw0rd", "Operator")
+    // err := c.UserDelete(ctx, "smoketest")
+
+    // TC-USR-5
+    // err := c.RoleCreate(ctx, "custom", []string{"Login", "ConfigureManager"})
+    // roles, err := c.Roles(ctx)
+
+    // TC-STO-2..5
+    // id, err := c.VolumeCreate(ctx, "<storageID>", bmc.VolumeCreateRequest{ /* RAIDType, Drives, CapacityBytes */ })
+    // err := c.VolumeInitialize(ctx, "<storageID>", id, "Fast")
+    // err := c.VolumeUpdate(ctx, "<storageID>", id, map[string]any{"Name": "newname"})
+    // err := c.VolumeDelete(ctx, "<storageID>", id)
+
+    // TC-FW-5
+    // taskID, err := c.SimpleUpdate(ctx, "http://10.0.0.2/lnvgy_fw.uxz", "HTTP")
+
+    // TC-BMC-2 / 3 / 5 / 7
+    // err := c.ResetToFactoryDefaults(ctx, "ResetAll")   // LAST — wipes config
+    // err := c.UpdateManager(ctx, map[string]any{"DateTimeLocalOffset": "+00:00"})
+    // err := c.LicenseInstall(ctx, "<base64-license>"); err = c.LicenseDelete(ctx, "<id>")
+    // err := c.SetSecureKeyRepoServers(ctx, []bmc.SecureKeyRepoServer{{HostName: "kmip.lab", Port: 5696}})
+
+    // TC-NET-2 / 3 / 5, TC-SER-2
+    // err := c.SetBMCNetworkInterface(ctx, "eth0", map[string]any{ /* ... */ })
+    // err := c.SetHostInterfaceEnabled(ctx, "1", true)
+    // err := c.SetNetworkProtocols(ctx, map[string]any{"SSDP": map[string]any{"ProtocolEnabled": false}})
+    // err := c.SetSerialInterface(ctx, "1", map[string]any{"BitRate": "115200"})
+
+    // TC-EVT-2 / 3 / 4
+    // id, err := c.EventSubscriptionCreate(ctx, bmc.EventSubscriptionRequest{ /* Destination, Protocol, RegistryPrefixes */ })
+    // err := c.SubmitTestEvent(ctx, "<MessageId>")
+    // err := c.EventSubscriptionDelete(ctx, id)
+    // err := c.SetEventService(ctx, map[string]any{"ServiceEnabled": true})
+
+    // TC-TEL-3, TC-SNM-3, TC-CRT-2..4, TC-LOG-2
+    // err := c.SubmitTestMetricReport(ctx, "<reportName>")
+    // err := c.SetSNMPAlertFilter(ctx, map[string]any{ /* ... */ })
+    // csr, err := c.GenerateCSR(ctx, bmc.CSRRequest{ /* CommonName, Org, ... */ })
+    // err := c.ReplaceCertificate(ctx, "<pem>", "/redfish/v1/Managers/1/NetworkProtocol/HTTPS/Certificates/1")
+    // err := c.RekeyCertificate(ctx, "<certURI>"); err = c.RenewCertificate(ctx, "<certURI>")
+    // entries, err := c.GetSystemEventLogRaw(ctx)
+
+    fmt.Println("done")
+}
+```
+
+Raw Redfish independent verification (no provider): every read above has a
+`$CURL $XCC/redfish/v1/...` form shown inline. XCC accepts HTTP Basic on all
+resources except it requires auth beyond `/redfish/v1/`.
+
+---
+
+## Release-gate sign-off
+
+Record per the RUNBOOK "What to record" list, plus this table:
+
+| TC | Run? | Result (PASS/WARN/FAIL/NA) | Evidence (log / UI screenshot / curl) | Notes |
+|----|------|----------------------------|---------------------------------------|-------|
+| TC-FND-1 … TC-SNM-3 | | | | |
+
+**Gate to ship:** every 🟢 read = PASS or justified WARN; every 🟡/🟠 mutation
+exercised on the lab box = PASS with independent verification; TC-FW-1 (firmware
+push) + TC-VM-1 (vmedia PATCH) = PASS (these are the two highest-variance XCC
+behaviours the fixtures cannot prove). 🔴 destructive cases (TC-STO-2/3/5,
+TC-BMC-2) run last, on a throwaway box, with a documented recovery path.

--- a/examples/lenovo-smoketest/RUNBOOK.md
+++ b/examples/lenovo-smoketest/RUNBOOK.md
@@ -1,0 +1,124 @@
+# Lenovo XCC provider — real-hardware smoke test runbook
+
+`lenovo-smoketest` validates the bmclib `lenovo` provider against a real Lenovo
+XClarity Controller (XCC). The unit tests run entirely against fixtures; this
+harness is the bridge to actual hardware.
+
+## Safety model
+
+- **Read-only by default.** A plain invocation performs only GET/read calls and
+  never changes the BMC or host.
+- **Mutations are double-gated.** A mutating operation runs only when BOTH the
+  master `-allow-writes` flag AND that operation's own flag are given. Otherwise
+  it is reported as `SKIP`.
+- **Exit code.** `0` when there are no `FAIL` results, `1` otherwise. `WARN`
+  (a capability the model does not expose) does not fail the run.
+
+## Result statuses
+
+| Status | Meaning |
+|--------|---------|
+| `PASS` | the check succeeded |
+| `WARN` | a non-core read failed — the XCC model may not expose it (telemetry, jobs, SKLM, audit log, …) |
+| `FAIL` | a core capability failed (compatibility, service root, power state, inventory) or a requested mutation failed |
+| `SKIP` | a mutation whose flag (or `-allow-writes`) was not provided |
+
+## 1. Read-only sweep (run this first)
+
+```bash
+go run ./examples/lenovo-smoketest -host <xcc-ip> -user <user> -pass <pass>
+# add -v for HTTP debug logging, -json to capture the report for CI
+```
+
+Expected: a list of `[PASS]`/`[WARN]`/`[SKIP]` lines and a summary with
+`0 FAIL`. Capture the output. Investigate every `FAIL`; review `WARN`s to
+confirm they correspond to genuinely-absent capabilities on the model under
+test.
+
+Reads exercised: serviceroot, power state, boot progress + override, BIOS,
+secure boot, thermal, power metrics, inventory, storage controllers + volumes,
+users, SEL, audit log, licenses, SKLM, BMC/server NICs, network protocols,
+serial, event service + subscriptions, telemetry service + reports + definitions,
+job service + list, certificate locations + read, SNMP, firmware install steps.
+
+## 2. Targeted mutation checks (opt-in, one at a time)
+
+Run against a lab/non-production server. Each needs `-allow-writes` plus its flag.
+
+```bash
+# power (use a state safe for the box under test)
+go run ./examples/lenovo-smoketest -host <ip> -user <u> -pass <p> -allow-writes -power on
+
+# next-boot device (one-time override). NOTE: XCC allows only a one-time (Once)
+# override — it rejects -bootdev-persistent (Continuous); manage persistent boot
+# via the BootOrder instead.
+... -allow-writes -bootdev pxe                 # one-time, legacy
+... -allow-writes -bootdev cdrom -bootdev-efi  # one-time, UEFI (boot a mounted ISO)
+
+# BIOS set / reset
+# BIOS attribute NAMES are model/firmware-specific. Discover the exact keys on
+# THIS box first (one unknown key fails the whole PATCH with PropertyUnknown):
+#     go run ./examples/lenovo-smoketest -host <ip> -user <u> -pass <p> -v 2>/dev/null | grep "bios attr"
+# then set a key copied verbatim from that list, e.g. on a ThinkSystem SR630 V2:
+... -allow-writes -set-bios "BootModes_SystemBootMode=UEFIMode"
+... -allow-writes -reset-bios
+
+# secure boot / power cap
+... -allow-writes -secureboot enable
+... -allow-writes -powercap 1200       # or: -powercap off
+
+# virtual media (host the ISO somewhere reachable by the XCC)
+... -allow-writes -vmedia-url http://10.0.0.2/boot.iso -vmedia-kind CD
+... -allow-writes -vmedia-eject -vmedia-kind CD
+
+# logs / SNMP / BMC reset / NMI
+... -allow-writes -clear-sel
+... -allow-writes -snmp-v1-trap enable
+... -allow-writes -bmc-reset GracefulRestart    # disconnects the session
+... -allow-writes -nmi
+```
+
+## 2b. Virtual-media boot flow (ordered: mount → set boot → power)
+
+A focused mode (folded in from the former `lenovo-vmedia-boot` example) that
+mounts an image, points the next boot at it, and powers the host on — in that
+order. It replaces the read/write sweep and is gated by `-allow-writes`.
+
+```bash
+go run ./examples/lenovo-smoketest -host <ip> -user <u> -pass <p> \
+    -allow-writes -vmedia-boot \
+    -vmedia-url http://10.0.0.2/installer.iso -vmedia-kind CD \
+    -bootdev-efi -power on
+```
+
+Notes: the boot device is derived from `-vmedia-kind` (CD/DVD→`cdrom`,
+Floppy→`floppy`, USBStick→`usb`); the override is one-time (XCC rejects a
+persistent/`Continuous` override — `-bootdev-persistent` will error); pass
+`-power on` explicitly (empty `-power` mounts + sets boot but skips powering on).
+
+## 3. Firmware install (highest-risk — dedicated lab box only)
+
+The firmware path validates the XCC push protocol (claim `HttpPushUriTargetsBusy`
+→ multipart `/mfwupdate` or raw `/fwupdate` → poll the Task → release). This is
+the protocol variance the unit tests can only fixture-test.
+
+```bash
+go run ./examples/lenovo-smoketest -host <ip> -user <u> -pass <p> \
+    -allow-writes \
+    -firmware /path/to/lnvgy_fw_*.uxz \
+    -firmware-component BMC-Backup \
+    -firmware-applytime OnReset \
+    -timeout 30m -firmware-poll 15s
+```
+
+The harness pushes the image, prints the task id, then polls the Task resource
+(never the TaskMonitor URI) until `complete`/`failed`. Use a long `-timeout`.
+
+## What to record for the release gate
+
+1. The full read-only sweep output (`-json` recommended) with `0 FAIL`.
+2. XCC firmware version / model (from the `inventory.read` line).
+3. For each mutation exercised: the `PASS` line and independent confirmation on
+   the BMC UI/CLI that the change took effect.
+4. The firmware task transcript (`pushed; taskID=…` → `task completed`).
+5. Any `WARN`/`FAIL` with notes on whether it is expected for the model.

--- a/examples/lenovo-smoketest/dump-xcc.sh
+++ b/examples/lenovo-smoketest/dump-xcc.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# dump-xcc.sh — READ-ONLY Redfish dumper for the Lenovo XCC bmclib provider.
+#
+# GETs every Redfish resource the `lenovo` provider touches and saves the raw
+# JSON under an output directory, so you can verify against real hardware the
+# paths, field names, OEM structures, action targets and *@Redfish.AllowableValues
+# the provider assumes. It performs ONLY GETs — it never mutates the BMC.
+#
+# Usage:
+#   ./dump-xcc.sh <host> <user> <pass> [outdir]
+#   XCC_INSECURE=0 ./dump-xcc.sh ...     # verify TLS (default: -k, insecure)
+#   TOP=5 ./dump-xcc.sh ...              # cap log-entry pages at $top=5 (default 5)
+#
+# Requires: curl. Optional: jq (enables collection-member expansion + pretty
+# printing + the BIOS attribute registry resolve; without it you get top-level
+# resources only). Output: one .json per resource + an _index.tsv of HTTP codes.
+#
+set -u
+
+HOST="${1:-}"; USERNAME="${2:-}"; PASSWORD="${3:-}"; OUTDIR="${4:-xcc-dump}"
+if [[ -z "$HOST" || -z "$USERNAME" || -z "$PASSWORD" ]]; then
+  echo "usage: $0 <host> <user> <pass> [outdir]" >&2
+  exit 2
+fi
+
+XCC="https://${HOST}"
+TOP="${TOP:-5}"
+CURL_INSECURE="-k"; [[ "${XCC_INSECURE:-1}" == "0" ]] && CURL_INSECURE=""
+AUTH=(-u "${USERNAME}:${PASSWORD}")
+HAVE_JQ=0; command -v jq >/dev/null 2>&1 && HAVE_JQ=1
+
+mkdir -p "$OUTDIR"
+INDEX="$OUTDIR/_index.tsv"
+: > "$INDEX"
+[[ $HAVE_JQ -eq 0 ]] && echo "WARN: jq not found — collections will not be expanded and output is raw" >&2
+
+# get <path> — GET $XCC<path>, save pretty JSON to a file named after the path,
+# and record "HTTP_CODE\tpath" in the index. Safe to call on absent resources.
+get() {
+  local path="$1"
+  local name="${path#/redfish/v1/}"; name="${name//\//__}"; name="${name%__}"
+  [[ -z "$name" ]] && name="serviceroot"
+  local out="$OUTDIR/${name}.json"
+  local code
+  code=$(curl -s $CURL_INSECURE "${AUTH[@]}" -H 'Accept: application/json' \
+               --connect-timeout 10 --max-time 60 \
+               -o "${out}.raw" -w '%{http_code}' "${XCC}${path}")
+  printf '%s\t%s\n' "$code" "$path" | tee -a "$INDEX"
+  if [[ ! -s "${out}.raw" ]]; then
+    # No body (connection failure, or an empty response): leave a placeholder.
+    rm -f "${out}.raw"; : > "$out"; return 0
+  fi
+  if [[ $HAVE_JQ -eq 1 ]] && jq . "${out}.raw" >"$out" 2>/dev/null; then
+    rm -f "${out}.raw"
+  else
+    mv -f "${out}.raw" "$out"
+  fi
+}
+
+# members <path> — print each Members[].@odata.id of a collection (needs jq).
+members() {
+  [[ $HAVE_JQ -eq 0 ]] && return 0
+  local out="$OUTDIR/$(echo "${1#/redfish/v1/}" | sed 's#/#__#g; s#__$##').json"
+  [[ -f "$out" ]] || return 0
+  jq -r '.Members[]?."@odata.id" // empty' "$out" 2>/dev/null
+}
+
+# get_members <collection-path> — dump the collection, then every member.
+get_members() { get "$1"; local m; for m in $(members "$1"); do get "$m"; done; }
+
+section() { echo; echo "### $1"; }
+
+# --------------------------------------------------------------------------
+section "Service root, registries, metadata"
+get "/redfish/v1/"
+get_members "/redfish/v1/Registries"
+# Resolve and dump the BIOS attribute registry (all valid attribute names,
+# types and AllowableValues — the source of truth for -set-bios keys).
+if [[ $HAVE_JQ -eq 1 && -f "$OUTDIR/Registries.json" ]]; then
+  for r in $(members "/redfish/v1/Registries"); do
+    rid=$(basename "$r")
+    case "$rid" in
+      *BiosAttributeRegistry*|*LenovoBiosAttributeRegistry*)
+        get "$r"
+        loc=$(jq -r '.Location[]?.Uri // empty' "$OUTDIR/$(echo "${r#/redfish/v1/}" | sed 's#/#__#g').json" 2>/dev/null | head -1)
+        [[ -n "$loc" ]] && get "$loc"
+        ;;
+    esac
+  done
+fi
+
+section "Systems: power, boot, BIOS, secure boot, NICs"
+get_members "/redfish/v1/Systems"
+sys=$(members "/redfish/v1/Systems" | head -1); sys="${sys:-/redfish/v1/Systems/1}"
+get "${sys}/Bios"
+get "${sys}/Bios/Pending"                       # @Redfish.Settings target (set-bios)
+get "${sys}/Bios/SD"                             # alt settings target on some FW
+get "${sys}/Bios/ChangePasswordActionInfo"       # ChangePassword allowable values
+get "${sys}/SecureBoot"
+get "${sys}/ResetActionInfo"                      # ComputerSystem.Reset allowable values
+get_members "${sys}/EthernetInterfaces"
+
+section "Chassis: thermal, power metrics, power cap"
+get_members "/redfish/v1/Chassis"
+ch=$(members "/redfish/v1/Chassis" | head -1); ch="${ch:-/redfish/v1/Chassis/1}"
+get "${ch}/Thermal"
+get "${ch}/Power"
+
+section "Storage and volumes"
+get_members "${sys}/Storage"
+for st in $(members "${sys}/Storage"); do
+  get_members "${st}/Volumes"
+  get_members "${st}/Drives"
+done
+
+section "Managers: BMC, network, serial, vmedia, SKLM, SNMP, logs"
+get_members "/redfish/v1/Managers"
+mgr=$(members "/redfish/v1/Managers" | head -1); mgr="${mgr:-/redfish/v1/Managers/1}"
+get "${mgr}/NetworkProtocol"
+get "${mgr}/NetworkProtocol/Oem/Lenovo/SNMP"
+get "${mgr}/Oem/Lenovo/SecureKeyLifecycleService"
+get_members "${mgr}/EthernetInterfaces"
+get_members "${mgr}/HostInterfaces"
+get_members "${mgr}/SerialInterfaces"
+get_members "${mgr}/VirtualMedia"
+# HTTPS certificate collection (cert replace/rekey/renew targets live here)
+get_members "${mgr}/NetworkProtocol/HTTPS/Certificates"
+
+section "Log services (SEL, audit, ...) — first \$top=$TOP entries each"
+get_members "${mgr}/LogServices"
+for ls in $(members "${mgr}/LogServices"); do
+  get "${ls}"
+  get "${ls}/Entries?\$top=${TOP}"
+done
+get_members "${ch}/LogServices"
+for ls in $(members "${ch}/LogServices"); do get "${ls}"; done
+
+section "Firmware: update service, inventory, tasks"
+get "/redfish/v1/UpdateService"
+get_members "/redfish/v1/UpdateService/FirmwareInventory"
+get_members "/redfish/v1/TaskService/Tasks"
+get "/redfish/v1/TaskService"
+
+section "Accounts and roles"
+get "/redfish/v1/AccountService"
+get_members "/redfish/v1/AccountService/Accounts"
+get_members "/redfish/v1/AccountService/Roles"
+
+section "Events and telemetry"
+get "/redfish/v1/EventService"
+get_members "/redfish/v1/EventService/Subscriptions"
+get "/redfish/v1/TelemetryService"
+get_members "/redfish/v1/TelemetryService/MetricReports"
+get_members "/redfish/v1/TelemetryService/MetricReportDefinitions"
+get_members "/redfish/v1/TelemetryService/MetricDefinitions"
+
+section "Jobs"
+get "/redfish/v1/JobService"
+get_members "/redfish/v1/JobService/Jobs"
+
+section "Certificates"
+get "/redfish/v1/CertificateService"
+get "/redfish/v1/CertificateService/CertificateLocations"
+
+section "License (404 on firmware levels without LicenseService)"
+get "/redfish/v1/LicenseService"
+get_members "/redfish/v1/LicenseService/Licenses"
+
+echo
+echo "done. dumps in: $OUTDIR/   index: $INDEX"
+echo "non-200 responses (absent/locked resources):"
+awk -F'\t' '$1!=200 {printf "  %s  %s\n", $1, $2}' "$INDEX" || true

--- a/examples/lenovo-smoketest/main.go
+++ b/examples/lenovo-smoketest/main.go
@@ -1,0 +1,868 @@
+// Command lenovo-smoketest runs an opt-in, real-hardware smoke test of the
+// Lenovo XCC bmclib provider, and (in -vmedia-boot mode) the ordered
+// virtual-media boot flow.
+//
+// By default it is READ-ONLY: it connects, runs the vendor compatibility check,
+// and exercises every read capability (power/boot/BIOS/secure-boot/thermal/
+// power/inventory/storage/users/logs/license/SKLM/network/serial/events/
+// telemetry/jobs/certificates/SNMP/firmware-steps), printing a PASS/WARN/FAIL/
+// SKIP report.
+//
+// Mutating operations are NEVER performed unless the master -allow-writes flag
+// is set AND the specific operation's flag is provided. This makes accidental
+// changes to production hardware impossible with a default invocation.
+//
+// Read failures on capabilities a given XCC model may not expose (telemetry,
+// jobs, SKLM, ...) are reported as WARN (non-fatal). Failures of the core
+// capabilities (compatibility, service root, power state, inventory) are FAIL
+// and set a non-zero exit code.
+//
+// Usage:
+//
+//	# read-only sweep
+//	go run ./examples/lenovo-smoketest -host <ip> -user <user> -pass <pass>
+//
+//	# include selected mutations (each still requires its own flag)
+//	go run ./examples/lenovo-smoketest -host <ip> -user <user> -pass <pass> \
+//	    -allow-writes -power on -bootdev pxe
+//
+//	# virtual-media boot: mount an ISO, set it as next boot device, power on
+//	# (one ordered flow; requires -allow-writes; skips the read/write sweep)
+//	go run ./examples/lenovo-smoketest -host <ip> -user <user> -pass <pass> \
+//	    -allow-writes -vmedia-boot -vmedia-url http://10.0.0.2/installer.iso \
+//	    -vmedia-kind CD -bootdev-efi -power on
+//
+// This is intended for manual validation against real hardware; it is not part
+// of the unit-test suite (which runs entirely against fixtures). See RUNBOOK.md
+// and HARDWARE-TEST-PLAN.md.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/bmc-toolbox/bmclib/v2/constants"
+	"github.com/bmc-toolbox/bmclib/v2/providers/lenovo"
+	logrusr "github.com/bombsimon/logrusr/v2"
+	"github.com/sirupsen/logrus"
+)
+
+// ---------------------------------------------------------------------------
+// harness
+// ---------------------------------------------------------------------------
+
+const (
+	statusPass = "PASS"
+	statusWarn = "WARN"
+	statusFail = "FAIL"
+	statusSkip = "SKIP"
+)
+
+// result is a single smoke-test check outcome.
+type result struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Detail string `json:"detail"`
+}
+
+// harness drives the checks against a connected XCC and accumulates results.
+type harness struct {
+	conn    *lenovo.Conn
+	ctx     context.Context
+	verbose bool
+	results []result
+}
+
+// record appends a result and prints it as it happens.
+func (h *harness) record(name, status, detail string) {
+	h.results = append(h.results, result{Name: name, Status: status, Detail: detail})
+	fmt.Printf("[%s] %-34s %s\n", status, name, detail)
+}
+
+// read runs a read-only check. On error the status is FAIL when critical (core
+// capability), otherwise WARN (the XCC model may not expose the resource).
+func (h *harness) read(name string, critical bool, fn func() (string, error)) {
+	summary, err := fn()
+	if err != nil {
+		status := statusWarn
+		if critical {
+			status = statusFail
+		}
+		h.record(name, status, err.Error())
+		return
+	}
+	h.record(name, statusPass, summary)
+}
+
+// action runs a mutating check. It is skipped unless enabled is true (the
+// operation's flag was given together with -allow-writes).
+func (h *harness) action(name string, enabled bool, skipReason string, fn func() error) {
+	if !enabled {
+		h.record(name, statusSkip, skipReason)
+		return
+	}
+	if err := fn(); err != nil {
+		h.record(name, statusFail, err.Error())
+		return
+	}
+	h.record(name, statusPass, "ok")
+}
+
+// ---------------------------------------------------------------------------
+// flags
+// ---------------------------------------------------------------------------
+
+// options holds the parsed command-line configuration.
+type options struct {
+	host, user, pass, port string
+	basic                  bool
+	verbose                bool
+	jsonOut                bool
+	timeout                time.Duration
+
+	// write gate + per-operation flags (all empty/false => skipped).
+	allowWrites    bool
+	power          string
+	bootDevice     string
+	bootPersistent bool
+	bootEFI        bool
+	nmi            bool
+	bmcReset       string
+	setBIOS        string
+	resetBIOS      bool
+	secureBoot     string
+	powerCap       string
+	vmediaURL      string
+	vmediaKind     string
+	vmediaEject    bool
+	vmediaBoot     bool
+	clearSEL       bool
+	snmpV1Trap     string
+	snmpV3Trap     string
+
+	firmwareFile      string
+	firmwareComponent string
+	firmwareApplyTime string
+	firmwarePollEvery time.Duration
+}
+
+func parseFlags() options {
+	var o options
+	flag.StringVar(&o.host, "host", "", "XCC hostname/IP (required)")
+	flag.StringVar(&o.user, "user", "", "username (required)")
+	flag.StringVar(&o.pass, "pass", "", "password (required)")
+	flag.StringVar(&o.port, "port", "443", "XCC Redfish port")
+	flag.BoolVar(&o.basic, "basic", false, "use HTTP Basic auth instead of a session")
+	flag.BoolVar(&o.verbose, "v", false, "verbose: dump full payloads for read checks")
+	flag.BoolVar(&o.jsonOut, "json", false, "emit the result report as JSON")
+	flag.DurationVar(&o.timeout, "timeout", 5*time.Minute, "overall timeout")
+
+	flag.BoolVar(&o.allowWrites, "allow-writes", false, "MASTER SWITCH: permit mutating operations (each still needs its own flag)")
+	flag.StringVar(&o.power, "power", "", "set power state: on|off|soft|cycle|reset")
+	flag.StringVar(&o.bootDevice, "bootdev", "", "set boot device: pxe|disk|cdrom|bios|usb|floppy|remote_drive|... (CD/DVD/USBStick aliases accepted)")
+	flag.BoolVar(&o.bootPersistent, "bootdev-persistent", false, "make -bootdev / -vmedia-boot persistent (Continuous)")
+	flag.BoolVar(&o.bootEFI, "bootdev-efi", false, "make -bootdev / -vmedia-boot UEFI mode")
+	flag.BoolVar(&o.nmi, "nmi", false, "send an NMI to the host")
+	flag.StringVar(&o.bmcReset, "bmc-reset", "", "reset the BMC: GracefulRestart|ForceRestart")
+	flag.StringVar(&o.setBIOS, "set-bios", "", "set BIOS attributes: \"Key=Value,Key2=Value2\"")
+	flag.BoolVar(&o.resetBIOS, "reset-bios", false, "reset BIOS settings to defaults")
+	flag.StringVar(&o.secureBoot, "secureboot", "", "set Secure Boot: enable|disable")
+	flag.StringVar(&o.powerCap, "powercap", "", "set power cap watts, or \"off\" to disable")
+	flag.StringVar(&o.vmediaURL, "vmedia-url", "", "insert virtual media from this URL")
+	flag.StringVar(&o.vmediaKind, "vmedia-kind", "CD", "virtual media kind for -vmedia-url / -vmedia-boot: CD|DVD|Floppy|USBStick")
+	flag.BoolVar(&o.vmediaEject, "vmedia-eject", false, "eject virtual media of -vmedia-kind")
+	flag.BoolVar(&o.vmediaBoot, "vmedia-boot", false, "ordered flow: mount -vmedia-url, set it as next boot device, power on (skips the read/write sweep)")
+	flag.BoolVar(&o.clearSEL, "clear-sel", false, "clear the System Event Log")
+	flag.StringVar(&o.snmpV1Trap, "snmp-v1-trap", "", "enable|disable the SNMPv1 trap")
+	flag.StringVar(&o.snmpV3Trap, "snmp-v3-trap", "", "enable|disable the SNMPv3 trap")
+	flag.StringVar(&o.firmwareFile, "firmware", "", "firmware image file to install (XCC push protocol)")
+	flag.StringVar(&o.firmwareComponent, "firmware-component", "", "firmware target (FirmwareInventory id, e.g. BMC-Backup); empty = auto-detect")
+	flag.StringVar(&o.firmwareApplyTime, "firmware-applytime", "OnReset", "firmware OperationApplyTime: Immediate|OnReset|OnStartUpdateRequest")
+	flag.DurationVar(&o.firmwarePollEvery, "firmware-poll", 15*time.Second, "firmware task poll interval")
+	flag.Parse()
+
+	return o
+}
+
+func main() {
+	o := parseFlags()
+	if o.host == "" || o.user == "" || o.pass == "" {
+		fmt.Fprintln(os.Stderr, "error: -host, -user and -pass are required")
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	l := logrus.New()
+	if o.verbose {
+		l.Level = logrus.DebugLevel
+	} else {
+		l.Level = logrus.InfoLevel
+	}
+	logger := logrusr.New(l)
+
+	ctx, cancel := context.WithTimeout(context.Background(), o.timeout)
+	defer cancel()
+
+	opts := []lenovo.Option{lenovo.WithPort(o.port)}
+	if o.basic {
+		opts = append(opts, lenovo.WithUseBasicAuth(true))
+	}
+	conn := lenovo.New(o.host, o.user, o.pass, logger, opts...)
+
+	h := &harness{conn: conn, ctx: ctx, verbose: o.verbose}
+
+	// Compatibility opens and closes its own session.
+	if !conn.Compatible(ctx) {
+		h.record("connection.compatible", statusFail, "device is NOT compatible with the lenovo provider")
+		h.finish(o)
+		return
+	}
+	h.record("connection.compatible", statusPass, "device identifies as Lenovo XCC")
+
+	if err := conn.Open(ctx); err != nil {
+		h.record("connection.open", statusFail, err.Error())
+		h.finish(o)
+		return
+	}
+	h.record("connection.open", statusPass, "session established")
+	defer conn.Close(ctx)
+
+	// -vmedia-boot is a focused, ordered mutation flow; it replaces the
+	// read/write sweep rather than running alongside it.
+	if o.vmediaBoot {
+		runVMediaBoot(h, o)
+		h.finish(o)
+		return
+	}
+
+	runReadChecks(h)
+	runWriteChecks(h, o)
+
+	h.finish(o)
+}
+
+// finish prints the report (text or JSON) and exits with the right code.
+func (h *harness) finish(o options) {
+	if o.jsonOut {
+		_ = json.NewEncoder(os.Stdout).Encode(h.results)
+	}
+
+	var pass, warn, fail, skip int
+	for _, r := range h.results {
+		switch r.Status {
+		case statusPass:
+			pass++
+		case statusWarn:
+			warn++
+		case statusFail:
+			fail++
+		case statusSkip:
+			skip++
+		}
+	}
+
+	fmt.Printf("\nsummary: %d PASS, %d WARN, %d FAIL, %d SKIP (%d checks)\n",
+		pass, warn, fail, skip, len(h.results))
+
+	if fail > 0 {
+		os.Exit(1)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// read checks
+// ---------------------------------------------------------------------------
+
+// runReadChecks exercises every read capability of the provider. Core
+// capabilities are marked critical (failure => non-zero exit); the rest are
+// non-critical (a given XCC model may not expose them, reported as WARN).
+func runReadChecks(h *harness) {
+	ctx := h.ctx
+	c := h.conn
+
+	h.read("serviceroot.read", true, func() (string, error) {
+		root, err := c.ServiceRoot(ctx)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("vendor=%q product=%q redfish=%s", root.Vendor, root.Product, root.RedfishVersion), nil
+	})
+
+	// --- power / boot ---
+	h.read("power.state", true, func() (string, error) {
+		state, err := c.PowerStateGet(ctx)
+		return "state=" + state, err
+	})
+	h.read("boot.progress", false, func() (string, error) {
+		bp, err := c.GetBootProgress()
+		if err != nil {
+			return "", err
+		}
+		return "lastState=" + string(bp.LastState), nil
+	})
+	h.read("boot.override", false, func() (string, error) {
+		o, err := c.BootDeviceOverrideGet(ctx)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("device=%s persistent=%t efi=%t", o.Device, o.IsPersistent, o.IsEFIBoot), nil
+	})
+
+	// --- bios / secure boot ---
+	h.read("bios.read", false, func() (string, error) {
+		cfg, err := c.GetBiosConfiguration(ctx)
+		if err != nil {
+			return "", err
+		}
+		// In verbose mode dump every attribute name=value so the operator can
+		// copy exact keys for -set-bios (attribute names are model/firmware
+		// specific; an unknown key fails the whole PATCH with PropertyUnknown).
+		if h.verbose {
+			keys := make([]string, 0, len(cfg))
+			for k := range cfg {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				fmt.Printf("       bios attr %s = %s\n", k, cfg[k])
+			}
+		}
+		return fmt.Sprintf("%d attributes", len(cfg)), nil
+	})
+	h.read("secureboot.read", false, func() (string, error) {
+		sb, err := c.GetSecureBoot(ctx)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("enabled=%t mode=%s current=%s", sb.Enabled, sb.Mode, sb.CurrentBoot), nil
+	})
+
+	// --- thermal / power metrics ---
+	h.read("thermal.read", false, func() (string, error) {
+		t, err := c.Thermal(ctx)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%d temps, %d fans", len(t.Temperatures), len(t.Fans)), nil
+	})
+	h.read("power.metrics", false, func() (string, error) {
+		p, err := c.ReadPower(ctx)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("consumed=%.0fW capacity=%.0fW supplies=%d", p.ConsumedWatts, p.CapacityWatts, len(p.PowerSupplies)), nil
+	})
+
+	// --- inventory / storage ---
+	h.read("inventory.read", true, func() (string, error) {
+		dev, err := c.Inventory(ctx)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("vendor=%q model=%q cpus=%d dimms=%d drives=%d nics=%d",
+			dev.Vendor, dev.Model, len(dev.CPUs), len(dev.Memory), len(dev.Drives), len(dev.NICs)), nil
+	})
+
+	var firstController string
+	h.read("storage.controllers", false, func() (string, error) {
+		ctrls, err := c.StorageControllers(ctx)
+		if err != nil {
+			return "", err
+		}
+		if len(ctrls) > 0 {
+			firstController = ctrls[0].ID
+		}
+		return fmt.Sprintf("%d controllers", len(ctrls)), nil
+	})
+	if firstController != "" {
+		h.read("storage.volumes", false, func() (string, error) {
+			vols, err := c.Volumes(ctx, firstController)
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("controller %s: %d volumes", firstController, len(vols)), nil
+		})
+	} else {
+		h.record("storage.volumes", statusSkip, "no storage controller to query")
+	}
+
+	// --- users ---
+	h.read("users.read", false, func() (string, error) {
+		users, err := c.UserRead(ctx)
+		return fmt.Sprintf("%d accounts", len(users)), err
+	})
+
+	// --- logs ---
+	h.read("sel.read", false, func() (string, error) {
+		entries, err := c.GetSystemEventLog(ctx)
+		return fmt.Sprintf("%d SEL entries", len(entries)), err
+	})
+	h.read("log.audit", false, func() (string, error) {
+		entries, err := c.EventLog(ctx, lenovo.LogServiceAudit)
+		return fmt.Sprintf("%d audit entries", len(entries)), err
+	})
+
+	// --- bmc management ---
+	h.read("license.read", false, func() (string, error) {
+		lics, err := c.Licenses(ctx)
+		return fmt.Sprintf("%d licenses", len(lics)), err
+	})
+	h.read("sklm.read", false, func() (string, error) {
+		cfg, err := c.GetSecureKeyLifecycle(ctx)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("deviceGroup=%q keyServers=%d", cfg.DeviceGroup, len(cfg.KeyRepoServers)), nil
+	})
+
+	// --- network / serial ---
+	h.read("network.bmc", false, func() (string, error) {
+		ifaces, err := c.BMCNetworkInterfaces(ctx)
+		return fmt.Sprintf("%d BMC NICs", len(ifaces)), err
+	})
+	h.read("network.server", false, func() (string, error) {
+		ifaces, err := c.ServerNetworkInterfaces(ctx)
+		return fmt.Sprintf("%d server NICs", len(ifaces)), err
+	})
+	h.read("network.protocols", false, func() (string, error) {
+		ps, err := c.NetworkProtocols(ctx)
+		return fmt.Sprintf("%d services", len(ps)), err
+	})
+	h.read("serial.read", false, func() (string, error) {
+		ifaces, err := c.SerialInterfaces(ctx)
+		return fmt.Sprintf("%d serial interfaces", len(ifaces)), err
+	})
+
+	// --- events / telemetry ---
+	h.read("event.service", false, func() (string, error) {
+		info, err := c.EventService(ctx)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("enabled=%t sse=%q", info.ServiceEnabled, info.SSEFilterURI), nil
+	})
+	h.read("event.subscriptions", false, func() (string, error) {
+		subs, err := c.EventSubscriptions(ctx)
+		return fmt.Sprintf("%d subscriptions", len(subs)), err
+	})
+	h.read("telemetry.service", false, func() (string, error) {
+		info, err := c.TelemetryService(ctx)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("enabled=%t maxReports=%d", info.ServiceEnabled, info.MaxReports), nil
+	})
+	h.read("telemetry.reports", false, func() (string, error) {
+		ids, err := c.MetricReports(ctx)
+		return fmt.Sprintf("%d metric reports", len(ids)), err
+	})
+	h.read("telemetry.definitions", false, func() (string, error) {
+		ids, err := c.MetricDefinitions(ctx)
+		return fmt.Sprintf("%d metric definitions", len(ids)), err
+	})
+
+	// --- jobs ---
+	h.read("job.service", false, func() (string, error) {
+		info, err := c.JobService(ctx)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("enabled=%t", info.ServiceEnabled), nil
+	})
+	h.read("job.list", false, func() (string, error) {
+		jobs, err := c.Jobs(ctx)
+		return fmt.Sprintf("%d jobs", len(jobs)), err
+	})
+
+	// --- certificates ---
+	var firstCert string
+	h.read("cert.locations", false, func() (string, error) {
+		locs, err := c.CertificateLocations(ctx)
+		if err != nil {
+			return "", err
+		}
+		if len(locs) > 0 {
+			firstCert = locs[0]
+		}
+		return fmt.Sprintf("%d certificates", len(locs)), nil
+	})
+	if firstCert != "" {
+		h.read("cert.read", false, func() (string, error) {
+			cert, err := c.Certificate(ctx, firstCert)
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("subject=%q notAfter=%s", cert.SubjectCommonName, cert.ValidNotAfter), nil
+		})
+	} else {
+		h.record("cert.read", statusSkip, "no certificate locations to read")
+	}
+
+	// --- snmp ---
+	h.read("snmp.read", false, func() (string, error) {
+		cfg, err := c.SNMP(ctx)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("v1Trap=%t v3Trap=%t port=%d", cfg.V1TrapEnabled, cfg.V3TrapEnabled, cfg.TrapPort), nil
+	})
+
+	// --- firmware (read-only step plan) ---
+	h.read("firmware.steps", false, func() (string, error) {
+		steps, err := c.FirmwareInstallSteps(ctx, "bmc")
+		return fmt.Sprintf("%d install steps", len(steps)), err
+	})
+}
+
+// ---------------------------------------------------------------------------
+// write checks
+// ---------------------------------------------------------------------------
+
+// gate returns whether a mutating operation may run. An operation runs only when
+// its own flag is set AND the master -allow-writes switch is on.
+func (o options) gate(flagSet bool) (bool, string) {
+	switch {
+	case !flagSet:
+		return false, "flag not set"
+	case !o.allowWrites:
+		return false, "-allow-writes not set"
+	default:
+		return true, ""
+	}
+}
+
+// runWriteChecks performs the gated mutating operations. With a default
+// invocation (no -allow-writes) every check here is SKIPped.
+func runWriteChecks(h *harness, o options) {
+	ctx := h.ctx
+	c := h.conn
+
+	enabled, reason := o.gate(o.power != "")
+	h.action("power.set", enabled, reason, func() error {
+		ok, err := c.PowerSet(ctx, o.power)
+		if err == nil && !ok {
+			return fmt.Errorf("power set returned ok=false")
+		}
+		return err
+	})
+
+	enabled, reason = o.gate(o.bootDevice != "")
+	h.action("boot.set", enabled, reason, func() error {
+		dev, perr := normalizeBootDevice(o.bootDevice)
+		if perr != nil {
+			return perr
+		}
+		ok, err := c.BootDeviceSet(ctx, dev, o.bootPersistent, o.bootEFI)
+		if err == nil && !ok {
+			return fmt.Errorf("boot device set returned ok=false")
+		}
+		return err
+	})
+
+	enabled, reason = o.gate(o.nmi)
+	h.action("power.nmi", enabled, reason, func() error {
+		return c.SendNMI(ctx)
+	})
+
+	enabled, reason = o.gate(o.bmcReset != "")
+	h.action("bmc.reset", enabled, reason, func() error {
+		ok, err := c.BmcReset(ctx, o.bmcReset)
+		if err == nil && !ok {
+			return fmt.Errorf("bmc reset returned ok=false")
+		}
+		return err
+	})
+
+	enabled, reason = o.gate(o.setBIOS != "")
+	h.action("bios.set", enabled, reason, func() error {
+		attrs, perr := parseKV(o.setBIOS)
+		if perr != nil {
+			return perr
+		}
+		// Pre-validate attribute names against this system's BIOS registry. XCC
+		// validates the PATCH atomically: a single unknown key fails the whole
+		// request with an opaque PropertyUnknown/InternalError 500. Catch it
+		// early with an actionable message (names are model/firmware-specific).
+		if cur, cerr := c.GetBiosConfiguration(ctx); cerr == nil && len(cur) > 0 {
+			var unknown []string
+			for k := range attrs {
+				if _, ok := cur[k]; !ok {
+					unknown = append(unknown, k)
+				}
+			}
+			if len(unknown) > 0 {
+				sort.Strings(unknown)
+				return fmt.Errorf("unknown BIOS attribute(s) %v on this system "+
+					"(names are model-specific; run with -v and grep 'bios attr' for valid keys)", unknown)
+			}
+		}
+		return c.SetBiosConfiguration(ctx, attrs)
+	})
+
+	enabled, reason = o.gate(o.resetBIOS)
+	h.action("bios.reset", enabled, reason, func() error {
+		return c.ResetBiosConfiguration(ctx)
+	})
+
+	enabled, reason = o.gate(o.secureBoot != "")
+	h.action("secureboot.set", enabled, reason, func() error {
+		on, perr := parseEnable(o.secureBoot)
+		if perr != nil {
+			return perr
+		}
+		return c.SetSecureBoot(ctx, on)
+	})
+
+	enabled, reason = o.gate(o.powerCap != "")
+	h.action("power.cap", enabled, reason, func() error {
+		limit, perr := parsePowerCap(o.powerCap)
+		if perr != nil {
+			return perr
+		}
+		return c.SetPowerCap(ctx, limit)
+	})
+
+	enabled, reason = o.gate(o.vmediaURL != "")
+	h.action("vmedia.insert", enabled, reason, func() error {
+		ok, err := c.SetVirtualMedia(ctx, o.vmediaKind, o.vmediaURL)
+		if err == nil && !ok {
+			return fmt.Errorf("set virtual media returned ok=false")
+		}
+		return err
+	})
+
+	enabled, reason = o.gate(o.vmediaEject)
+	h.action("vmedia.eject", enabled, reason, func() error {
+		ok, err := c.SetVirtualMedia(ctx, o.vmediaKind, "")
+		if err == nil && !ok {
+			return fmt.Errorf("eject virtual media returned ok=false")
+		}
+		return err
+	})
+
+	enabled, reason = o.gate(o.clearSEL)
+	h.action("sel.clear", enabled, reason, func() error {
+		return c.ClearSystemEventLog(ctx)
+	})
+
+	enabled, reason = o.gate(o.snmpV1Trap != "")
+	h.action("snmp.v1trap", enabled, reason, func() error {
+		on, perr := parseEnable(o.snmpV1Trap)
+		if perr != nil {
+			return perr
+		}
+		return c.EnableSNMPv1Trap(ctx, on)
+	})
+
+	enabled, reason = o.gate(o.snmpV3Trap != "")
+	h.action("snmp.v3trap", enabled, reason, func() error {
+		on, perr := parseEnable(o.snmpV3Trap)
+		if perr != nil {
+			return perr
+		}
+		return c.EnableSNMPv3Trap(ctx, on)
+	})
+
+	runFirmwareCheck(h, o)
+}
+
+// runFirmwareCheck performs the XCC firmware push (claim -> push -> poll task ->
+// release) and polls the task to a terminal state. It is the key real-hardware
+// validation for the firmware protocol variance.
+func runFirmwareCheck(h *harness, o options) {
+	enabled, reason := o.gate(o.firmwareFile != "")
+	if !enabled {
+		h.record("firmware.install", statusSkip, reason)
+		return
+	}
+
+	f, err := os.Open(o.firmwareFile)
+	if err != nil {
+		h.record("firmware.install", statusFail, "open image: "+err.Error())
+		return
+	}
+	defer f.Close()
+
+	taskID, err := h.conn.FirmwareInstall(h.ctx, o.firmwareComponent, o.firmwareApplyTime, false, f)
+	if err != nil {
+		h.record("firmware.install", statusFail, "push: "+err.Error())
+		return
+	}
+	h.record("firmware.install", statusPass, "pushed; taskID="+taskID)
+
+	// Poll the Task resource to a terminal state.
+	for {
+		select {
+		case <-h.ctx.Done():
+			h.record("firmware.task", statusFail, "timed out polling task "+taskID+": "+h.ctx.Err().Error())
+			return
+		default:
+		}
+
+		state, status, terr := h.conn.FirmwareTaskStatus(h.ctx, constants.FirmwareInstallStepInstallStatus, o.firmwareComponent, taskID, "")
+		if terr != nil {
+			h.record("firmware.task", statusFail, "poll: "+terr.Error())
+			return
+		}
+
+		fmt.Printf("       firmware task %s: state=%s %s\n", taskID, state, status)
+
+		switch state {
+		case constants.Complete:
+			h.record("firmware.task", statusPass, "task completed: "+status)
+			return
+		case constants.Failed:
+			h.record("firmware.task", statusFail, "task failed: "+status)
+			return
+		}
+
+		time.Sleep(o.firmwarePollEvery)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// virtual-media boot flow (formerly the lenovo-vmedia-boot example)
+// ---------------------------------------------------------------------------
+
+// runVMediaBoot performs the ordered virtual-media boot flow against the XCC:
+// mount the image, set it as the next boot device, then power on. The order
+// matters (insert -> set next boot -> power), which is why it is a dedicated
+// mode rather than relying on the fixed order of runWriteChecks. Like every
+// other mutation it is gated behind -allow-writes.
+func runVMediaBoot(h *harness, o options) {
+	ctx := h.ctx
+	c := h.conn
+
+	if !o.allowWrites {
+		h.record("vmediaboot", statusSkip, "-allow-writes not set")
+		return
+	}
+	if o.vmediaURL == "" {
+		h.record("vmediaboot", statusFail, "-vmedia-boot requires -vmedia-url")
+		return
+	}
+
+	// Step 1: mount the remote image into the virtual media slot. A non-empty
+	// URL inserts (ejecting anything already in the slot first); the
+	// TransferProtocolType is derived from the URL scheme.
+	h.action("vmediaboot.mount", true, "", func() error {
+		ok, err := c.SetVirtualMedia(ctx, o.vmediaKind, o.vmediaURL)
+		if err == nil && !ok {
+			return fmt.Errorf("set virtual media returned ok=false")
+		}
+		return err
+	})
+
+	// Step 2: set the next boot device to match the mounted media kind. With
+	// -bootdev-persistent it boots the media every time; otherwise it is a
+	// one-time override. -bootdev-efi selects UEFI vs legacy.
+	bootDevice := "cdrom"
+	switch o.vmediaKind {
+	case "Floppy":
+		bootDevice = "floppy"
+	case "USBStick":
+		bootDevice = "usb"
+	}
+	h.action("vmediaboot.bootdev", true, "", func() error {
+		ok, err := c.BootDeviceSet(ctx, bootDevice, o.bootPersistent, o.bootEFI)
+		if err == nil && !ok {
+			return fmt.Errorf("boot device set returned ok=false")
+		}
+		return err
+	})
+
+	// Step 3: power the server on (or cycle/reset). -power "" skips this.
+	if o.power == "" {
+		h.record("vmediaboot.power", statusSkip, "-power \"\" (pass -power on to boot now)")
+		return
+	}
+	h.action("vmediaboot.power", true, "", func() error {
+		ok, err := c.PowerSet(ctx, o.power)
+		if err == nil && !ok {
+			return fmt.Errorf("power %q returned ok=false", o.power)
+		}
+		return err
+	})
+}
+
+// ---------------------------------------------------------------------------
+// parse helpers
+// ---------------------------------------------------------------------------
+
+// parseKV parses "Key=Value,Key2=Value2" into a map.
+func parseKV(s string) (map[string]string, error) {
+	out := map[string]string{}
+	for _, pair := range strings.Split(s, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(pair, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid key=value pair: %q", pair)
+		}
+		out[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no key=value pairs parsed from %q", s)
+	}
+	return out, nil
+}
+
+// parseEnable parses "enable"/"disable" (and on/off, true/false) into a bool.
+func parseEnable(s string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "enable", "enabled", "on", "true":
+		return true, nil
+	case "disable", "disabled", "off", "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("expected enable|disable, got %q", s)
+	}
+}
+
+// parsePowerCap parses a watt value or "off" (nil => disable capping).
+func parsePowerCap(s string) (*float64, error) {
+	if strings.EqualFold(strings.TrimSpace(s), "off") {
+		return nil, nil
+	}
+	var watts float64
+	if _, err := fmt.Sscanf(strings.TrimSpace(s), "%f", &watts); err != nil {
+		return nil, fmt.Errorf("invalid power cap %q: %w", s, err)
+	}
+	return &watts, nil
+}
+
+// validBootDevices are the bmclib boot-device names BootDeviceSet accepts.
+var validBootDevices = []string{
+	"bios", "cdrom", "diag", "floppy", "disk", "none",
+	"pxe", "remote_drive", "sd_card", "usb", "utilities",
+}
+
+// normalizeBootDevice validates the -bootdev value against the bmclib set,
+// mapping the common -vmedia-kind aliases (CD/DVD/USBStick) so users who reuse
+// the virtual-media vocabulary get a working boot device instead of the opaque
+// "invalid boot device" error from the wrapper.
+func normalizeBootDevice(s string) (string, error) {
+	d := strings.ToLower(strings.TrimSpace(s))
+	switch d {
+	case "cd", "dvd", "cdrom":
+		return "cdrom", nil
+	case "usbstick", "usb":
+		return "usb", nil
+	case "hdd", "harddisk":
+		return "disk", nil
+	}
+	for _, v := range validBootDevices {
+		if d == v {
+			return d, nil
+		}
+	}
+	return "", fmt.Errorf("invalid boot device %q; valid: %s", s, strings.Join(validBootDevices, " "))
+}

--- a/option.go
+++ b/option.go
@@ -153,6 +153,32 @@ func WithDellRedfishUseBasicAuth(useBasicAuth bool) Option {
 	}
 }
 
+// WithLenovoPort sets the port for the Lenovo XCC (redfish) provider.
+func WithLenovoPort(port string) Option {
+	return func(args *Client) {
+		args.providerConfig.lenovo.Port = port
+	}
+}
+
+// WithLenovoUseBasicAuth sets HTTP Basic auth (instead of session login) for the
+// Lenovo XCC provider.
+func WithLenovoUseBasicAuth(useBasicAuth bool) Option {
+	return func(args *Client) {
+		args.providerConfig.lenovo.UseBasicAuth = useBasicAuth
+	}
+}
+
+// WithLenovoVersionsNotCompatible sets the list of incompatible redfish versions
+// for the Lenovo XCC provider.
+//
+// With this option set, the bmclib.Registry.FilterForCompatible(ctx) method will
+// not proceed on devices with the given redfish version(s).
+func WithLenovoVersionsNotCompatible(versions []string) Option {
+	return func(args *Client) {
+		args.providerConfig.lenovo.VersionsNotCompatible = append(args.providerConfig.lenovo.VersionsNotCompatible, versions...)
+	}
+}
+
 func WithRPCOpt(opt rpc.Provider) Option {
 	return func(args *Client) {
 		args.providerConfig.rpc = opt

--- a/providers/lenovo/accounts_test.go
+++ b/providers/lenovo/accounts_test.go
@@ -1,0 +1,150 @@
+package lenovo
+
+import (
+	"context"
+	"testing"
+)
+
+// Requirement: Read accounts.
+func TestUserRead(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	users, err := c.UserRead(context.Background())
+	if err != nil {
+		t.Fatalf("UserRead: %v", err)
+	}
+	// Only the named account (USERID) is returned; the empty slot is skipped.
+	if len(users) != 1 {
+		t.Fatalf("got %d users, want 1", len(users))
+	}
+	if users[0]["Username"] != "USERID" || users[0]["RoleID"] != "Administrator" {
+		t.Errorf("unexpected user: %+v", users[0])
+	}
+}
+
+// Requirement: Create account — via POST.
+func TestUserCreatePost(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	ok, err := c.UserCreate(context.Background(), "ops", "secret123", "Operator")
+	if err != nil || !ok {
+		t.Fatalf("UserCreate = (%v, %v), want (true, nil)", ok, err)
+	}
+	if !ts.didPostAccount() {
+		t.Error("expected an account POST")
+	}
+}
+
+// Requirement: Create account — Purley PATCH fallback.
+func TestUserCreatePurleyFallback(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{rejectAccountPost: true})
+	c := ts.openedClient(t)
+
+	ok, err := c.UserCreate(context.Background(), "ops", "secret123", "Operator")
+	if err != nil || !ok {
+		t.Fatalf("UserCreate (fallback) = (%v, %v), want (true, nil)", ok, err)
+	}
+	if !ts.didPatchAccount() {
+		t.Error("expected a slot PATCH fallback when POST is rejected")
+	}
+}
+
+// Requirement: Create account — duplicate username errors.
+func TestUserCreateDuplicate(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if _, err := c.UserCreate(context.Background(), "USERID", "secret123", "Administrator"); err == nil {
+		t.Fatal("expected an error creating a duplicate username")
+	}
+}
+
+// Requirement: Create account — missing params error.
+func TestUserCreateMissingParams(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if _, err := c.UserCreate(context.Background(), "ops", "", "Operator"); err == nil {
+		t.Fatal("expected an error when the password is empty")
+	}
+}
+
+// Requirement: Update account — change a user's role.
+func TestUserUpdate(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	ok, err := c.UserUpdate(context.Background(), "USERID", "", "Operator")
+	if err != nil || !ok {
+		t.Fatalf("UserUpdate = (%v, %v), want (true, nil)", ok, err)
+	}
+	if !ts.didPatchAccount() {
+		t.Error("expected the matching account to be PATCHed")
+	}
+}
+
+// Requirement: Update account — unknown user errors.
+func TestUserUpdateUnknown(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if _, err := c.UserUpdate(context.Background(), "ghost", "x", "Operator"); err == nil {
+		t.Fatal("expected an error updating an unknown user")
+	}
+}
+
+// Requirement: Delete account.
+func TestUserDelete(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	ok, err := c.UserDelete(context.Background(), "USERID")
+	if err != nil || !ok {
+		t.Fatalf("UserDelete = (%v, %v), want (true, nil)", ok, err)
+	}
+	if !ts.didPatchAccount() {
+		t.Error("expected the account slot to be cleared via PATCH")
+	}
+}
+
+// Requirement: Custom role and account-service management — read roles.
+func TestRoles(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	roles, err := c.Roles(context.Background())
+	if err != nil {
+		t.Fatalf("Roles: %v", err)
+	}
+	if len(roles) != 2 {
+		t.Fatalf("got %d roles, want 2", len(roles))
+	}
+	var admin *RoleInfo
+	for i := range roles {
+		if roles[i].ID == "Administrator" {
+			admin = &roles[i]
+		}
+	}
+	if admin == nil {
+		t.Fatal("Administrator role not found")
+	}
+	if len(admin.Privileges) == 0 || !admin.Predefined {
+		t.Errorf("unexpected Administrator role: %+v", admin)
+	}
+}
+
+// Requirement: Custom role and account-service management — create a custom role.
+func TestRoleCreate(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	err := c.RoleCreate(context.Background(), "CustomOps", []string{"Login", "ConfigureComponents"})
+	if err != nil {
+		t.Fatalf("RoleCreate: %v", err)
+	}
+	if !ts.didPostRole() {
+		t.Error("expected a POST to the roles collection")
+	}
+}

--- a/providers/lenovo/bios.go
+++ b/providers/lenovo/bios.go
@@ -1,0 +1,60 @@
+package lenovo
+
+import (
+	"context"
+
+	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
+	"github.com/stmcginnis/gofish/schemas"
+)
+
+// GetBiosConfiguration returns the current BIOS attributes as a key/value map,
+// read from the ComputerSystem Bios resource Attributes.
+//
+// Implements bmc.BiosConfigurationGetter.
+func (c *Conn) GetBiosConfiguration(ctx context.Context) (biosConfig map[string]string, err error) {
+	return c.redfishwrapper.GetBiosConfiguration(ctx)
+}
+
+// SetBiosConfiguration writes pending BIOS attributes, staged for the next host
+// reset.
+//
+// This is an XCC-specific override of the shared
+// redfishwrapper.SetBiosConfiguration. The wrapper PATCHes the settings target
+// with an "@Redfish.SettingsApplyTime" annotation (gofish
+// UpdateBiosAttributesApplyAt with OnReset), but the XCC BIOS settings resource
+// rejects that property — it returns Base.1.11.PropertyUnknown for both
+// "@Redfish.SettingsApplyTime" and "ApplyTime" and fails the whole request.
+// XCC stages BIOS changes for the next reset implicitly, so this override
+// PATCHes "Attributes" only (gofish UpdateBiosAttributes, no apply-time), while
+// still GETting the settings target first so gofish supplies the If-Match etag.
+//
+// Implements bmc.BiosConfigurationSetter.
+func (c *Conn) SetBiosConfiguration(ctx context.Context, biosConfig map[string]string) (err error) {
+	sys, err := c.redfishwrapper.System()
+	if err != nil {
+		return err
+	}
+
+	bios, err := sys.Bios()
+	if err != nil {
+		return err
+	}
+	if bios == nil {
+		return bmclibErrs.ErrNoBiosAttributes
+	}
+
+	settingsAttributes := make(schemas.SettingsAttributes, len(biosConfig))
+	for attr, value := range biosConfig {
+		settingsAttributes[attr] = value
+	}
+
+	return bios.UpdateBiosAttributes(settingsAttributes)
+}
+
+// ResetBiosConfiguration restores BIOS settings to their default values via the
+// Bios.ResetBios action.
+//
+// Implements bmc.BiosConfigurationResetter.
+func (c *Conn) ResetBiosConfiguration(ctx context.Context) (err error) {
+	return c.redfishwrapper.ResetBiosConfiguration(ctx)
+}

--- a/providers/lenovo/bmc.go
+++ b/providers/lenovo/bmc.go
@@ -1,0 +1,54 @@
+package lenovo
+
+import (
+	"context"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+// compile-time assertion that the provider implements the interface.
+var _ bmc.BMCResetter = (*Conn)(nil)
+
+// BmcReset restarts the BMC via the Manager.Reset action.
+//
+// resetType is a Redfish ResetType, typically "GracefulRestart" or
+// "ForceRestart". Implements bmc.BMCResetter.
+func (c *Conn) BmcReset(ctx context.Context, resetType string) (ok bool, err error) {
+	return c.redfishwrapper.BMCReset(ctx, resetType)
+}
+
+// ResetToFactoryDefaults resets the BMC to its factory defaults via the
+// Manager.ResetToDefaults action.
+//
+// resetType is a Redfish ResetToDefaultsType, e.g. "ResetAll",
+// "PreserveNetworkAndUsers" or "PreserveNetwork". This is destructive and
+// disconnects the session. It is an XCC-specific provider method (the
+// bmc.BMCResetter interface only covers Manager.Reset).
+func (c *Conn) ResetToFactoryDefaults(ctx context.Context, resetType string) error {
+	manager, err := c.redfishwrapper.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	if resetType == "" {
+		resetType = "ResetAll"
+	}
+
+	target := singleTrailingSlashJoin(manager.ODataID, "Actions/Manager.ResetToDefaults")
+	payload := map[string]any{"ResetType": resetType}
+
+	return checkResponse(c.redfishwrapper.PostWithHeaders(ctx, target, payload, nil))
+}
+
+// UpdateManager PATCHes Manager properties (e.g. the OEM time zone and other
+// OEM fields).
+//
+// This is an XCC-specific provider method.
+func (c *Conn) UpdateManager(ctx context.Context, properties map[string]any) error {
+	manager, err := c.redfishwrapper.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	return checkResponse(c.redfishwrapper.PatchWithHeaders(ctx, manager.ODataID, properties, nil))
+}

--- a/providers/lenovo/bmc_management_test.go
+++ b/providers/lenovo/bmc_management_test.go
@@ -1,0 +1,124 @@
+package lenovo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+// Requirement: BMC reset.
+func TestBmcReset(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	ok, err := c.BmcReset(context.Background(), "GracefulRestart")
+	if err != nil || !ok {
+		t.Fatalf("BmcReset = (%v, %v), want (true, nil)", ok, err)
+	}
+	if !ts.didBmcReset() {
+		t.Error("expected a Manager.Reset action")
+	}
+}
+
+// Requirement: Reset to factory defaults.
+func TestResetToFactoryDefaults(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if err := c.ResetToFactoryDefaults(context.Background(), "ResetAll"); err != nil {
+		t.Fatalf("ResetToFactoryDefaults: %v", err)
+	}
+	if !ts.didFactoryReset() {
+		t.Error("expected a Manager.ResetToDefaults action")
+	}
+}
+
+// Requirement: License management — read installed licenses.
+func TestLicenses(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	licenses, err := c.Licenses(context.Background())
+	if err != nil {
+		t.Fatalf("Licenses: %v", err)
+	}
+	if len(licenses) != 1 {
+		t.Fatalf("got %d licenses, want 1", len(licenses))
+	}
+	if licenses[0].ID != "XCC_Advanced" || licenses[0].LicenseType != "Production" || !licenses[0].Removable {
+		t.Errorf("unexpected license: %+v", licenses[0])
+	}
+}
+
+// Requirement: License management — an absent LicenseService (404 on firmware
+// levels without it) is reported as "no licenses", not an error.
+func TestLicensesNotFound(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{licenseServiceNotFound: true})
+	c := ts.openedClient(t)
+
+	licenses, err := c.Licenses(context.Background())
+	if err != nil {
+		t.Fatalf("Licenses on a box without LicenseService should not error, got: %v", err)
+	}
+	if len(licenses) != 0 {
+		t.Fatalf("got %d licenses, want 0", len(licenses))
+	}
+}
+
+// Requirement: License management — install a license.
+func TestLicenseInstall(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if err := c.LicenseInstall(context.Background(), "QUJDREVGRw=="); err != nil {
+		t.Fatalf("LicenseInstall: %v", err)
+	}
+	if !ts.didInstallLicense() {
+		t.Error("expected a POST to the License collection")
+	}
+}
+
+// Requirement: License management — delete a license.
+func TestLicenseDelete(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if err := c.LicenseDelete(context.Background(), "XCC_Advanced"); err != nil {
+		t.Fatalf("LicenseDelete: %v", err)
+	}
+	if !ts.didDeleteLicense() {
+		t.Error("expected a DELETE of the license")
+	}
+}
+
+// Requirement: Secure Key Lifecycle — read properties.
+func TestGetSecureKeyLifecycle(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	cfg, err := c.GetSecureKeyLifecycle(context.Background())
+	if err != nil {
+		t.Fatalf("GetSecureKeyLifecycle: %v", err)
+	}
+	if cfg.DeviceGroup != "TKLM_DEV_GROUP" {
+		t.Errorf("DeviceGroup = %q, want %q", cfg.DeviceGroup, "TKLM_DEV_GROUP")
+	}
+	if len(cfg.KeyRepoServers) != 2 || cfg.KeyRepoServers[0].Port != 5696 {
+		t.Errorf("unexpected key repo servers: %+v", cfg.KeyRepoServers)
+	}
+}
+
+// Requirement: Secure Key Lifecycle — update key servers.
+func TestSetSecureKeyRepoServers(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	servers := []bmc.SecureKeyRepoServer{{HostName: "10.0.0.20", Port: 5696}}
+	if err := c.SetSecureKeyRepoServers(context.Background(), servers); err != nil {
+		t.Fatalf("SetSecureKeyRepoServers: %v", err)
+	}
+	if !ts.didPatchSKLM() {
+		t.Error("expected a PATCH of the SecureKeyLifecycleService")
+	}
+}

--- a/providers/lenovo/boot.go
+++ b/providers/lenovo/boot.go
@@ -1,0 +1,92 @@
+package lenovo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+	"github.com/stmcginnis/gofish/schemas"
+)
+
+// BootDeviceSet sets the next boot device by writing the ComputerSystem Boot
+// override.
+//
+// bootDevice is a bmclib boot-device name (e.g. "pxe", "disk", "cdrom",
+// "bios"). setPersistent selects BootSourceOverrideEnabled "Continuous" when
+// true and "Once" otherwise; efiBoot selects BootSourceOverrideMode "UEFI" when
+// true and "Legacy" otherwise. Implements bmc.BootDeviceSetter.
+//
+// XCC quirk: the BootSourceOverrideEnabled property typically advertises only
+// {Once, Disabled} — it rejects "Continuous" (a persistent override) with
+// PropertyValueNotInList. XCC expresses persistent boot through the BootOrder,
+// not the override. So when a persistent override is requested but the system
+// does not advertise "Continuous" as allowable, fail with an actionable error
+// instead of the opaque dual ("system resource"/"settings resource") 400 the
+// shared wrapper would surface.
+func (c *Conn) BootDeviceSet(ctx context.Context, bootDevice string, setPersistent, efiBoot bool) (ok bool, err error) {
+	if setPersistent && !c.bootOverrideAllowsContinuous(ctx) {
+		return false, fmt.Errorf(
+			"XCC does not support a persistent (Continuous) boot override on this system "+
+				"(BootSourceOverrideEnabled allows only Once/Disabled); use a one-time override "+
+				"(setPersistent=false) and manage persistent boot via the BootOrder: %w",
+			errPersistentBootUnsupported)
+	}
+	return c.redfishwrapper.SystemBootDeviceSet(ctx, bootDevice, setPersistent, efiBoot)
+}
+
+// bootOverrideAllowsContinuous reports whether the ComputerSystem advertises
+// "Continuous" among Boot.BootSourceOverrideEnabled@Redfish.AllowableValues.
+// When the system does not advertise the list at all (field absent), it returns
+// true so the write is still attempted (no regression on BMCs that accept
+// Continuous without advertising it).
+func (c *Conn) bootOverrideAllowsContinuous(ctx context.Context) bool {
+	sys, err := c.redfishwrapper.System()
+	if err != nil {
+		return true // can't tell — don't pre-empt the write
+	}
+
+	var doc struct {
+		Boot struct {
+			AllowableEnabled []string `json:"BootSourceOverrideEnabled@Redfish.AllowableValues"`
+		} `json:"Boot"`
+	}
+	if err := c.getJSON(sys.ODataID, &doc); err != nil {
+		return true
+	}
+
+	if len(doc.Boot.AllowableEnabled) == 0 {
+		return true // not advertised — let the write attempt proceed
+	}
+	for _, v := range doc.Boot.AllowableEnabled {
+		if v == "Continuous" {
+			return true
+		}
+	}
+	return false
+}
+
+// BootDeviceOverrideGet returns the current boot override (target, persistence,
+// UEFI/legacy mode) read from the ComputerSystem Boot object.
+//
+// Implements bmc.BootDeviceOverrideGetter.
+func (c *Conn) BootDeviceOverrideGet(ctx context.Context) (override bmc.BootDeviceOverride, err error) {
+	return c.redfishwrapper.GetBootDeviceOverride(ctx)
+}
+
+// GetBootProgress returns the BootProgress of the managed system.
+//
+// XCC reports BootProgress on the ComputerSystem (Redfish >= 1.13.0). Following
+// the convention of the other vendor providers, the first system's progress is
+// returned. Advertised via providers.FeatureBootProgress.
+func (c *Conn) GetBootProgress() (*schemas.BootProgress, error) {
+	progress, err := c.redfishwrapper.GetBootProgress()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(progress) == 0 {
+		return nil, fmt.Errorf("no boot progress reported by the device")
+	}
+
+	return progress[0], nil
+}

--- a/providers/lenovo/certificates.go
+++ b/providers/lenovo/certificates.go
@@ -1,0 +1,148 @@
+package lenovo
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+const (
+	certificateServiceURI   = "/redfish/v1/CertificateService"
+	certificateLocationsURI = certificateServiceURI + "/CertificateLocations"
+	generateCSRURI          = certificateServiceURI + "/Actions/CertificateService.GenerateCSR"
+	replaceCertificateURI   = certificateServiceURI + "/Actions/CertificateService.ReplaceCertificate"
+	// defaultCertificateCollection is the XCC BMC HTTPS certificate collection.
+	defaultCertificateCollection = "/redfish/v1/Managers/1/NetworkProtocol/HTTPS/Certificates"
+)
+
+// compile-time assertion that the provider implements the interface.
+var _ bmc.CertificateManager = (*Conn)(nil)
+
+// CertificateLocations returns the @odata.id locations of installed certificates.
+//
+// Implements bmc.CertificateManager.
+func (c *Conn) CertificateLocations(ctx context.Context) ([]string, error) {
+	var doc struct {
+		Links struct {
+			Certificates []odataID `json:"Certificates"`
+		} `json:"Links"`
+	}
+	if err := c.getJSON(certificateLocationsURI, &doc); err != nil {
+		return nil, err
+	}
+
+	out := make([]string, 0, len(doc.Links.Certificates))
+	for _, cert := range doc.Links.Certificates {
+		out = append(out, cert.ODataID)
+	}
+
+	return out, nil
+}
+
+// Certificate returns a certificate's properties by its @odata.id location.
+//
+// Implements bmc.CertificateManager.
+func (c *Conn) Certificate(ctx context.Context, location string) (bmc.CertificateInfo, error) {
+	var doc struct {
+		ID      string `json:"Id"`
+		Subject struct {
+			CommonName string `json:"CommonName"`
+		} `json:"Subject"`
+		Issuer struct {
+			CommonName string `json:"CommonName"`
+		} `json:"Issuer"`
+		ValidNotBefore string `json:"ValidNotBefore"`
+		ValidNotAfter  string `json:"ValidNotAfter"`
+	}
+	if err := c.getJSON(location, &doc); err != nil {
+		return bmc.CertificateInfo{}, err
+	}
+
+	return bmc.CertificateInfo{
+		ID:                doc.ID,
+		SubjectCommonName: doc.Subject.CommonName,
+		IssuerCommonName:  doc.Issuer.CommonName,
+		ValidNotBefore:    doc.ValidNotBefore,
+		ValidNotAfter:     doc.ValidNotAfter,
+	}, nil
+}
+
+// GenerateCSR generates a CSR via CertificateService.GenerateCSR and returns the
+// PEM CSR string.
+//
+// Implements bmc.CertificateManager.
+func (c *Conn) GenerateCSR(ctx context.Context, req bmc.CSRRequest) (string, error) {
+	collection := req.CertificateCollection
+	if collection == "" {
+		collection = defaultCertificateCollection
+	}
+
+	payload := map[string]any{
+		"CommonName":            req.CommonName,
+		"CertificateCollection": map[string]string{"@odata.id": collection},
+	}
+	addIfSet(payload, "Country", req.Country)
+	addIfSet(payload, "State", req.State)
+	addIfSet(payload, "City", req.City)
+	addIfSet(payload, "Organization", req.Organization)
+	addIfSet(payload, "OrganizationalUnit", req.OrganizationalUnit)
+	addIfSet(payload, "Email", req.Email)
+
+	resp, err := c.redfishwrapper.PostWithHeaders(ctx, generateCSRURI, payload, nil)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", parseRedfishError(resp)
+	}
+
+	var out struct {
+		CSRString string `json:"CSRString"`
+	}
+	if err := decodeJSONBody(resp, &out); err != nil {
+		return "", err
+	}
+
+	return out.CSRString, nil
+}
+
+// ReplaceCertificate replaces the certificate at targetURI with the given PEM.
+//
+// Implements bmc.CertificateManager.
+func (c *Conn) ReplaceCertificate(ctx context.Context, certificatePEM, targetURI string) error {
+	payload := map[string]any{
+		"CertificateString": certificatePEM,
+		"CertificateType":   "PEM",
+		"CertificateUri":    map[string]string{"@odata.id": targetURI},
+	}
+
+	return checkResponse(c.redfishwrapper.PostWithHeaders(ctx, replaceCertificateURI, payload, nil))
+}
+
+// RekeyCertificate generates a new key pair and CSR for the certificate at
+// certURI via Certificate.Rekey.
+//
+// Implements bmc.CertificateManager.
+func (c *Conn) RekeyCertificate(ctx context.Context, certURI string) error {
+	target := singleTrailingSlashJoin(certURI, "Actions/Certificate.Rekey")
+	return checkResponse(c.redfishwrapper.PostWithHeaders(ctx, target, map[string]any{}, nil))
+}
+
+// RenewCertificate generates a CSR using the existing key for the certificate at
+// certURI via Certificate.Renew.
+//
+// Implements bmc.CertificateManager.
+func (c *Conn) RenewCertificate(ctx context.Context, certURI string) error {
+	target := singleTrailingSlashJoin(certURI, "Actions/Certificate.Renew")
+	return checkResponse(c.redfishwrapper.PostWithHeaders(ctx, target, map[string]any{}, nil))
+}
+
+// addIfSet adds k=v to m when v is non-empty.
+func addIfSet(m map[string]any, k, v string) {
+	if v != "" {
+		m[k] = v
+	}
+}

--- a/providers/lenovo/errors.go
+++ b/providers/lenovo/errors.go
@@ -1,0 +1,125 @@
+package lenovo
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/stmcginnis/gofish/schemas"
+)
+
+// errFailedToParseResponse is returned when a response body could not be read
+// or decoded.
+var errFailedToParseResponse = errors.New("failed to parse XCC response")
+
+// errResourceNotFound wraps a 404 response so callers can distinguish an absent
+// resource (e.g. an OEM service a given XCC firmware level does not expose) from
+// other failures via errors.Is.
+var errResourceNotFound = errors.New("resource not found")
+
+// errPersistentBootUnsupported is returned when a persistent (Continuous) boot
+// override is requested but the XCC only allows a one-time (Once) override.
+var errPersistentBootUnsupported = errors.New("persistent boot override unsupported")
+
+// isNotFound reports whether err is a gofish HTTP error carrying a 404 status.
+// gofish surfaces non-2xx responses as a *schemas.Error before redfishwrapper
+// hands the response back, so a 404 arrives as an error rather than a response.
+func isNotFound(err error) bool {
+	var re *schemas.Error
+	if errors.As(err, &re) {
+		return re.HTTPReturnedStatusCode == http.StatusNotFound
+	}
+	return false
+}
+
+// checkResponse closes resp.Body and returns an error if the request errored or
+// the response was not a 2xx status. It is used by the raw PATCH/POST paths that
+// drop below gofish for XCC OEM operations.
+func checkResponse(resp *http.Response, err error) error {
+	if err != nil {
+		return err
+	}
+	if resp == nil {
+		return errFailedToParseResponse
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return parseRedfishError(resp)
+	}
+
+	return nil
+}
+
+// parseRedfishError converts a non-2xx XCC Redfish HTTP response into an error.
+//
+// When the body carries the standard Redfish error envelope, the returned error
+// includes the registry message id, the message text and (for Lenovo OEM
+// "ExtendedError" messages) the suggested resolution, so callers get an
+// actionable message rather than a bare status code. The caller is responsible
+// for closing resp.Body.
+func parseRedfishError(resp *http.Response) error {
+	if resp == nil {
+		return errFailedToParseResponse
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("%w: %d: %v", errFailedToParseResponse, resp.StatusCode, err)
+	}
+
+	detail := redfishErrorDetail(body)
+	if detail == "" {
+		// No parseable Redfish envelope — fall back to status + raw body.
+		detail = strings.TrimSpace(string(body))
+	}
+
+	if detail == "" {
+		return fmt.Errorf("unexpected XCC response: HTTP %d", resp.StatusCode)
+	}
+
+	return fmt.Errorf("unexpected XCC response: HTTP %d: %s", resp.StatusCode, detail)
+}
+
+// redfishErrorDetail extracts a human-readable detail string from a Redfish
+// error body. It returns an empty string when the body is not a recognisable
+// Redfish error envelope.
+func redfishErrorDetail(body []byte) string {
+	var re redfishError
+	if err := json.Unmarshal(body, &re); err != nil {
+		return ""
+	}
+
+	// Prefer the most specific extended-info entry (XCC OEM messages live here).
+	for _, info := range re.Error.ExtendedInfo {
+		parts := make([]string, 0, 3)
+		if info.MessageID != "" {
+			parts = append(parts, info.MessageID)
+		}
+		if info.Message != "" {
+			parts = append(parts, info.Message)
+		}
+		if info.Resolution != "" && info.Resolution != "None" {
+			parts = append(parts, "resolution: "+info.Resolution)
+		}
+
+		if len(parts) > 0 {
+			return strings.Join(parts, ": ")
+		}
+	}
+
+	// Fall back to the top-level code/message.
+	switch {
+	case re.Error.Code != "" && re.Error.Message != "":
+		return re.Error.Code + ": " + re.Error.Message
+	case re.Error.Message != "":
+		return re.Error.Message
+	case re.Error.Code != "":
+		return re.Error.Code
+	default:
+		return ""
+	}
+}

--- a/providers/lenovo/events.go
+++ b/providers/lenovo/events.go
@@ -1,0 +1,135 @@
+package lenovo
+
+import (
+	"context"
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+const (
+	eventServiceURI       = "/redfish/v1/EventService"
+	eventSubscriptionsURI = eventServiceURI + "/Subscriptions"
+	submitTestEventURI    = eventServiceURI + "/Actions/EventService.SubmitTestEvent"
+)
+
+// compile-time assertion that the provider implements the interface.
+var _ bmc.EventSubscriber = (*Conn)(nil)
+
+// EventService returns the XCC event-service configuration.
+//
+// Implements bmc.EventSubscriber.
+func (c *Conn) EventService(ctx context.Context) (bmc.EventServiceInfo, error) {
+	var doc struct {
+		ServiceEnabled               bool   `json:"ServiceEnabled"`
+		DeliveryRetryAttempts        int    `json:"DeliveryRetryAttempts"`
+		DeliveryRetryIntervalSeconds int    `json:"DeliveryRetryIntervalSeconds"`
+		ServerSentEventURI           string `json:"ServerSentEventUri"`
+	}
+	if err := c.getJSON(eventServiceURI, &doc); err != nil {
+		return bmc.EventServiceInfo{}, err
+	}
+
+	return bmc.EventServiceInfo{
+		ServiceEnabled:               doc.ServiceEnabled,
+		DeliveryRetryAttempts:        doc.DeliveryRetryAttempts,
+		DeliveryRetryIntervalSeconds: doc.DeliveryRetryIntervalSeconds,
+		SSEFilterURI:                 doc.ServerSentEventURI,
+	}, nil
+}
+
+// EventSubscriptions lists the XCC event subscriptions.
+//
+// Implements bmc.EventSubscriber.
+func (c *Conn) EventSubscriptions(ctx context.Context) ([]bmc.EventSubscription, error) {
+	members, err := c.collectionMembers(eventSubscriptionsURI)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]bmc.EventSubscription, 0, len(members))
+	for _, m := range members {
+		var sub struct {
+			ID          string `json:"Id"`
+			Destination string `json:"Destination"`
+			Protocol    string `json:"Protocol"`
+			Context     string `json:"Context"`
+		}
+		if err := c.getJSON(m.ODataID, &sub); err != nil {
+			return nil, err
+		}
+		out = append(out, bmc.EventSubscription{
+			ID:          sub.ID,
+			Destination: sub.Destination,
+			Protocol:    sub.Protocol,
+			Context:     sub.Context,
+		})
+	}
+
+	return out, nil
+}
+
+// EventSubscriptionCreate creates a subscription and returns its Id.
+//
+// Implements bmc.EventSubscriber.
+func (c *Conn) EventSubscriptionCreate(ctx context.Context, req bmc.EventSubscriptionRequest) (string, error) {
+	protocol := req.Protocol
+	if protocol == "" {
+		protocol = "Redfish"
+	}
+
+	payload := map[string]any{
+		"Destination": req.Destination,
+		"Protocol":    protocol,
+	}
+	if req.Context != "" {
+		payload["Context"] = req.Context
+	}
+	if len(req.RegistryPrefixes) > 0 {
+		payload["RegistryPrefixes"] = req.RegistryPrefixes
+	}
+
+	resp, err := c.redfishwrapper.PostWithHeaders(ctx, eventSubscriptionsURI, payload, nil)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", parseRedfishError(resp)
+	}
+
+	if loc := resp.Header.Get("Location"); loc != "" {
+		return path.Base(strings.TrimRight(loc, "/")), nil
+	}
+
+	return "", nil
+}
+
+// EventSubscriptionDelete deletes a subscription by Id.
+//
+// Implements bmc.EventSubscriber.
+func (c *Conn) EventSubscriptionDelete(ctx context.Context, id string) error {
+	return checkResponse(c.redfishwrapper.Delete(singleTrailingSlashJoin(eventSubscriptionsURI, id)))
+}
+
+// SubmitTestEvent submits a test event via EventService.SubmitTestEvent.
+//
+// Implements bmc.EventSubscriber.
+func (c *Conn) SubmitTestEvent(ctx context.Context, messageID string) error {
+	payload := map[string]any{}
+	if messageID != "" {
+		payload["MessageId"] = messageID
+	}
+
+	return checkResponse(c.redfishwrapper.PostWithHeaders(ctx, submitTestEventURI, payload, nil))
+}
+
+// SetEventService PATCHes the event-service properties.
+//
+// Implements bmc.EventSubscriber.
+func (c *Conn) SetEventService(ctx context.Context, attrs map[string]any) error {
+	return checkResponse(c.redfishwrapper.PatchWithHeaders(ctx, eventServiceURI, attrs, nil))
+}

--- a/providers/lenovo/events_telemetry_test.go
+++ b/providers/lenovo/events_telemetry_test.go
@@ -1,0 +1,164 @@
+package lenovo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+// Requirement: Read event service.
+func TestEventService(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	info, err := c.EventService(context.Background())
+	if err != nil {
+		t.Fatalf("EventService: %v", err)
+	}
+	if !info.ServiceEnabled || info.DeliveryRetryAttempts != 3 {
+		t.Errorf("unexpected event service: %+v", info)
+	}
+	if info.SSEFilterURI == "" {
+		t.Error("expected an SSE URI")
+	}
+}
+
+// Requirement: List subscriptions.
+func TestEventSubscriptions(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	subs, err := c.EventSubscriptions(context.Background())
+	if err != nil {
+		t.Fatalf("EventSubscriptions: %v", err)
+	}
+	if len(subs) != 1 || subs[0].Destination == "" {
+		t.Fatalf("unexpected subscriptions: %+v", subs)
+	}
+}
+
+// Requirement: Create a webhook subscription.
+func TestEventSubscriptionCreate(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	id, err := c.EventSubscriptionCreate(context.Background(), bmc.EventSubscriptionRequest{
+		Destination: "https://listener.example.com/hook",
+		Context:     "ctx",
+	})
+	if err != nil {
+		t.Fatalf("EventSubscriptionCreate: %v", err)
+	}
+	if id != "2" {
+		t.Errorf("subscription id = %q, want %q", id, "2")
+	}
+	if !ts.didCreateSubscription() {
+		t.Error("expected a POST to the subscriptions collection")
+	}
+}
+
+// Requirement: Delete a subscription.
+func TestEventSubscriptionDelete(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if err := c.EventSubscriptionDelete(context.Background(), "1"); err != nil {
+		t.Fatalf("EventSubscriptionDelete: %v", err)
+	}
+	if !ts.didDeleteSubscription() {
+		t.Error("expected a DELETE of the subscription")
+	}
+}
+
+// Requirement: Submit a test event.
+func TestSubmitTestEvent(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if err := c.SubmitTestEvent(context.Background(), "Base.1.0.TestMessage"); err != nil {
+		t.Fatalf("SubmitTestEvent: %v", err)
+	}
+	if !ts.didSubmitTestEvent() {
+		t.Error("expected a SubmitTestEvent action")
+	}
+}
+
+// Requirement: Configure event service.
+func TestSetEventService(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if err := c.SetEventService(context.Background(), map[string]any{"DeliveryRetryAttempts": 5}); err != nil {
+		t.Fatalf("SetEventService: %v", err)
+	}
+	if !ts.didPatchEventService() {
+		t.Error("expected a PATCH of the EventService")
+	}
+}
+
+// Requirement: Read telemetry service.
+func TestTelemetryService(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	info, err := c.TelemetryService(context.Background())
+	if err != nil {
+		t.Fatalf("TelemetryService: %v", err)
+	}
+	if !info.ServiceEnabled || info.MaxReports != 10 {
+		t.Errorf("unexpected telemetry service: %+v", info)
+	}
+}
+
+// Requirement: Read a metric report.
+func TestMetricReport(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	ids, err := c.MetricReports(context.Background())
+	if err != nil {
+		t.Fatalf("MetricReports: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "PowerMetrics" {
+		t.Fatalf("unexpected report ids: %v", ids)
+	}
+
+	report, err := c.MetricReport(context.Background(), "PowerMetrics")
+	if err != nil {
+		t.Fatalf("MetricReport: %v", err)
+	}
+	// XCC identifies each reading by MetricProperty (MetricId is typically empty).
+	if len(report.Values) != 2 ||
+		report.Values[0].MetricProperty != "/redfish/v1/Chassis/1/Power#/PowerControl/0/PowerMetrics/MaxConsumedWatts" ||
+		report.Values[0].Value != "287" {
+		t.Errorf("unexpected report values: %+v", report.Values)
+	}
+}
+
+// Requirement: List metric definitions.
+func TestMetricDefinitions(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	defs, err := c.MetricDefinitions(context.Background())
+	if err != nil {
+		t.Fatalf("MetricDefinitions: %v", err)
+	}
+	if len(defs) != 2 {
+		t.Fatalf("got %d metric definitions, want 2", len(defs))
+	}
+}
+
+// Requirement: Submit a test metric report.
+func TestSubmitTestMetricReport(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if err := c.SubmitTestMetricReport(context.Background(), "PowerMetrics"); err != nil {
+		t.Fatalf("SubmitTestMetricReport: %v", err)
+	}
+	if !ts.didSubmitTestMetric() {
+		t.Error("expected a SubmitTestMetricReport action")
+	}
+}

--- a/providers/lenovo/firmware.go
+++ b/providers/lenovo/firmware.go
@@ -1,0 +1,175 @@
+package lenovo
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+	"github.com/bmc-toolbox/bmclib/v2/constants"
+)
+
+// simpleUpdateURI is the XCC UpdateService.SimpleUpdate action.
+const simpleUpdateURI = "/redfish/v1/UpdateService/Actions/UpdateService.SimpleUpdate"
+
+// compile-time assertions that the provider implements the firmware interfaces.
+var (
+	_ bmc.FirmwareInstaller          = (*Conn)(nil)
+	_ bmc.FirmwareUploader           = (*Conn)(nil)
+	_ bmc.FirmwareInstallerUploaded  = (*Conn)(nil)
+	_ bmc.FirmwareInstallProvider    = (*Conn)(nil)
+	_ bmc.FirmwareInstallVerifier    = (*Conn)(nil)
+	_ bmc.FirmwareTaskVerifier       = (*Conn)(nil)
+	_ bmc.FirmwareInstallStepsGetter = (*Conn)(nil)
+)
+
+// FirmwareInstall uploads a firmware image and initiates the install in a single
+// step using the XCC push protocol, returning the install task id.
+//
+// component is the XCC FirmwareInventory target id (e.g. "BMC-Backup", "UEFI")
+// or empty to let the XCC auto-detect the target from the image.
+// operationApplyTime is one of the bmclib OperationApplyTime values (defaults to
+// Immediate). Implements bmc.FirmwareInstaller.
+func (c *Conn) FirmwareInstall(ctx context.Context, component, operationApplyTime string, forceInstall bool, reader io.Reader) (taskID string, err error) {
+	file, cleanup, err := tempFileFromReader(reader)
+	if err != nil {
+		return "", err
+	}
+	defer cleanup()
+
+	return c.pushFirmware(ctx, component, file, operationApplyTimeOrDefault(operationApplyTime))
+}
+
+// FirmwareInstallUploadAndInitiate uploads a firmware image and initiates the
+// install in a single step, returning the task id.
+//
+// Implements bmc.FirmwareInstallProvider.
+func (c *Conn) FirmwareInstallUploadAndInitiate(ctx context.Context, component string, file *os.File) (taskID string, err error) {
+	return c.pushFirmware(ctx, component, file, constants.Immediate)
+}
+
+// FirmwareUpload uploads a firmware image, returning the upload/verify task id.
+//
+// The image is pushed with OperationApplyTime "OnStartUpdateRequest" so the
+// install is started separately by FirmwareInstallUploaded. Implements
+// bmc.FirmwareUploader.
+func (c *Conn) FirmwareUpload(ctx context.Context, component string, file *os.File) (uploadVerifyTaskID string, err error) {
+	return c.pushFirmware(ctx, component, file, constants.OnStartUpdateRequest)
+}
+
+// FirmwareInstallUploaded starts the install for firmware previously uploaded
+// with FirmwareUpload, returning the install task id.
+//
+// Implements bmc.FirmwareInstallerUploaded.
+func (c *Conn) FirmwareInstallUploaded(ctx context.Context, component, uploadTaskID string) (installTaskID string, err error) {
+	return c.redfishwrapper.StartUpdateForUploadedFirmware(ctx)
+}
+
+// FirmwareInstallStatus returns the install status for the given task id.
+//
+// Implements bmc.FirmwareInstallVerifier.
+func (c *Conn) FirmwareInstallStatus(ctx context.Context, installVersion, component, taskID string) (status string, err error) {
+	state, _, err := c.firmwareTask(ctx, taskID)
+	if err != nil {
+		return "", err
+	}
+
+	return string(state), nil
+}
+
+// FirmwareTaskStatus returns the state and status of a firmware upload/install
+// task.
+//
+// The task is read from the Task resource — never the XCC TaskMonitor URI, since
+// a GET on TaskMonitor deletes a finished task. When the task reaches a terminal
+// state the update service claim is released. Implements bmc.FirmwareTaskVerifier.
+func (c *Conn) FirmwareTaskStatus(ctx context.Context, kind constants.FirmwareInstallStep, component, taskID, installVersion string) (state constants.TaskState, status string, err error) {
+	return c.firmwareTask(ctx, taskID)
+}
+
+// FirmwareInstallSteps returns the ordered steps the provider performs for a
+// firmware install: the XCC push uploads and initiates the install in one step,
+// followed by polling the install task.
+//
+// Implements bmc.FirmwareInstallStepsGetter.
+func (c *Conn) FirmwareInstallSteps(ctx context.Context, component string) ([]constants.FirmwareInstallStep, error) {
+	return []constants.FirmwareInstallStep{
+		constants.FirmwareInstallStepUploadInitiateInstall,
+		constants.FirmwareInstallStepInstallStatus,
+	}, nil
+}
+
+// SimpleUpdate triggers an UpdateService.SimpleUpdate where the XCC pulls the
+// image from imageURI itself, returning the created task id.
+//
+// transferProtocol is an optional Redfish TransferProtocol (e.g. "HTTPS",
+// "SFTP"); when empty it is inferred by the XCC from the URI scheme. This is an
+// XCC-specific provider method (not part of a bmc.Feature interface).
+func (c *Conn) SimpleUpdate(ctx context.Context, imageURI, transferProtocol string) (taskID string, err error) {
+	payload := map[string]any{"ImageURI": imageURI}
+	if transferProtocol != "" {
+		payload["TransferProtocol"] = transferProtocol
+	}
+
+	resp, err := c.redfishwrapper.PostWithHeaders(ctx, simpleUpdateURI, payload, nil)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", parseRedfishError(resp)
+	}
+
+	if loc := resp.Header.Get("Location"); loc != "" {
+		return path.Base(strings.TrimRight(loc, "/")), nil
+	}
+
+	return "", nil
+}
+
+// firmwareTask polls the Task resource for a firmware task and releases the
+// update service claim once the task reaches a terminal state.
+func (c *Conn) firmwareTask(ctx context.Context, taskID string) (constants.TaskState, string, error) {
+	state, status, err := c.redfishwrapper.TaskStatus(ctx, taskID)
+	if err != nil {
+		return "", "", err
+	}
+
+	if state == constants.Complete || state == constants.Failed {
+		// Best-effort release of the busy claim once the update is done.
+		_ = c.releaseUpdateService(ctx, true)
+	}
+
+	return state, status, nil
+}
+
+// tempFileFromReader writes reader to a temporary file and returns it positioned
+// at the start, along with a cleanup function that closes and removes it.
+func tempFileFromReader(reader io.Reader) (*os.File, func(), error) {
+	f, err := os.CreateTemp("", "lenovo-fw-*")
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("creating temp firmware file: %w", err)
+	}
+
+	cleanup := func() {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+	}
+
+	if _, err := io.Copy(f, reader); err != nil {
+		cleanup()
+		return nil, func() {}, fmt.Errorf("buffering firmware image: %w", err)
+	}
+
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		cleanup()
+		return nil, func() {}, fmt.Errorf("rewinding firmware image: %w", err)
+	}
+
+	return f, cleanup, nil
+}

--- a/providers/lenovo/firmware_push.go
+++ b/providers/lenovo/firmware_push.go
@@ -1,0 +1,143 @@
+package lenovo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/bmc-toolbox/bmclib/v2/constants"
+	"github.com/bmc-toolbox/bmclib/v2/internal/redfishwrapper"
+)
+
+const (
+	// updateServicePath is the XCC Redfish UpdateService resource.
+	updateServicePath = "/redfish/v1/UpdateService"
+	// firmwareInventoryBase is the base path for XCC firmware-inventory targets.
+	firmwareInventoryBase = "/redfish/v1/UpdateService/FirmwareInventory/"
+)
+
+// updateServiceDoc is a partial model of the XCC UpdateService used to drive the
+// firmware push protocol. Only the fields the protocol needs are modelled.
+type updateServiceDoc struct {
+	ServiceEnabled         bool   `json:"ServiceEnabled"`
+	HTTPPushURI            string `json:"HttpPushUri"`
+	MultipartHTTPPushURI   string `json:"MultipartHttpPushUri"`
+	HTTPPushURITargetsBusy bool   `json:"HttpPushUriTargetsBusy"`
+}
+
+// readUpdateService GETs and parses the XCC UpdateService.
+func (c *Conn) readUpdateService(ctx context.Context) (*updateServiceDoc, error) {
+	resp, err := c.redfishwrapper.Get(updateServicePath)
+	if err != nil {
+		return nil, fmt.Errorf("reading XCC update service: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, parseRedfishError(resp)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", errFailedToParseResponse, err)
+	}
+
+	doc := &updateServiceDoc{}
+	if err := json.Unmarshal(body, doc); err != nil {
+		return nil, fmt.Errorf("%w: %v", errFailedToParseResponse, err)
+	}
+
+	return doc, nil
+}
+
+// componentToTargets maps a component slug to the XCC FirmwareInventory
+// target(s) referenced by HttpPushUriTargets / UpdateParameters.Targets.
+//
+// An empty component yields no targets, letting the XCC auto-detect the target
+// from the firmware image. A component that already looks like a Redfish path is
+// used verbatim; otherwise it is treated as a FirmwareInventory member id (e.g.
+// "BMC-Backup", "UEFI").
+func componentToTargets(component string) []string {
+	switch {
+	case component == "":
+		return nil
+	case len(component) > 0 && component[0] == '/':
+		return []string{component}
+	default:
+		return []string{firmwareInventoryBase + component}
+	}
+}
+
+// claimUpdateService claims the XCC update service for a firmware push.
+//
+// Per the XCC protocol the client must verify HttpPushUriTargetsBusy is false,
+// then set it to true to claim the service (and set HttpPushUriTargets to the
+// component target(s)). It errors if the service is already busy.
+func (c *Conn) claimUpdateService(ctx context.Context, targets []string) error {
+	doc, err := c.readUpdateService(ctx)
+	if err != nil {
+		return err
+	}
+
+	if doc.HTTPPushURITargetsBusy {
+		return fmt.Errorf("XCC update service is busy (HttpPushUriTargetsBusy=true); another firmware update is in progress")
+	}
+
+	payload := map[string]any{"HttpPushUriTargetsBusy": true}
+	if len(targets) > 0 {
+		payload["HttpPushUriTargets"] = targets
+	}
+
+	return checkResponse(c.redfishwrapper.PatchWithHeaders(ctx, updateServicePath, payload, nil))
+}
+
+// releaseUpdateService releases the claim taken by claimUpdateService by setting
+// HttpPushUriTargetsBusy back to false. When clearTargets is true (e.g. for a
+// BMC backup target) it also clears HttpPushUriTargets.
+func (c *Conn) releaseUpdateService(ctx context.Context, clearTargets bool) error {
+	payload := map[string]any{"HttpPushUriTargetsBusy": false}
+	if clearTargets {
+		payload["HttpPushUriTargets"] = []string{}
+	}
+
+	return checkResponse(c.redfishwrapper.PatchWithHeaders(ctx, updateServicePath, payload, nil))
+}
+
+// pushFirmware runs the XCC push protocol: claim the service, push the image
+// (multipart to MultipartHttpPushUri, falling back to a raw push to HttpPushUri
+// — the selection is made by the underlying wrapper), and return the created
+// task id. On any error after the claim the service is released so the busy flag
+// is not leaked.
+func (c *Conn) pushFirmware(ctx context.Context, component string, file *os.File, applyTime constants.OperationApplyTime) (taskID string, err error) {
+	targets := componentToTargets(component)
+
+	if err := c.claimUpdateService(ctx, targets); err != nil {
+		return "", err
+	}
+
+	params := &redfishwrapper.RedfishUpdateServiceParameters{
+		Targets:            targets,
+		OperationApplyTime: applyTime,
+	}
+
+	taskID, err = c.redfishwrapper.FirmwareUpload(ctx, file, params)
+	if err != nil {
+		// Release the claim so a failed push does not leave the service busy.
+		_ = c.releaseUpdateService(ctx, len(targets) > 0)
+		return "", fmt.Errorf("xcc firmware push: %w", err)
+	}
+
+	return taskID, nil
+}
+
+// operationApplyTimeOrDefault converts the bmclib operationApplyTime string into
+// a constants.OperationApplyTime, defaulting to Immediate when empty.
+func operationApplyTimeOrDefault(s string) constants.OperationApplyTime {
+	if s == "" {
+		return constants.Immediate
+	}
+	return constants.OperationApplyTime(s)
+}

--- a/providers/lenovo/firmware_test.go
+++ b/providers/lenovo/firmware_test.go
@@ -1,0 +1,175 @@
+package lenovo
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bmc-toolbox/bmclib/v2/constants"
+)
+
+// withDeadline returns a context with a deadline, required by the wrapper's
+// firmware upload (it derives the HTTP client timeout from the context).
+func withDeadline(t *testing.T) (context.Context, context.CancelFunc) {
+	t.Helper()
+	return context.WithTimeout(context.Background(), 30*time.Second)
+}
+
+// Requirement: Claim and release the update service + multipart push returns a
+// task.
+func TestFirmwareInstallClaimsAndPushes(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+	ctx, cancel := withDeadline(t)
+	defer cancel()
+
+	taskID, err := c.FirmwareInstall(ctx, "BMC-Backup", "", false, strings.NewReader("firmware-bytes"))
+	if err != nil {
+		t.Fatalf("FirmwareInstall: %v", err)
+	}
+	if taskID != "1" {
+		t.Errorf("taskID = %q, want %q", taskID, "1")
+	}
+	if !ts.didClaimBusy() {
+		t.Error("expected the update service to be claimed (HttpPushUriTargetsBusy=true)")
+	}
+	if !ts.didMultipartPush() {
+		t.Error("expected a multipart push to /mfwupdate")
+	}
+}
+
+// Requirement: Service is busy.
+func TestFirmwareInstallServiceBusy(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{updateServiceFixture: "updateservice.busy.json"})
+	c := ts.openedClient(t)
+	ctx, cancel := withDeadline(t)
+	defer cancel()
+
+	_, err := c.FirmwareInstall(ctx, "BMC-Backup", "", false, strings.NewReader("fw"))
+	if err == nil {
+		t.Fatal("expected FirmwareInstall to fail when the update service is busy")
+	}
+	if ts.didMultipartPush() || ts.didRawPush() {
+		t.Error("did not expect a push when the service is busy")
+	}
+}
+
+// Requirement: Multipart and raw push paths — fallback to raw push.
+func TestFirmwareInstallRawFallback(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{updateServiceFixture: "updateservice.rawonly.json"})
+	c := ts.openedClient(t)
+	ctx, cancel := withDeadline(t)
+	defer cancel()
+
+	if _, err := c.FirmwareInstall(ctx, "", "", false, strings.NewReader("fw")); err != nil {
+		t.Fatalf("FirmwareInstall (raw): %v", err)
+	}
+	if !ts.didRawPush() {
+		t.Error("expected a raw push to /fwupdate when multipart is unavailable")
+	}
+	if ts.didMultipartPush() {
+		t.Error("did not expect a multipart push when MultipartHttpPushUri is absent")
+	}
+}
+
+// Requirement: Task polling without TaskMonitor GET + completed task maps to a
+// terminal state + service released after completion.
+func TestFirmwareTaskStatus(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	state, status, err := c.FirmwareTaskStatus(context.Background(), constants.FirmwareInstallStepInstallStatus, "BMC-Backup", "1", "")
+	if err != nil {
+		t.Fatalf("FirmwareTaskStatus: %v", err)
+	}
+	if state != constants.Complete {
+		t.Errorf("state = %q, want %q", state, constants.Complete)
+	}
+	if status == "" {
+		t.Error("expected a non-empty status string")
+	}
+	if !ts.didReleaseBusy() {
+		t.Error("expected the update service to be released after a terminal task")
+	}
+}
+
+// Requirement: FirmwareInstallStatus reports the install status.
+func TestFirmwareInstallStatus(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	status, err := c.FirmwareInstallStatus(context.Background(), "", "BMC-Backup", "1")
+	if err != nil {
+		t.Fatalf("FirmwareInstallStatus: %v", err)
+	}
+	if status != string(constants.Complete) {
+		t.Errorf("status = %q, want %q", status, constants.Complete)
+	}
+}
+
+// Requirement: Firmware install steps.
+func TestFirmwareInstallSteps(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	steps, err := c.FirmwareInstallSteps(context.Background(), "BMC-Backup")
+	if err != nil {
+		t.Fatalf("FirmwareInstallSteps: %v", err)
+	}
+	if len(steps) == 0 {
+		t.Fatal("expected at least one install step")
+	}
+	if steps[0] != constants.FirmwareInstallStepUploadInitiateInstall {
+		t.Errorf("first step = %q, want %q", steps[0], constants.FirmwareInstallStepUploadInitiateInstall)
+	}
+}
+
+// Requirement: two-phase upload then start update.
+func TestFirmwareUploadThenInstallUploaded(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+	ctx, cancel := withDeadline(t)
+	defer cancel()
+
+	f, cleanup, err := tempFileFromReader(strings.NewReader("fw"))
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer cleanup()
+
+	if _, err := c.FirmwareUpload(ctx, "BMC-Backup", f); err != nil {
+		t.Fatalf("FirmwareUpload: %v", err)
+	}
+	if !ts.didMultipartPush() {
+		t.Error("expected the upload to push to /mfwupdate")
+	}
+
+	taskID, err := c.FirmwareInstallUploaded(ctx, "BMC-Backup", "1")
+	if err != nil {
+		t.Fatalf("FirmwareInstallUploaded: %v", err)
+	}
+	if taskID != "1" {
+		t.Errorf("install taskID = %q, want %q", taskID, "1")
+	}
+	if !ts.didStartUpdate() {
+		t.Error("expected FirmwareInstallUploaded to POST UpdateService.StartUpdate")
+	}
+}
+
+// Requirement: Simple update issues SimpleUpdate.
+func TestSimpleUpdate(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	taskID, err := c.SimpleUpdate(context.Background(), "https://images.example.com/fw.uxz", "HTTPS")
+	if err != nil {
+		t.Fatalf("SimpleUpdate: %v", err)
+	}
+	if taskID != "1" {
+		t.Errorf("taskID = %q, want %q", taskID, "1")
+	}
+	if !ts.didSimpleUpdate() {
+		t.Error("expected a POST to UpdateService.SimpleUpdate")
+	}
+}

--- a/providers/lenovo/fixtures/v1/account.1.json
+++ b/providers/lenovo/fixtures/v1/account.1.json
@@ -1,0 +1,12 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#ManagerAccount.ManagerAccount",
+    "@odata.id": "/redfish/v1/AccountService/Accounts/1",
+    "@odata.type": "#ManagerAccount.v1_6_0.ManagerAccount",
+    "Id": "1",
+    "Name": "User Account 1",
+    "UserName": "USERID",
+    "RoleId": "Administrator",
+    "Enabled": true,
+    "Locked": false,
+    "AccountTypes": ["Redfish", "OEM"]
+}

--- a/providers/lenovo/fixtures/v1/account.2.json
+++ b/providers/lenovo/fixtures/v1/account.2.json
@@ -1,0 +1,11 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#ManagerAccount.ManagerAccount",
+    "@odata.id": "/redfish/v1/AccountService/Accounts/2",
+    "@odata.type": "#ManagerAccount.v1_6_0.ManagerAccount",
+    "Id": "2",
+    "Name": "User Account 2",
+    "UserName": "",
+    "RoleId": "",
+    "Enabled": false,
+    "Locked": false
+}

--- a/providers/lenovo/fixtures/v1/accounts.json
+++ b/providers/lenovo/fixtures/v1/accounts.json
@@ -1,0 +1,15 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#ManagerAccountCollection.ManagerAccountCollection",
+    "@odata.id": "/redfish/v1/AccountService/Accounts",
+    "@odata.type": "#ManagerAccountCollection.ManagerAccountCollection",
+    "Name": "Accounts Collection",
+    "Members@odata.count": 2,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/AccountService/Accounts/1"
+        },
+        {
+            "@odata.id": "/redfish/v1/AccountService/Accounts/2"
+        }
+    ]
+}

--- a/providers/lenovo/fixtures/v1/accountservice.json
+++ b/providers/lenovo/fixtures/v1/accountservice.json
@@ -1,0 +1,17 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#AccountService.AccountService",
+    "@odata.id": "/redfish/v1/AccountService",
+    "@odata.type": "#AccountService.v1_7_0.AccountService",
+    "Id": "AccountService",
+    "Name": "Account Service",
+    "ServiceEnabled": true,
+    "AccountLockoutThreshold": 5,
+    "AccountLockoutDuration": 600,
+    "MinPasswordLength": 8,
+    "Accounts": {
+        "@odata.id": "/redfish/v1/AccountService/Accounts"
+    },
+    "Roles": {
+        "@odata.id": "/redfish/v1/AccountService/Roles"
+    }
+}

--- a/providers/lenovo/fixtures/v1/bios.json
+++ b/providers/lenovo/fixtures/v1/bios.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Bios.Bios",
+    "@odata.id": "/redfish/v1/Systems/1/Bios",
+    "@odata.type": "#Bios.v1_2_0.Bios",
+    "@odata.etag": "\"6c40cc24cc1762f085cb94\"",
+    "Id": "Bios",
+    "Name": "Bios",
+    "Description": "System Bios",
+    "AttributeRegistry": "BiosAttributeRegistry.1.0.0",
+    "@Redfish.Settings": {
+        "SettingsObject": {
+            "@odata.id": "/redfish/v1/Systems/1/Bios/Pending"
+        },
+        "SupportedApplyTimes": ["OnReset"],
+        "@odata.type": "#Settings.v1_3_3.Settings"
+    },
+    "Attributes": {
+        "BootModes_SystemBootMode": "LegacyMode",
+        "Processors_HyperThreading": "Enabled",
+        "Memory_MemorySpeed": "MaximumPerformance",
+        "OperatingModes_ChooseOperatingMode": "Efficiency_FavorPerformance",
+        "SecureBootConfiguration_SecureBootSetting": "Disabled"
+    },
+    "Actions": {
+        "#Bios.ResetBios": {
+            "target": "/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios"
+        },
+        "#Bios.ChangePassword": {
+            "target": "/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword"
+        }
+    }
+}

--- a/providers/lenovo/fixtures/v1/bios.pending.json
+++ b/providers/lenovo/fixtures/v1/bios.pending.json
@@ -1,0 +1,11 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Bios.Bios",
+    "@odata.id": "/redfish/v1/Systems/1/Bios/Pending",
+    "@odata.type": "#Bios.v1_2_0.Bios",
+    "@odata.etag": "\"6c40cc24cc1762f085cb94\"",
+    "Id": "Pending",
+    "Name": "BIOS Configuration Pending Settings",
+    "Description": "BIOS Configuration Pending Settings",
+    "AttributeRegistry": "BiosAttributeRegistry.1.0.0",
+    "Attributes": {}
+}

--- a/providers/lenovo/fixtures/v1/certificate.1.json
+++ b/providers/lenovo/fixtures/v1/certificate.1.json
@@ -1,0 +1,15 @@
+{
+    "@odata.id": "/redfish/v1/Managers/1/NetworkProtocol/HTTPS/Certificates/1",
+    "@odata.type": "#Certificate.v1_6_0.Certificate",
+    "Id": "1",
+    "Name": "HTTPS Certificate",
+    "CertificateType": "PEM",
+    "Subject": {"CommonName": "XCC-7Z60-SN"},
+    "Issuer": {"CommonName": "XCC-7Z60-SN"},
+    "ValidNotBefore": "2023-01-01T00:00:00Z",
+    "ValidNotAfter": "2033-01-01T00:00:00Z",
+    "Actions": {
+        "#Certificate.Rekey": {"target": "/redfish/v1/Managers/1/NetworkProtocol/HTTPS/Certificates/1/Actions/Certificate.Rekey"},
+        "#Certificate.Renew": {"target": "/redfish/v1/Managers/1/NetworkProtocol/HTTPS/Certificates/1/Actions/Certificate.Renew"}
+    }
+}

--- a/providers/lenovo/fixtures/v1/certificatelocations.json
+++ b/providers/lenovo/fixtures/v1/certificatelocations.json
@@ -1,0 +1,11 @@
+{
+    "@odata.id": "/redfish/v1/CertificateService/CertificateLocations",
+    "@odata.type": "#CertificateLocations.v1_0_2.CertificateLocations",
+    "Id": "CertificateLocations",
+    "Name": "Certificate Locations",
+    "Links": {
+        "Certificates": [
+            {"@odata.id": "/redfish/v1/Managers/1/NetworkProtocol/HTTPS/Certificates/1"}
+        ]
+    }
+}

--- a/providers/lenovo/fixtures/v1/certificateservice.json
+++ b/providers/lenovo/fixtures/v1/certificateservice.json
@@ -1,0 +1,15 @@
+{
+    "@odata.id": "/redfish/v1/CertificateService",
+    "@odata.type": "#CertificateService.v1_0_4.CertificateService",
+    "Id": "CertificateService",
+    "Name": "Certificate Service",
+    "CertificateLocations": {"@odata.id": "/redfish/v1/CertificateService/CertificateLocations"},
+    "Actions": {
+        "#CertificateService.GenerateCSR": {
+            "target": "/redfish/v1/CertificateService/Actions/CertificateService.GenerateCSR"
+        },
+        "#CertificateService.ReplaceCertificate": {
+            "target": "/redfish/v1/CertificateService/Actions/CertificateService.ReplaceCertificate"
+        }
+    }
+}

--- a/providers/lenovo/fixtures/v1/chassis.1.json
+++ b/providers/lenovo/fixtures/v1/chassis.1.json
@@ -1,0 +1,24 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Chassis.Chassis",
+    "@odata.id": "/redfish/v1/Chassis/1",
+    "@odata.type": "#Chassis.v1_11_0.Chassis",
+    "Id": "1",
+    "Name": "Chassis",
+    "ChassisType": "RackMount",
+    "Manufacturer": "Lenovo",
+    "Model": "ThinkSystem SR650",
+    "PowerState": "On",
+    "Status": {
+        "Health": "OK",
+        "State": "Enabled"
+    },
+    "Power": {
+        "@odata.id": "/redfish/v1/Chassis/1/Power"
+    },
+    "Thermal": {
+        "@odata.id": "/redfish/v1/Chassis/1/Thermal"
+    },
+    "LogServices": {
+        "@odata.id": "/redfish/v1/Chassis/1/LogServices"
+    }
+}

--- a/providers/lenovo/fixtures/v1/chassis.1.logservices.json
+++ b/providers/lenovo/fixtures/v1/chassis.1.logservices.json
@@ -1,0 +1,10 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogServiceCollection.LogServiceCollection",
+    "@odata.id": "/redfish/v1/Chassis/1/LogServices",
+    "@odata.type": "#LogServiceCollection.LogServiceCollection",
+    "Name": "Log Service Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {"@odata.id": "/redfish/v1/Chassis/1/LogServices/Sel"}
+    ]
+}

--- a/providers/lenovo/fixtures/v1/chassis.json
+++ b/providers/lenovo/fixtures/v1/chassis.json
@@ -1,0 +1,13 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#ChassisCollection.ChassisCollection",
+    "@odata.id": "/redfish/v1/Chassis",
+    "@odata.type": "#ChassisCollection.ChassisCollection",
+    "Description": "Collection of Chassis",
+    "Name": "Chassis Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1"
+        }
+    ]
+}

--- a/providers/lenovo/fixtures/v1/chassis.ls.sel.json
+++ b/providers/lenovo/fixtures/v1/chassis.ls.sel.json
@@ -1,0 +1,13 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogService.LogService",
+    "@odata.id": "/redfish/v1/Chassis/1/LogServices/Sel",
+    "@odata.type": "#LogService.v1_3_0.LogService",
+    "Id": "Sel",
+    "Name": "Chassis SEL",
+    "Entries": {"@odata.id": "/redfish/v1/Chassis/1/LogServices/Sel/Entries"},
+    "Actions": {
+        "#LogService.ClearLog": {
+            "target": "/redfish/v1/Chassis/1/LogServices/Sel/Actions/LogService.ClearLog"
+        }
+    }
+}

--- a/providers/lenovo/fixtures/v1/eventservice.json
+++ b/providers/lenovo/fixtures/v1/eventservice.json
@@ -1,0 +1,16 @@
+{
+    "@odata.id": "/redfish/v1/EventService",
+    "@odata.type": "#EventService.v1_7_0.EventService",
+    "Id": "EventService",
+    "Name": "Event Service",
+    "ServiceEnabled": true,
+    "DeliveryRetryAttempts": 3,
+    "DeliveryRetryIntervalSeconds": 60,
+    "ServerSentEventUri": "/redfish/v1/EventService/SSE",
+    "Subscriptions": {"@odata.id": "/redfish/v1/EventService/Subscriptions"},
+    "Actions": {
+        "#EventService.SubmitTestEvent": {
+            "target": "/redfish/v1/EventService/Actions/EventService.SubmitTestEvent"
+        }
+    }
+}

--- a/providers/lenovo/fixtures/v1/job.restart.json
+++ b/providers/lenovo/fixtures/v1/job.restart.json
@@ -1,0 +1,13 @@
+{
+    "@odata.id": "/redfish/v1/JobService/Jobs/Restart",
+    "@odata.type": "#Job.v1_0_6.Job",
+    "Id": "Restart",
+    "Name": "Scheduled Restart",
+    "JobState": "Scheduled",
+    "PercentComplete": 0,
+    "StartTime": "2024-06-01T02:00:00Z",
+    "Schedule": {
+        "Name": "weekly",
+        "RecurrenceInterval": "P7D"
+    }
+}

--- a/providers/lenovo/fixtures/v1/jobs.json
+++ b/providers/lenovo/fixtures/v1/jobs.json
@@ -1,0 +1,7 @@
+{
+    "@odata.id": "/redfish/v1/JobService/Jobs",
+    "@odata.type": "#JobCollection.JobCollection",
+    "Name": "Job Collection",
+    "Members@odata.count": 1,
+    "Members": [{"@odata.id": "/redfish/v1/JobService/Jobs/Restart"}]
+}

--- a/providers/lenovo/fixtures/v1/jobservice.json
+++ b/providers/lenovo/fixtures/v1/jobservice.json
@@ -1,0 +1,8 @@
+{
+    "@odata.id": "/redfish/v1/JobService",
+    "@odata.type": "#JobService.v1_0_4.JobService",
+    "Id": "JobService",
+    "Name": "Job Service",
+    "ServiceEnabled": true,
+    "Jobs": {"@odata.id": "/redfish/v1/JobService/Jobs"}
+}

--- a/providers/lenovo/fixtures/v1/license.xcc_advanced.json
+++ b/providers/lenovo/fixtures/v1/license.xcc_advanced.json
@@ -1,0 +1,14 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#License.License",
+    "@odata.id": "/redfish/v1/LicenseService/Licenses/XCC_Advanced",
+    "@odata.type": "#License.v1_1_0.License",
+    "Id": "XCC_Advanced",
+    "Name": "XClarity Controller Advanced",
+    "EntitlementId": "XCC_Advanced",
+    "LicenseType": "Production",
+    "Removable": true,
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    }
+}

--- a/providers/lenovo/fixtures/v1/licenses.json
+++ b/providers/lenovo/fixtures/v1/licenses.json
@@ -1,0 +1,10 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LicenseCollection.LicenseCollection",
+    "@odata.id": "/redfish/v1/LicenseService/Licenses",
+    "@odata.type": "#LicenseCollection.LicenseCollection",
+    "Name": "License Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {"@odata.id": "/redfish/v1/LicenseService/Licenses/XCC_Advanced"}
+    ]
+}

--- a/providers/lenovo/fixtures/v1/ls.audit.entries.json
+++ b/providers/lenovo/fixtures/v1/ls.audit.entries.json
@@ -1,0 +1,10 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntryCollection.LogEntryCollection",
+    "@odata.id": "/redfish/v1/Managers/1/LogServices/AuditLog/Entries",
+    "@odata.type": "#LogEntryCollection.LogEntryCollection",
+    "Name": "Log Entry Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {"@odata.id": "/redfish/v1/Managers/1/LogServices/AuditLog/Entries/1"}
+    ]
+}

--- a/providers/lenovo/fixtures/v1/ls.audit.entry.1.json
+++ b/providers/lenovo/fixtures/v1/ls.audit.entry.1.json
@@ -1,0 +1,11 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.id": "/redfish/v1/Managers/1/LogServices/AuditLog/Entries/1",
+    "@odata.type": "#LogEntry.v1_8_0.LogEntry",
+    "Id": "1",
+    "Name": "Audit Entry 1",
+    "Created": "2024-05-01T12:05:00Z",
+    "EntryType": "Oem",
+    "Severity": "OK",
+    "Message": "User USERID logged in from 10.0.0.5."
+}

--- a/providers/lenovo/fixtures/v1/ls.audit.json
+++ b/providers/lenovo/fixtures/v1/ls.audit.json
@@ -1,0 +1,9 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogService.LogService",
+    "@odata.id": "/redfish/v1/Managers/1/LogServices/AuditLog",
+    "@odata.type": "#LogService.v1_3_0.LogService",
+    "Id": "AuditLog",
+    "Name": "Audit Log",
+    "OverWritePolicy": "WrapsWhenFull",
+    "Entries": {"@odata.id": "/redfish/v1/Managers/1/LogServices/AuditLog/Entries"}
+}

--- a/providers/lenovo/fixtures/v1/ls.sel.entries.json
+++ b/providers/lenovo/fixtures/v1/ls.sel.entries.json
@@ -1,0 +1,10 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntryCollection.LogEntryCollection",
+    "@odata.id": "/redfish/v1/Managers/1/LogServices/Sel/Entries",
+    "@odata.type": "#LogEntryCollection.LogEntryCollection",
+    "Name": "Log Entry Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {"@odata.id": "/redfish/v1/Managers/1/LogServices/Sel/Entries/1"}
+    ]
+}

--- a/providers/lenovo/fixtures/v1/ls.sel.entry.1.json
+++ b/providers/lenovo/fixtures/v1/ls.sel.entry.1.json
@@ -1,0 +1,12 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.id": "/redfish/v1/Managers/1/LogServices/Sel/Entries/1",
+    "@odata.type": "#LogEntry.v1_8_0.LogEntry",
+    "Id": "1",
+    "Name": "Log Entry 1",
+    "Created": "2024-05-01T12:00:00Z",
+    "EntryType": "SEL",
+    "Severity": "OK",
+    "Message": "System boot completed.",
+    "SensorNumber": 0
+}

--- a/providers/lenovo/fixtures/v1/ls.sel.json
+++ b/providers/lenovo/fixtures/v1/ls.sel.json
@@ -1,0 +1,14 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogService.LogService",
+    "@odata.id": "/redfish/v1/Managers/1/LogServices/Sel",
+    "@odata.type": "#LogService.v1_3_0.LogService",
+    "Id": "Sel",
+    "Name": "IPMI SEL",
+    "OverWritePolicy": "WrapsWhenFull",
+    "Entries": {"@odata.id": "/redfish/v1/Managers/1/LogServices/Sel/Entries"},
+    "Actions": {
+        "#LogService.ClearLog": {
+            "target": "/redfish/v1/Managers/1/LogServices/Sel/Actions/LogService.ClearLog"
+        }
+    }
+}

--- a/providers/lenovo/fixtures/v1/manager.1.json
+++ b/providers/lenovo/fixtures/v1/manager.1.json
@@ -1,0 +1,41 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Manager.Manager",
+    "@odata.id": "/redfish/v1/Managers/1",
+    "@odata.type": "#Manager.v1_9_0.Manager",
+    "Id": "1",
+    "Name": "Manager",
+    "ManagerType": "BMC",
+    "FirmwareVersion": "TEE142M-2.41",
+    "Status": {
+        "Health": "OK",
+        "State": "Enabled"
+    },
+    "VirtualMedia": {
+        "@odata.id": "/redfish/v1/Managers/1/VirtualMedia"
+    },
+    "LogServices": {
+        "@odata.id": "/redfish/v1/Managers/1/LogServices"
+    },
+    "EthernetInterfaces": {
+        "@odata.id": "/redfish/v1/Managers/1/EthernetInterfaces"
+    },
+    "HostInterfaces": {
+        "@odata.id": "/redfish/v1/Managers/1/HostInterfaces"
+    },
+    "SerialInterfaces": {
+        "@odata.id": "/redfish/v1/Managers/1/SerialInterfaces"
+    },
+    "NetworkProtocol": {
+        "@odata.id": "/redfish/v1/Managers/1/NetworkProtocol"
+    },
+    "Actions": {
+        "#Manager.Reset": {
+            "target": "/redfish/v1/Managers/1/Actions/Manager.Reset",
+            "ResetType@Redfish.AllowableValues": ["GracefulRestart", "ForceRestart"]
+        },
+        "#Manager.ResetToDefaults": {
+            "target": "/redfish/v1/Managers/1/Actions/Manager.ResetToDefaults",
+            "ResetType@Redfish.AllowableValues": ["ResetAll"]
+        }
+    }
+}

--- a/providers/lenovo/fixtures/v1/manager.eth0.json
+++ b/providers/lenovo/fixtures/v1/manager.eth0.json
@@ -1,0 +1,15 @@
+{
+    "@odata.id": "/redfish/v1/Managers/1/EthernetInterfaces/eth0",
+    "@odata.type": "#EthernetInterface.v1_6_0.EthernetInterface",
+    "Id": "eth0",
+    "Name": "Manager Ethernet Interface",
+    "MACAddress": "7C:D3:0A:11:22:33",
+    "HostName": "XCC-SR650",
+    "InterfaceEnabled": true,
+    "IPv4Addresses": [
+        {"Address": "10.0.0.50", "SubnetMask": "255.255.255.0", "Gateway": "10.0.0.1", "AddressOrigin": "Static"}
+    ],
+    "IPv6Addresses": [
+        {"Address": "fe80::7ed3:aff:fe11:2233", "PrefixLength": 64, "AddressOrigin": "LinkLocal"}
+    ]
+}

--- a/providers/lenovo/fixtures/v1/manager.ethernetinterfaces.json
+++ b/providers/lenovo/fixtures/v1/manager.ethernetinterfaces.json
@@ -1,0 +1,7 @@
+{
+    "@odata.id": "/redfish/v1/Managers/1/EthernetInterfaces",
+    "@odata.type": "#EthernetInterfaceCollection.EthernetInterfaceCollection",
+    "Name": "Ethernet Interface Collection",
+    "Members@odata.count": 1,
+    "Members": [{"@odata.id": "/redfish/v1/Managers/1/EthernetInterfaces/eth0"}]
+}

--- a/providers/lenovo/fixtures/v1/manager.hostinterface.1.json
+++ b/providers/lenovo/fixtures/v1/manager.hostinterface.1.json
@@ -1,0 +1,8 @@
+{
+    "@odata.id": "/redfish/v1/Managers/1/HostInterfaces/1",
+    "@odata.type": "#HostInterface.v1_3_0.HostInterface",
+    "Id": "1",
+    "Name": "Host Interface",
+    "InterfaceEnabled": true,
+    "HostInterfaceType": "NetworkHostInterface"
+}

--- a/providers/lenovo/fixtures/v1/manager.hostinterfaces.json
+++ b/providers/lenovo/fixtures/v1/manager.hostinterfaces.json
@@ -1,0 +1,7 @@
+{
+    "@odata.id": "/redfish/v1/Managers/1/HostInterfaces",
+    "@odata.type": "#HostInterfaceCollection.HostInterfaceCollection",
+    "Name": "Host Interface Collection",
+    "Members@odata.count": 1,
+    "Members": [{"@odata.id": "/redfish/v1/Managers/1/HostInterfaces/1"}]
+}

--- a/providers/lenovo/fixtures/v1/manager.serial.1.json
+++ b/providers/lenovo/fixtures/v1/manager.serial.1.json
@@ -1,0 +1,12 @@
+{
+    "@odata.id": "/redfish/v1/Managers/1/SerialInterfaces/1",
+    "@odata.type": "#SerialInterface.v1_1_8.SerialInterface",
+    "Id": "1",
+    "Name": "Serial Interface 1",
+    "InterfaceEnabled": true,
+    "BitRate": "115200",
+    "Parity": "None",
+    "DataBits": "8",
+    "StopBits": "1",
+    "FlowControl": "None"
+}

--- a/providers/lenovo/fixtures/v1/manager.serialinterfaces.json
+++ b/providers/lenovo/fixtures/v1/manager.serialinterfaces.json
@@ -1,0 +1,7 @@
+{
+    "@odata.id": "/redfish/v1/Managers/1/SerialInterfaces",
+    "@odata.type": "#SerialInterfaceCollection.SerialInterfaceCollection",
+    "Name": "Serial Interface Collection",
+    "Members@odata.count": 1,
+    "Members": [{"@odata.id": "/redfish/v1/Managers/1/SerialInterfaces/1"}]
+}

--- a/providers/lenovo/fixtures/v1/managers.1.logservices.json
+++ b/providers/lenovo/fixtures/v1/managers.1.logservices.json
@@ -1,0 +1,11 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogServiceCollection.LogServiceCollection",
+    "@odata.id": "/redfish/v1/Managers/1/LogServices",
+    "@odata.type": "#LogServiceCollection.LogServiceCollection",
+    "Name": "Log Service Collection",
+    "Members@odata.count": 2,
+    "Members": [
+        {"@odata.id": "/redfish/v1/Managers/1/LogServices/Sel"},
+        {"@odata.id": "/redfish/v1/Managers/1/LogServices/AuditLog"}
+    ]
+}

--- a/providers/lenovo/fixtures/v1/managers.1.virtualmedia.json
+++ b/providers/lenovo/fixtures/v1/managers.1.virtualmedia.json
@@ -1,0 +1,15 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#VirtualMediaCollection.VirtualMediaCollection",
+    "@odata.id": "/redfish/v1/Managers/1/VirtualMedia",
+    "@odata.type": "#VirtualMediaCollection.VirtualMediaCollection",
+    "Name": "Virtual Media Collection",
+    "Members@odata.count": 2,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/1/VirtualMedia/CD"
+        },
+        {
+            "@odata.id": "/redfish/v1/Managers/1/VirtualMedia/Floppy"
+        }
+    ]
+}

--- a/providers/lenovo/fixtures/v1/managers.json
+++ b/providers/lenovo/fixtures/v1/managers.json
@@ -1,0 +1,12 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#ManagerCollection.ManagerCollection",
+    "@odata.id": "/redfish/v1/Managers",
+    "@odata.type": "#ManagerCollection.ManagerCollection",
+    "Name": "Manager Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/1"
+        }
+    ]
+}

--- a/providers/lenovo/fixtures/v1/metricdefinitions.json
+++ b/providers/lenovo/fixtures/v1/metricdefinitions.json
@@ -1,0 +1,10 @@
+{
+    "@odata.id": "/redfish/v1/TelemetryService/MetricDefinitions",
+    "@odata.type": "#MetricDefinitionCollection.MetricDefinitionCollection",
+    "Name": "Metric Definition Collection",
+    "Members@odata.count": 2,
+    "Members": [
+        {"@odata.id": "/redfish/v1/TelemetryService/MetricDefinitions/PowerConsumedWatts"},
+        {"@odata.id": "/redfish/v1/TelemetryService/MetricDefinitions/InletTemp"}
+    ]
+}

--- a/providers/lenovo/fixtures/v1/metricreport.power.json
+++ b/providers/lenovo/fixtures/v1/metricreport.power.json
@@ -1,0 +1,13 @@
+{
+    "@odata.id": "/redfish/v1/TelemetryService/MetricReports/PowerMetrics",
+    "@odata.type": "#MetricReport.v1_4_2.MetricReport",
+    "Id": "PowerMetrics",
+    "Name": "Power Metrics Report",
+    "MetricReportDefinition": {
+        "@odata.id": "/redfish/v1/TelemetryService/MetricReportDefinitions/PowerMetrics"
+    },
+    "MetricValues": [
+        {"MetricProperty": "/redfish/v1/Chassis/1/Power#/PowerControl/0/PowerMetrics/MaxConsumedWatts", "MetricValue": "287", "Timestamp": "2026-06-09T11:58:30+00:00"},
+        {"MetricProperty": "/redfish/v1/Chassis/1/Power#/PowerControl/0/PowerMetrics/MinConsumedWatts", "MetricValue": "23", "Timestamp": "2026-06-09T11:58:30+00:00"}
+    ]
+}

--- a/providers/lenovo/fixtures/v1/metricreportdefinitions.json
+++ b/providers/lenovo/fixtures/v1/metricreportdefinitions.json
@@ -1,0 +1,7 @@
+{
+    "@odata.id": "/redfish/v1/TelemetryService/MetricReportDefinitions",
+    "@odata.type": "#MetricReportDefinitionCollection.MetricReportDefinitionCollection",
+    "Name": "Metric Report Definition Collection",
+    "Members@odata.count": 1,
+    "Members": [{"@odata.id": "/redfish/v1/TelemetryService/MetricReportDefinitions/PowerMetrics"}]
+}

--- a/providers/lenovo/fixtures/v1/metricreports.json
+++ b/providers/lenovo/fixtures/v1/metricreports.json
@@ -1,0 +1,7 @@
+{
+    "@odata.id": "/redfish/v1/TelemetryService/MetricReports",
+    "@odata.type": "#MetricReportCollection.MetricReportCollection",
+    "Name": "Metric Report Collection",
+    "Members@odata.count": 1,
+    "Members": [{"@odata.id": "/redfish/v1/TelemetryService/MetricReports/PowerMetrics"}]
+}

--- a/providers/lenovo/fixtures/v1/networkprotocol.json
+++ b/providers/lenovo/fixtures/v1/networkprotocol.json
@@ -1,0 +1,16 @@
+{
+    "@odata.id": "/redfish/v1/Managers/1/NetworkProtocol",
+    "@odata.type": "#ManagerNetworkProtocol.v1_5_0.ManagerNetworkProtocol",
+    "Id": "NetworkProtocol",
+    "Name": "Manager Network Protocol",
+    "HostName": "XCC-SR650",
+    "HTTP":  {"ProtocolEnabled": false, "Port": 80},
+    "HTTPS": {"ProtocolEnabled": true,  "Port": 443},
+    "SSH":   {"ProtocolEnabled": true,  "Port": 22},
+    "IPMI":  {"ProtocolEnabled": true,  "Port": 623},
+    "SNMP":  {"ProtocolEnabled": false, "Port": 161},
+    "NTP":   {"ProtocolEnabled": true,  "Port": 123, "NTPServers": ["pool.ntp.org"]},
+    "KVMIP": {"ProtocolEnabled": true,  "Port": 3900},
+    "VirtualMedia": {"ProtocolEnabled": true, "Port": 3900},
+    "SSDP":  {"ProtocolEnabled": true,  "Port": 1900}
+}

--- a/providers/lenovo/fixtures/v1/power.json
+++ b/providers/lenovo/fixtures/v1/power.json
@@ -1,0 +1,50 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Power.Power",
+    "@odata.id": "/redfish/v1/Chassis/1/Power",
+    "@odata.type": "#Power.v1_5_0.Power",
+    "Id": "Power",
+    "Name": "Power",
+    "PowerControl@odata.count": 1,
+    "PowerControl": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Power#/PowerControl/0",
+            "MemberId": "0",
+            "Name": "Server Power Control",
+            "PowerConsumedWatts": 287,
+            "PowerCapacityWatts": 1800,
+            "PowerLimit": {
+                "LimitInWatts": null,
+                "LimitException": "NoAction"
+            },
+            "PowerMetrics": {
+                "IntervalInMin": 1,
+                "MaxConsumedWatts": 320,
+                "MinConsumedWatts": 250,
+                "AverageConsumedWatts": 290
+            }
+        }
+    ],
+    "PowerSupplies@odata.count": 2,
+    "PowerSupplies": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Power#/PowerSupplies/0",
+            "MemberId": "0",
+            "Name": "PSU 1",
+            "PowerCapacityWatts": 900,
+            "Status": {
+                "Health": "OK",
+                "State": "Enabled"
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Power#/PowerSupplies/1",
+            "MemberId": "1",
+            "Name": "PSU 2",
+            "PowerCapacityWatts": 900,
+            "Status": {
+                "Health": "OK",
+                "State": "Enabled"
+            }
+        }
+    ]
+}

--- a/providers/lenovo/fixtures/v1/role.administrator.json
+++ b/providers/lenovo/fixtures/v1/role.administrator.json
@@ -1,0 +1,10 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Role.Role",
+    "@odata.id": "/redfish/v1/AccountService/Roles/Administrator",
+    "@odata.type": "#Role.v1_3_1.Role",
+    "Id": "Administrator",
+    "Name": "User Role",
+    "RoleId": "Administrator",
+    "IsPredefined": true,
+    "AssignedPrivileges": ["Login", "ConfigureManager", "ConfigureUsers", "ConfigureSelf", "ConfigureComponents"]
+}

--- a/providers/lenovo/fixtures/v1/role.operator.json
+++ b/providers/lenovo/fixtures/v1/role.operator.json
@@ -1,0 +1,10 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Role.Role",
+    "@odata.id": "/redfish/v1/AccountService/Roles/Operator",
+    "@odata.type": "#Role.v1_3_1.Role",
+    "Id": "Operator",
+    "Name": "User Role",
+    "RoleId": "Operator",
+    "IsPredefined": true,
+    "AssignedPrivileges": ["Login", "ConfigureComponents", "ConfigureSelf"]
+}

--- a/providers/lenovo/fixtures/v1/roles.json
+++ b/providers/lenovo/fixtures/v1/roles.json
@@ -1,0 +1,15 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#RoleCollection.RoleCollection",
+    "@odata.id": "/redfish/v1/AccountService/Roles",
+    "@odata.type": "#RoleCollection.RoleCollection",
+    "Name": "Roles Collection",
+    "Members@odata.count": 2,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/AccountService/Roles/Administrator"
+        },
+        {
+            "@odata.id": "/redfish/v1/AccountService/Roles/Operator"
+        }
+    ]
+}

--- a/providers/lenovo/fixtures/v1/secureboot.json
+++ b/providers/lenovo/fixtures/v1/secureboot.json
@@ -1,0 +1,17 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#SecureBoot.SecureBoot",
+    "@odata.id": "/redfish/v1/Systems/1/SecureBoot",
+    "@odata.type": "#SecureBoot.v1_0_4.SecureBoot",
+    "Id": "SecureBoot",
+    "Name": "UEFI Secure Boot",
+    "SecureBootEnable": true,
+    "SecureBootCurrentBoot": "Disabled",
+    "SecureBootMode": "SetupMode",
+    "Actions": {
+        "#SecureBoot.ResetKeys": {
+            "target": "/redfish/v1/Systems/1/SecureBoot/Actions/SecureBoot.ResetKeys",
+            "title": "ResetKeys",
+            "@Redfish.ActionInfo": "/redfish/v1/Systems/1/SecureBoot/ResetKeysActionInfo"
+        }
+    }
+}

--- a/providers/lenovo/fixtures/v1/serviceroot.json
+++ b/providers/lenovo/fixtures/v1/serviceroot.json
@@ -1,0 +1,69 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
+    "@odata.id": "/redfish/v1/",
+    "@odata.type": "#ServiceRoot.v1_5_0.ServiceRoot",
+    "Id": "RootService",
+    "Name": "Root Service",
+    "Description": "This resource is used to represent a service root for a Redfish implementation.",
+    "Vendor": "Lenovo",
+    "Product": "ThinkSystem",
+    "RedfishVersion": "1.15.0",
+    "UUID": "92384634-2938-2342-8820-489239905423",
+    "AccountService": {
+        "@odata.id": "/redfish/v1/AccountService"
+    },
+    "CertificateService": {
+        "@odata.id": "/redfish/v1/CertificateService"
+    },
+    "Chassis": {
+        "@odata.id": "/redfish/v1/Chassis"
+    },
+    "EventService": {
+        "@odata.id": "/redfish/v1/EventService"
+    },
+    "JobService": {
+        "@odata.id": "/redfish/v1/JobService"
+    },
+    "JsonSchemas": {
+        "@odata.id": "/redfish/v1/JsonSchemas"
+    },
+    "Managers": {
+        "@odata.id": "/redfish/v1/Managers"
+    },
+    "Registries": {
+        "@odata.id": "/redfish/v1/Registries"
+    },
+    "SessionService": {
+        "@odata.id": "/redfish/v1/SessionService"
+    },
+    "Systems": {
+        "@odata.id": "/redfish/v1/Systems"
+    },
+    "Tasks": {
+        "@odata.id": "/redfish/v1/TaskService"
+    },
+    "TelemetryService": {
+        "@odata.id": "/redfish/v1/TelemetryService"
+    },
+    "UpdateService": {
+        "@odata.id": "/redfish/v1/UpdateService"
+    },
+    "Links": {
+        "Sessions": {
+            "@odata.id": "/redfish/v1/SessionService/Sessions"
+        }
+    },
+    "ProtocolFeaturesSupported": {
+        "ExcerptQuery": true,
+        "ExpandQuery": {
+            "ExpandAll": true,
+            "Levels": true,
+            "Links": true,
+            "MaxLevels": 2,
+            "NoLinks": true
+        },
+        "FilterQuery": true,
+        "OnlyMemberQuery": true,
+        "SelectQuery": true
+    }
+}

--- a/providers/lenovo/fixtures/v1/sklm.json
+++ b/providers/lenovo/fixtures/v1/sklm.json
@@ -1,0 +1,12 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LenovoSecureKeyLifecycle.LenovoSecureKeyLifecycle",
+    "@odata.id": "/redfish/v1/Managers/1/Oem/Lenovo/SecureKeyLifecycleService",
+    "@odata.type": "#LenovoSecureKeyLifecycle.v1_0_0.LenovoSecureKeyLifecycle",
+    "Id": "SecureKeyLifecycleService",
+    "Name": "Secure Key Lifecycle Service",
+    "DeviceGroup": "TKLM_DEV_GROUP",
+    "KeyRepoServers": [
+        {"HostName": "10.0.0.10", "Port": 5696},
+        {"HostName": "", "Port": 5696}
+    ]
+}

--- a/providers/lenovo/fixtures/v1/snmp.json
+++ b/providers/lenovo/fixtures/v1/snmp.json
@@ -1,0 +1,26 @@
+{
+    "@odata.id": "/redfish/v1/Managers/1/NetworkProtocol/Oem/Lenovo/SNMP",
+    "@odata.type": "#LenovoSNMPProtocol.v1_0_0.LenovoSNMPProtocol",
+    "Id": "SNMP",
+    "Name": "SNMP Protocol",
+    "CommunityNames": ["public"],
+    "SNMPTraps": {
+        "SNMPv1TrapEnabled": false,
+        "ProtocolEnabled": false,
+        "Port": 162,
+        "Targets": [
+            {
+                "Addresses": [null]
+            }
+        ],
+        "AlertRecipient": {
+            "WarningEvents": {"AcceptedEvents": [], "Enabled": false},
+            "CriticalEvents": {"AcceptedEvents": [], "Enabled": false},
+            "SystemEvents": {"AcceptedEvents": [], "Enabled": false}
+        }
+    },
+    "SNMPv3Agent": {
+        "ProtocolEnabled": false,
+        "Port": 161
+    }
+}

--- a/providers/lenovo/fixtures/v1/storage.json
+++ b/providers/lenovo/fixtures/v1/storage.json
@@ -1,0 +1,13 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#StorageCollection.StorageCollection",
+    "@odata.id": "/redfish/v1/Systems/1/Storage",
+    "@odata.type": "#StorageCollection.StorageCollection",
+    "Description": "Collection of Storage resource instances",
+    "Name": "Storage Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/1/Storage/RAID_Slot1"
+        }
+    ]
+}

--- a/providers/lenovo/fixtures/v1/storage.raid.json
+++ b/providers/lenovo/fixtures/v1/storage.raid.json
@@ -1,0 +1,38 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Storage.Storage",
+    "@odata.id": "/redfish/v1/Systems/1/Storage/RAID_Slot1",
+    "@odata.type": "#Storage.v1_9_0.Storage",
+    "Id": "RAID_Slot1",
+    "Name": "RAID Controller",
+    "Status": {
+        "Health": "OK",
+        "HealthRollup": "OK",
+        "State": "Enabled"
+    },
+    "StorageControllers": [
+        {
+            "@odata.id": "/redfish/v1/Systems/1/Storage/RAID_Slot1#/StorageControllers/0",
+            "MemberId": "0",
+            "Name": "ThinkSystem RAID 930-8i",
+            "Manufacturer": "Lenovo",
+            "Model": "ThinkSystem RAID 930-8i 2GB Flash",
+            "FirmwareVersion": "51.10.0-3151",
+            "Status": {
+                "Health": "OK",
+                "State": "Enabled"
+            }
+        }
+    ],
+    "Drives@odata.count": 2,
+    "Drives": [
+        {
+            "@odata.id": "/redfish/v1/Systems/1/Storage/RAID_Slot1/Drives/Disk.0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/Storage/RAID_Slot1/Drives/Disk.1"
+        }
+    ],
+    "Volumes": {
+        "@odata.id": "/redfish/v1/Systems/1/Storage/RAID_Slot1/Volumes"
+    }
+}

--- a/providers/lenovo/fixtures/v1/subscription.1.json
+++ b/providers/lenovo/fixtures/v1/subscription.1.json
@@ -1,0 +1,10 @@
+{
+    "@odata.id": "/redfish/v1/EventService/Subscriptions/1",
+    "@odata.type": "#EventDestination.v1_10_0.EventDestination",
+    "Id": "1",
+    "Name": "Subscription 1",
+    "Destination": "https://listener.example.com/webhook",
+    "Protocol": "Redfish",
+    "Context": "lenovo-test",
+    "SubscriptionType": "RedfishEvent"
+}

--- a/providers/lenovo/fixtures/v1/subscriptions.json
+++ b/providers/lenovo/fixtures/v1/subscriptions.json
@@ -1,0 +1,7 @@
+{
+    "@odata.id": "/redfish/v1/EventService/Subscriptions",
+    "@odata.type": "#EventDestinationCollection.EventDestinationCollection",
+    "Name": "Event Subscriptions Collection",
+    "Members@odata.count": 1,
+    "Members": [{"@odata.id": "/redfish/v1/EventService/Subscriptions/1"}]
+}

--- a/providers/lenovo/fixtures/v1/system.eth.nic1.json
+++ b/providers/lenovo/fixtures/v1/system.eth.nic1.json
@@ -1,0 +1,11 @@
+{
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/NIC.1",
+    "@odata.type": "#EthernetInterface.v1_6_0.EthernetInterface",
+    "Id": "NIC.1",
+    "Name": "Server NIC 1",
+    "MACAddress": "7C:D3:0A:44:55:66",
+    "InterfaceEnabled": true,
+    "IPv4Addresses": [
+        {"Address": "192.168.10.20", "SubnetMask": "255.255.255.0", "AddressOrigin": "DHCP"}
+    ]
+}

--- a/providers/lenovo/fixtures/v1/system.ethernetinterfaces.json
+++ b/providers/lenovo/fixtures/v1/system.ethernetinterfaces.json
@@ -1,0 +1,7 @@
+{
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces",
+    "@odata.type": "#EthernetInterfaceCollection.EthernetInterfaceCollection",
+    "Name": "Ethernet Interface Collection",
+    "Members@odata.count": 1,
+    "Members": [{"@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/NIC.1"}]
+}

--- a/providers/lenovo/fixtures/v1/system.lenovo.json
+++ b/providers/lenovo/fixtures/v1/system.lenovo.json
@@ -1,0 +1,78 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+    "@odata.id": "/redfish/v1/Systems/1",
+    "@odata.type": "#ComputerSystem.v1_10_0.ComputerSystem",
+    "Id": "1",
+    "Name": "System",
+    "Manufacturer": "Lenovo",
+    "Model": "ThinkSystem SR650",
+    "SKU": "7X06CTO1WW",
+    "SerialNumber": "J100ABCD",
+    "UUID": "92384634-2938-2342-8820-489239905423",
+    "PowerState": "On",
+    "SystemType": "Physical",
+    "BiosVersion": "TEE142M-2.41",
+    "Status": {
+        "Health": "OK",
+        "HealthRollup": "OK",
+        "State": "Enabled"
+    },
+    "BootProgress": {
+        "LastState": "SystemHardwareInitializationComplete"
+    },
+    "Bios": {
+        "@odata.id": "/redfish/v1/Systems/1/Bios"
+    },
+    "SecureBoot": {
+        "@odata.id": "/redfish/v1/Systems/1/SecureBoot"
+    },
+    "Storage": {
+        "@odata.id": "/redfish/v1/Systems/1/Storage"
+    },
+    "EthernetInterfaces": {
+        "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces"
+    },
+    "Boot": {
+        "BootSourceOverrideEnabled": "Once",
+        "BootSourceOverrideMode": "Legacy",
+        "BootSourceOverrideTarget": "Hdd",
+        "BootSourceOverrideTarget@Redfish.AllowableValues": [
+            "None",
+            "Pxe",
+            "Cd",
+            "Hdd",
+            "BiosSetup"
+        ],
+        "BootSourceOverrideEnabled@Redfish.AllowableValues": [
+            "Once",
+            "Disabled"
+        ],
+        "UefiTargetBootSourceOverride": null
+    },
+    "Actions": {
+        "#ComputerSystem.Reset": {
+            "target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+            "ResetType@Redfish.AllowableValues": [
+                "On",
+                "ForceOff",
+                "GracefulShutdown",
+                "GracefulRestart",
+                "ForceRestart",
+                "Nmi",
+                "ForceOn"
+            ]
+        }
+    },
+    "Links": {
+        "ManagedBy": [
+            {
+                "@odata.id": "/redfish/v1/Managers/1"
+            }
+        ],
+        "Chassis": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/1"
+            }
+        ]
+    }
+}

--- a/providers/lenovo/fixtures/v1/system.nonlenovo.json
+++ b/providers/lenovo/fixtures/v1/system.nonlenovo.json
@@ -1,0 +1,30 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+    "@odata.id": "/redfish/v1/Systems/1",
+    "@odata.type": "#ComputerSystem.v1_10_0.ComputerSystem",
+    "Id": "1",
+    "Name": "System",
+    "Manufacturer": "Dell Inc.",
+    "Model": "PowerEdge R6515",
+    "SerialNumber": "CN000000",
+    "UUID": "4c4c4544-004c-4410-8058-c6c04f443533",
+    "PowerState": "On",
+    "SystemType": "Physical",
+    "Status": {
+        "Health": "OK",
+        "State": "Enabled"
+    },
+    "Actions": {
+        "#ComputerSystem.Reset": {
+            "target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+            "ResetType@Redfish.AllowableValues": [
+                "On",
+                "ForceOff",
+                "GracefulShutdown",
+                "GracefulRestart",
+                "ForceRestart",
+                "Nmi"
+            ]
+        }
+    }
+}

--- a/providers/lenovo/fixtures/v1/systems.json
+++ b/providers/lenovo/fixtures/v1/systems.json
@@ -1,0 +1,13 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection",
+    "@odata.id": "/redfish/v1/Systems",
+    "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+    "Description": "Collection of Computer Systems",
+    "Name": "Computer System Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/1"
+        }
+    ]
+}

--- a/providers/lenovo/fixtures/v1/task.1.json
+++ b/providers/lenovo/fixtures/v1/task.1.json
@@ -1,0 +1,16 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Task.Task",
+    "@odata.id": "/redfish/v1/TaskService/Tasks/1",
+    "@odata.type": "#Task.v1_4_3.Task",
+    "Id": "1",
+    "Name": "Task 1",
+    "TaskState": "Completed",
+    "TaskStatus": "OK",
+    "PercentComplete": 100,
+    "Messages": [
+        {
+            "MessageId": "Update.1.0.UpdateSuccessful",
+            "Message": "Device firmware updated successfully."
+        }
+    ]
+}

--- a/providers/lenovo/fixtures/v1/tasks.json
+++ b/providers/lenovo/fixtures/v1/tasks.json
@@ -1,0 +1,12 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#TaskCollection.TaskCollection",
+    "@odata.id": "/redfish/v1/TaskService/Tasks",
+    "@odata.type": "#TaskCollection.TaskCollection",
+    "Name": "Task Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/TaskService/Tasks/1"
+        }
+    ]
+}

--- a/providers/lenovo/fixtures/v1/taskservice.json
+++ b/providers/lenovo/fixtures/v1/taskservice.json
@@ -1,0 +1,11 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#TaskService.TaskService",
+    "@odata.id": "/redfish/v1/TaskService",
+    "@odata.type": "#TaskService.v1_1_4.TaskService",
+    "Id": "TaskService",
+    "Name": "Task Service",
+    "ServiceEnabled": true,
+    "Tasks": {
+        "@odata.id": "/redfish/v1/TaskService/Tasks"
+    }
+}

--- a/providers/lenovo/fixtures/v1/telemetryservice.json
+++ b/providers/lenovo/fixtures/v1/telemetryservice.json
@@ -1,0 +1,17 @@
+{
+    "@odata.id": "/redfish/v1/TelemetryService",
+    "@odata.type": "#TelemetryService.v1_3_1.TelemetryService",
+    "Id": "TelemetryService",
+    "Name": "Telemetry Service",
+    "ServiceEnabled": true,
+    "MaxReports": 10,
+    "MinCollectionInterval": "PT10S",
+    "MetricReports": {"@odata.id": "/redfish/v1/TelemetryService/MetricReports"},
+    "MetricReportDefinitions": {"@odata.id": "/redfish/v1/TelemetryService/MetricReportDefinitions"},
+    "MetricDefinitions": {"@odata.id": "/redfish/v1/TelemetryService/MetricDefinitions"},
+    "Actions": {
+        "#TelemetryService.SubmitTestMetricReport": {
+            "target": "/redfish/v1/TelemetryService/Actions/TelemetryService.SubmitTestMetricReport"
+        }
+    }
+}

--- a/providers/lenovo/fixtures/v1/thermal.json
+++ b/providers/lenovo/fixtures/v1/thermal.json
@@ -1,0 +1,40 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Thermal.Thermal",
+    "@odata.id": "/redfish/v1/Chassis/1/Thermal",
+    "@odata.type": "#Thermal.v1_4_0.Thermal",
+    "Id": "Thermal",
+    "Name": "Thermal",
+    "Temperatures@odata.count": 1,
+    "Temperatures": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/0",
+            "MemberId": "0",
+            "Name": "Ambient Temp",
+            "SensorNumber": 49,
+            "ReadingCelsius": 23,
+            "UpperThresholdNonCritical": 43,
+            "UpperThresholdCritical": 47,
+            "UpperThresholdFatal": 50,
+            "Status": {
+                "Health": "OK",
+                "State": "Enabled"
+            }
+        }
+    ],
+    "Fans@odata.count": 1,
+    "Fans": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Fans/0",
+            "MemberId": "0",
+            "Name": "Fan 1 Tach",
+            "FanName": "Fan 1 Tach",
+            "SensorNumber": 65,
+            "Reading": 6840,
+            "ReadingUnits": "RPM",
+            "Status": {
+                "Health": "OK",
+                "State": "Enabled"
+            }
+        }
+    ]
+}

--- a/providers/lenovo/fixtures/v1/updateservice.busy.json
+++ b/providers/lenovo/fixtures/v1/updateservice.busy.json
@@ -1,0 +1,14 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#UpdateService.UpdateService",
+    "@odata.id": "/redfish/v1/UpdateService",
+    "@odata.type": "#UpdateService.v1_8_0.UpdateService",
+    "Id": "UpdateService",
+    "Name": "Update Service",
+    "ServiceEnabled": true,
+    "HttpPushUri": "/fwupdate",
+    "MultipartHttpPushUri": "/mfwupdate",
+    "HttpPushUriTargetsBusy": true,
+    "FirmwareInventory": {
+        "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory"
+    }
+}

--- a/providers/lenovo/fixtures/v1/updateservice.json
+++ b/providers/lenovo/fixtures/v1/updateservice.json
@@ -1,0 +1,23 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#UpdateService.UpdateService",
+    "@odata.id": "/redfish/v1/UpdateService",
+    "@odata.type": "#UpdateService.v1_8_0.UpdateService",
+    "Id": "UpdateService",
+    "Name": "Update Service",
+    "ServiceEnabled": true,
+    "HttpPushUri": "/fwupdate",
+    "MultipartHttpPushUri": "/mfwupdate",
+    "HttpPushUriTargetsBusy": false,
+    "HttpPushUriTargets": [],
+    "FirmwareInventory": {
+        "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory"
+    },
+    "Actions": {
+        "#UpdateService.SimpleUpdate": {
+            "target": "/redfish/v1/UpdateService/Actions/UpdateService.SimpleUpdate"
+        },
+        "#UpdateService.StartUpdate": {
+            "target": "/redfish/v1/UpdateService/Actions/UpdateService.StartUpdate"
+        }
+    }
+}

--- a/providers/lenovo/fixtures/v1/updateservice.rawonly.json
+++ b/providers/lenovo/fixtures/v1/updateservice.rawonly.json
@@ -1,0 +1,13 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#UpdateService.UpdateService",
+    "@odata.id": "/redfish/v1/UpdateService",
+    "@odata.type": "#UpdateService.v1_8_0.UpdateService",
+    "Id": "UpdateService",
+    "Name": "Update Service",
+    "ServiceEnabled": true,
+    "HttpPushUri": "/fwupdate",
+    "HttpPushUriTargetsBusy": false,
+    "FirmwareInventory": {
+        "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory"
+    }
+}

--- a/providers/lenovo/fixtures/v1/vm.cd.json
+++ b/providers/lenovo/fixtures/v1/vm.cd.json
@@ -1,0 +1,17 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#VirtualMedia.VirtualMedia",
+    "@odata.id": "/redfish/v1/Managers/1/VirtualMedia/CD",
+    "@odata.type": "#VirtualMedia.v1_3_0.VirtualMedia",
+    "Id": "CD",
+    "Name": "Remote CD",
+    "MediaTypes": [
+        "CD",
+        "DVD"
+    ],
+    "Image": null,
+    "ImageName": null,
+    "Inserted": false,
+    "WriteProtected": true,
+    "ConnectedVia": "NotConnected",
+    "TransferProtocolType": null
+}

--- a/providers/lenovo/fixtures/v1/vm.floppy.json
+++ b/providers/lenovo/fixtures/v1/vm.floppy.json
@@ -1,0 +1,17 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#VirtualMedia.VirtualMedia",
+    "@odata.id": "/redfish/v1/Managers/1/VirtualMedia/Floppy",
+    "@odata.type": "#VirtualMedia.v1_3_0.VirtualMedia",
+    "Id": "Floppy",
+    "Name": "Remote Floppy",
+    "MediaTypes": [
+        "Floppy",
+        "USBStick"
+    ],
+    "Image": "http://192.168.1.2/boot.img",
+    "ImageName": "boot.img",
+    "Inserted": true,
+    "WriteProtected": false,
+    "ConnectedVia": "URI",
+    "TransferProtocolType": "HTTP"
+}

--- a/providers/lenovo/fixtures/v1/volume.1.json
+++ b/providers/lenovo/fixtures/v1/volume.1.json
@@ -1,0 +1,19 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Volume.Volume",
+    "@odata.id": "/redfish/v1/Systems/1/Storage/RAID_Slot1/Volumes/1",
+    "@odata.type": "#Volume.v1_6_2.Volume",
+    "Id": "1",
+    "Name": "Volume 1",
+    "RAIDType": "RAID1",
+    "CapacityBytes": 999653638144,
+    "Encrypted": false,
+    "Status": {
+        "Health": "OK",
+        "State": "Enabled"
+    },
+    "Actions": {
+        "#Volume.Initialize": {
+            "target": "/redfish/v1/Systems/1/Storage/RAID_Slot1/Volumes/1/Actions/Volume.Initialize"
+        }
+    }
+}

--- a/providers/lenovo/fixtures/v1/volumes.json
+++ b/providers/lenovo/fixtures/v1/volumes.json
@@ -1,0 +1,13 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#VolumeCollection.VolumeCollection",
+    "@odata.id": "/redfish/v1/Systems/1/Storage/RAID_Slot1/Volumes",
+    "@odata.type": "#VolumeCollection.VolumeCollection",
+    "Description": "Collection of Volumes",
+    "Name": "Volume Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/1/Storage/RAID_Slot1/Volumes/1"
+        }
+    ]
+}

--- a/providers/lenovo/floppy.go
+++ b/providers/lenovo/floppy.go
@@ -1,0 +1,44 @@
+package lenovo
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+// compile-time assertions that the provider implements the interfaces.
+var (
+	_ bmc.FloppyImageMounter   = (*Conn)(nil)
+	_ bmc.FloppyImageUnmounter = (*Conn)(nil)
+)
+
+// errFloppyUploadUnsupported is returned by MountFloppyImage: the XCC mounts
+// virtual media by URL and its documented Redfish API exposes no endpoint to
+// upload a raw floppy image.
+var errFloppyUploadUnsupported = errors.New(
+	"lenovo XCC mounts virtual media by URL and does not support uploading a raw floppy image; " +
+		"host the image and use SetVirtualMedia(ctx, \"Floppy\", url) instead")
+
+// MountFloppyImage is not supported on the XCC.
+//
+// Unlike vendors that accept a multipart image upload, the XCC's Redfish API
+// only mounts virtual media referenced by a URL. This method therefore returns a
+// descriptive error directing the caller to host the image and use
+// [Conn.SetVirtualMedia] with a Floppy media URL. Implements
+// bmc.FloppyImageMounter.
+func (c *Conn) MountFloppyImage(ctx context.Context, image io.Reader) error {
+	return errFloppyUploadUnsupported
+}
+
+// UnmountFloppyImage ejects the media mounted in the XCC Floppy virtual-media
+// slot.
+//
+// Implements bmc.FloppyImageUnmounter.
+func (c *Conn) UnmountFloppyImage(ctx context.Context) error {
+	// Use the provider's PATCH-based SetVirtualMedia (XCC does not expose the
+	// EjectMedia action), not the gofish action-based wrapper.
+	_, err := c.SetVirtualMedia(ctx, "Floppy", "")
+	return err
+}

--- a/providers/lenovo/inventory.go
+++ b/providers/lenovo/inventory.go
@@ -1,0 +1,22 @@
+package lenovo
+
+import (
+	"context"
+
+	"github.com/bmc-toolbox/common"
+)
+
+// Inventory collects the hardware and firmware inventory of the XCC-managed
+// system into a *common.Device: system/board identity, memory, processors
+// (CPU/GPU), PCIe devices, network adapters, storage controllers/drives, and
+// the firmware versions reported by UpdateService/FirmwareInventory.
+//
+// When the connection's failInventoryOnError is false (the default, set via
+// [WithFailInventoryOnError]), a failure reading one sub-resource does not abort
+// the whole inventory — the provider returns what it could collect. When true,
+// the first sub-resource error is returned.
+//
+// Implements bmc.InventoryGetter.
+func (c *Conn) Inventory(ctx context.Context) (device *common.Device, err error) {
+	return c.redfishwrapper.Inventory(ctx, c.failInventoryOnError)
+}

--- a/providers/lenovo/inventory_storage_test.go
+++ b/providers/lenovo/inventory_storage_test.go
@@ -1,0 +1,161 @@
+package lenovo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+// Requirement: Aggregate hardware and firmware inventory + partial-failure
+// tolerance (default failInventoryOnError=false).
+func TestInventory(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	device, err := c.Inventory(context.Background())
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	if device == nil {
+		t.Fatal("Inventory returned a nil device")
+	}
+}
+
+// Requirement: Partial-failure tolerance — fail-fast mode surfaces the error.
+//
+// With FailInventoryOnError set and the mock not serving UpdateService, the
+// first sub-resource read fails and Inventory returns an error.
+func TestInventoryFailFast(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t, WithFailInventoryOnError(true))
+
+	if _, err := c.Inventory(context.Background()); err == nil {
+		t.Fatal("expected Inventory to fail fast when a sub-resource is unavailable")
+	}
+}
+
+// Requirement: Storage pool and controller reads.
+func TestStorageControllers(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	controllers, err := c.StorageControllers(context.Background())
+	if err != nil {
+		t.Fatalf("StorageControllers: %v", err)
+	}
+	if len(controllers) != 1 {
+		t.Fatalf("got %d controllers, want 1", len(controllers))
+	}
+	got := controllers[0]
+	if got.ID != "RAID_Slot1" {
+		t.Errorf("controller ID = %q, want %q", got.ID, "RAID_Slot1")
+	}
+	if got.DriveCount != 2 {
+		t.Errorf("DriveCount = %d, want 2", got.DriveCount)
+	}
+	if got.Model == "" {
+		t.Error("controller Model is empty")
+	}
+}
+
+// Requirement: List volumes of a controller.
+func TestVolumes(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	volumes, err := c.Volumes(context.Background(), "RAID_Slot1")
+	if err != nil {
+		t.Fatalf("Volumes: %v", err)
+	}
+	if len(volumes) != 1 {
+		t.Fatalf("got %d volumes, want 1", len(volumes))
+	}
+	if volumes[0].RAIDType != "RAID1" {
+		t.Errorf("RAIDType = %q, want %q", volumes[0].RAIDType, "RAID1")
+	}
+	if volumes[0].CapacityBytes != 999653638144 {
+		t.Errorf("CapacityBytes = %d, want 999653638144", volumes[0].CapacityBytes)
+	}
+}
+
+// Requirement: Volume creation.
+func TestVolumeCreate(t *testing.T) {
+	t.Run("create returns the new volume id", func(t *testing.T) {
+		ts := newTestServer(t, testServerOpts{})
+		c := ts.openedClient(t)
+
+		id, err := c.VolumeCreate(context.Background(), "RAID_Slot1", bmcVolumeReq())
+		if err != nil {
+			t.Fatalf("VolumeCreate: %v", err)
+		}
+		if id != "2" {
+			t.Errorf("new volume id = %q, want %q", id, "2")
+		}
+		if !ts.didCreateVolume() {
+			t.Fatal("expected a POST to the Volumes collection")
+		}
+	})
+
+	t.Run("unknown controller errors", func(t *testing.T) {
+		ts := newTestServer(t, testServerOpts{})
+		c := ts.openedClient(t)
+
+		if _, err := c.VolumeCreate(context.Background(), "NoSuchController", bmcVolumeReq()); err == nil {
+			t.Fatal("expected an error for an unknown controller")
+		}
+	})
+}
+
+// Requirement: Volume initialize, update, delete.
+func TestVolumeLifecycleActions(t *testing.T) {
+	t.Run("initialize", func(t *testing.T) {
+		ts := newTestServer(t, testServerOpts{})
+		c := ts.openedClient(t)
+		if err := c.VolumeInitialize(context.Background(), "RAID_Slot1", "1", "Fast"); err != nil {
+			t.Fatalf("VolumeInitialize: %v", err)
+		}
+		if !ts.didInitializeVolume() {
+			t.Fatal("expected the Volume.Initialize action to be posted")
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		ts := newTestServer(t, testServerOpts{})
+		c := ts.openedClient(t)
+		if err := c.VolumeUpdate(context.Background(), "RAID_Slot1", "1", map[string]any{"Encrypted": true}); err != nil {
+			t.Fatalf("VolumeUpdate: %v", err)
+		}
+		if !ts.didUpdateVolume() {
+			t.Fatal("expected the Volume to be PATCHed")
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		ts := newTestServer(t, testServerOpts{})
+		c := ts.openedClient(t)
+		if err := c.VolumeDelete(context.Background(), "RAID_Slot1", "1"); err != nil {
+			t.Fatalf("VolumeDelete: %v", err)
+		}
+		if !ts.didDeleteVolume() {
+			t.Fatal("expected the Volume to be DELETEd")
+		}
+	})
+
+	t.Run("unknown volume errors", func(t *testing.T) {
+		ts := newTestServer(t, testServerOpts{})
+		c := ts.openedClient(t)
+		if err := c.VolumeDelete(context.Background(), "RAID_Slot1", "999"); err == nil {
+			t.Fatal("expected an error for an unknown volume")
+		}
+	})
+}
+
+func bmcVolumeReq() bmc.VolumeCreateRequest {
+	return bmc.VolumeCreateRequest{
+		Name:          "newvol",
+		RAIDType:      "RAID0",
+		CapacityBytes: 1000000000,
+		Drives:        []string{"/redfish/v1/Systems/1/Storage/RAID_Slot1/Drives/Disk.0"},
+	}
+}

--- a/providers/lenovo/jobs.go
+++ b/providers/lenovo/jobs.go
@@ -1,0 +1,87 @@
+package lenovo
+
+import (
+	"context"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+const (
+	jobServiceURI = "/redfish/v1/JobService"
+	jobsURI       = jobServiceURI + "/Jobs"
+)
+
+// compile-time assertion that the provider implements the interface.
+var _ bmc.JobManager = (*Conn)(nil)
+
+// JobService returns the XCC job-service configuration.
+//
+// Implements bmc.JobManager.
+func (c *Conn) JobService(ctx context.Context) (bmc.JobServiceInfo, error) {
+	var doc struct {
+		ServiceEnabled bool `json:"ServiceEnabled"`
+	}
+	if err := c.getJSON(jobServiceURI, &doc); err != nil {
+		return bmc.JobServiceInfo{}, err
+	}
+
+	return bmc.JobServiceInfo{ServiceEnabled: doc.ServiceEnabled}, nil
+}
+
+// Jobs lists the XCC jobs.
+//
+// Implements bmc.JobManager.
+func (c *Conn) Jobs(ctx context.Context) ([]bmc.JobInfo, error) {
+	members, err := c.collectionMembers(jobsURI)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]bmc.JobInfo, 0, len(members))
+	for _, m := range members {
+		job, err := c.jobAt(m.ODataID)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, job)
+	}
+
+	return out, nil
+}
+
+// Job returns a job by Id.
+//
+// Implements bmc.JobManager.
+func (c *Conn) Job(ctx context.Context, id string) (bmc.JobInfo, error) {
+	return c.jobAt(singleTrailingSlashJoin(jobsURI, id))
+}
+
+// JobUpdateSchedule PATCHes a job's Schedule.
+//
+// Implements bmc.JobManager.
+func (c *Conn) JobUpdateSchedule(ctx context.Context, id string, schedule map[string]any) error {
+	payload := map[string]any{"Schedule": schedule}
+	return checkResponse(c.redfishwrapper.PatchWithHeaders(ctx, singleTrailingSlashJoin(jobsURI, id), payload, nil))
+}
+
+// jobAt reads a single job resource.
+func (c *Conn) jobAt(url string) (bmc.JobInfo, error) {
+	var doc struct {
+		ID              string `json:"Id"`
+		Name            string `json:"Name"`
+		JobState        string `json:"JobState"`
+		PercentComplete int    `json:"PercentComplete"`
+		StartTime       string `json:"StartTime"`
+	}
+	if err := c.getJSON(url, &doc); err != nil {
+		return bmc.JobInfo{}, err
+	}
+
+	return bmc.JobInfo{
+		ID:              doc.ID,
+		Name:            doc.Name,
+		JobState:        doc.JobState,
+		PercentComplete: doc.PercentComplete,
+		StartTime:       doc.StartTime,
+	}, nil
+}

--- a/providers/lenovo/jobs_certs_snmp_test.go
+++ b/providers/lenovo/jobs_certs_snmp_test.go
@@ -1,0 +1,199 @@
+package lenovo
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+// Requirement: Read job service.
+func TestJobService(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	info, err := c.JobService(context.Background())
+	if err != nil {
+		t.Fatalf("JobService: %v", err)
+	}
+	if !info.ServiceEnabled {
+		t.Error("expected the job service to be enabled")
+	}
+}
+
+// Requirement: Read a job.
+func TestJob(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	job, err := c.Job(context.Background(), "Restart")
+	if err != nil {
+		t.Fatalf("Job: %v", err)
+	}
+	if job.ID != "Restart" || job.JobState != "Scheduled" {
+		t.Errorf("unexpected job: %+v", job)
+	}
+}
+
+// Requirement: Update a job schedule.
+func TestJobUpdateSchedule(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if err := c.JobUpdateSchedule(context.Background(), "Restart", map[string]any{"RecurrenceInterval": "P1D"}); err != nil {
+		t.Fatalf("JobUpdateSchedule: %v", err)
+	}
+	if !ts.didUpdateJobSchedule() {
+		t.Error("expected a PATCH of the job schedule")
+	}
+}
+
+// Requirement: Unknown job errors.
+func TestJobUnknown(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if _, err := c.Job(context.Background(), "DoesNotExist"); err == nil {
+		t.Fatal("expected an error for an unknown job")
+	}
+}
+
+// Requirement: Read certificate locations.
+func TestCertificateLocations(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	locs, err := c.CertificateLocations(context.Background())
+	if err != nil {
+		t.Fatalf("CertificateLocations: %v", err)
+	}
+	if len(locs) != 1 || !strings.Contains(locs[0], "Certificates/1") {
+		t.Fatalf("unexpected locations: %v", locs)
+	}
+}
+
+// Requirement: Read a certificate.
+func TestCertificate(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	cert, err := c.Certificate(context.Background(), "/redfish/v1/Managers/1/NetworkProtocol/HTTPS/Certificates/1")
+	if err != nil {
+		t.Fatalf("Certificate: %v", err)
+	}
+	if cert.SubjectCommonName != "XCC-7Z60-SN" || cert.ValidNotAfter == "" {
+		t.Errorf("unexpected certificate: %+v", cert)
+	}
+}
+
+// Requirement: Generate a CSR.
+func TestGenerateCSR(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	csr, err := c.GenerateCSR(context.Background(), bmc.CSRRequest{CommonName: "XCC-test", Country: "US"})
+	if err != nil {
+		t.Fatalf("GenerateCSR: %v", err)
+	}
+	if !strings.Contains(csr, "BEGIN CERTIFICATE REQUEST") {
+		t.Errorf("unexpected CSR: %q", csr)
+	}
+	if !ts.didGenerateCSR() {
+		t.Error("expected a GenerateCSR action")
+	}
+}
+
+// Requirement: Replace a certificate.
+func TestReplaceCertificate(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	err := c.ReplaceCertificate(context.Background(), "-----BEGIN CERTIFICATE-----\nx\n-----END CERTIFICATE-----",
+		"/redfish/v1/Managers/1/NetworkProtocol/HTTPS/Certificates/1")
+	if err != nil {
+		t.Fatalf("ReplaceCertificate: %v", err)
+	}
+	if !ts.didReplaceCertificate() {
+		t.Error("expected a ReplaceCertificate action")
+	}
+}
+
+// Requirement: Rekey and renew a certificate.
+func TestRekeyRenewCertificate(t *testing.T) {
+	certURI := "/redfish/v1/Managers/1/NetworkProtocol/HTTPS/Certificates/1"
+
+	t.Run("rekey", func(t *testing.T) {
+		ts := newTestServer(t, testServerOpts{})
+		c := ts.openedClient(t)
+		if err := c.RekeyCertificate(context.Background(), certURI); err != nil {
+			t.Fatalf("RekeyCertificate: %v", err)
+		}
+		if !ts.didRekeyCertificate() {
+			t.Error("expected a Certificate.Rekey action")
+		}
+	})
+
+	t.Run("renew", func(t *testing.T) {
+		ts := newTestServer(t, testServerOpts{})
+		c := ts.openedClient(t)
+		if err := c.RenewCertificate(context.Background(), certURI); err != nil {
+			t.Fatalf("RenewCertificate: %v", err)
+		}
+		if !ts.didRenewCertificate() {
+			t.Error("expected a Certificate.Renew action")
+		}
+	})
+}
+
+// Requirement: Read SNMP config.
+func TestSNMP(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	cfg, err := c.SNMP(context.Background())
+	if err != nil {
+		t.Fatalf("SNMP: %v", err)
+	}
+	// CommunityNames lives at the top level of the XCC OEM SNMP resource (not
+	// inside SNMPTraps); assert it is read from there.
+	if cfg.TrapPort != 162 || len(cfg.CommunityNames) != 1 || cfg.CommunityNames[0] != "public" {
+		t.Errorf("unexpected SNMP config: %+v", cfg)
+	}
+}
+
+// Requirement: Configure the alert filter + enable v1/v3 traps.
+func TestSNMPConfigure(t *testing.T) {
+	t.Run("alert filter", func(t *testing.T) {
+		ts := newTestServer(t, testServerOpts{})
+		c := ts.openedClient(t)
+		if err := c.SetSNMPAlertFilter(context.Background(), map[string]any{"SNMPv1TrapEnabled": true}); err != nil {
+			t.Fatalf("SetSNMPAlertFilter: %v", err)
+		}
+		if !ts.didPatchSNMP() {
+			t.Error("expected a PATCH of the SNMP resource")
+		}
+	})
+
+	t.Run("enable v1 trap", func(t *testing.T) {
+		ts := newTestServer(t, testServerOpts{})
+		c := ts.openedClient(t)
+		if err := c.EnableSNMPv1Trap(context.Background(), true); err != nil {
+			t.Fatalf("EnableSNMPv1Trap: %v", err)
+		}
+		if !ts.didPatchSNMP() {
+			t.Error("expected a PATCH enabling the SNMPv1 trap")
+		}
+	})
+
+	t.Run("enable v3 trap", func(t *testing.T) {
+		ts := newTestServer(t, testServerOpts{})
+		c := ts.openedClient(t)
+		if err := c.EnableSNMPv3Trap(context.Background(), true); err != nil {
+			t.Fatalf("EnableSNMPv3Trap: %v", err)
+		}
+		if !ts.didPatchSNMP() {
+			t.Error("expected a PATCH enabling the SNMPv3 trap")
+		}
+	})
+}

--- a/providers/lenovo/lenovo.go
+++ b/providers/lenovo/lenovo.go
@@ -1,0 +1,335 @@
+// Package lenovo implements a bmclib provider for Lenovo servers managed by the
+// Lenovo XClarity Controller (XCC).
+//
+// XCC implements the DMTF Redfish standard (Redfish Specification 1.15.0,
+// Schema Bundle 2021.4) with a number of Lenovo OEM extensions. This provider
+// is built on top of the shared gofish-backed [redfishwrapper.Client] — the
+// same foundation used by the generic redfish and the vendor supermicro
+// providers — and layers XCC-specific behaviour (the firmware push protocol,
+// OEM payload fields and registries, vendor compatibility gating) on top in
+// dedicated files.
+//
+// # XCC conventions
+//
+// The following XCC behaviours are relevant throughout the provider and are
+// documented here once:
+//
+//   - Authentication: XCC supports both HTTP Basic authentication and Redfish
+//     session login (the X-Auth-Token header). Only the service root
+//     "/redfish/v1/" is reachable without authentication. Set
+//     [WithUseBasicAuth] to use Basic auth instead of a session.
+//
+//   - Session cap: XCC limits the number of concurrent open sessions to 16.
+//     The provider therefore always releases its session on [Conn.Close]; a
+//     failed operation must still be followed by Close so the session is not
+//     leaked.
+//
+//   - OEM registries: XCC publishes the Lenovo "ExtendedError",
+//     "LenovoExtendedWarning", "LenovoFirmwareUpdateRegistry" and
+//     "BiosAttributeRegistry" registries under "/redfish/v1/Registries". The
+//     error mapping in errors.go lifts the ExtendedError message id and
+//     resolution text into the returned error when present.
+//
+//   - Task monitor quirk: a GET on the XCC TaskMonitor URI deletes a finished
+//     task. Code that waits on long-running operations (e.g. firmware install)
+//     must poll the Task resource, never the TaskMonitor URI.
+//
+// This file holds the provider scaffold: identity, configuration, the
+// connection lifecycle and the vendor compatibility check. Data-plane
+// capabilities (power, boot, BIOS, inventory, firmware, virtual media, ...) are
+// implemented in their own files and registered by appending to [Features].
+package lenovo
+
+import (
+	"context"
+	"crypto/x509"
+	"net/http"
+	"strings"
+
+	"github.com/bmc-toolbox/bmclib/v2/internal/httpclient"
+	"github.com/bmc-toolbox/bmclib/v2/internal/redfishwrapper"
+	"github.com/bmc-toolbox/bmclib/v2/providers"
+	"github.com/go-logr/logr"
+	"github.com/jacobweinstock/registrar"
+
+	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
+)
+
+const (
+	// ProviderName is the registered name of this provider.
+	ProviderName = "lenovo"
+	// ProviderProtocol is the transport/protocol this provider speaks.
+	ProviderProtocol = "redfish"
+
+	// vendorLenovo is the lower-cased token matched against the device
+	// manufacturer/model during the compatibility check.
+	//
+	// Note: github.com/bmc-toolbox/common does not define a VendorLenovo
+	// constant, so the vendor is detected with a case-insensitive substring
+	// match rather than a typed comparison.
+	vendorLenovo = "lenovo"
+)
+
+// Features is the set of bmclib features this provider implements.
+//
+// Each capability change appends the feature flags it implements so the
+// registry advertises only what is actually wired up.
+var Features = registrar.Features{
+	// power-boot-bios
+	providers.FeaturePowerState,
+	providers.FeaturePowerSet,
+	providers.FeatureBootDeviceSet,
+	providers.FeatureBootProgress,
+	providers.FeatureGetBiosConfiguration,
+	providers.FeatureSetBiosConfiguration,
+	providers.FeatureResetBiosConfiguration,
+	providers.FeatureSecureBoot,
+	providers.FeatureThermalRead,
+	providers.FeaturePowerRead,
+	providers.FeaturePowerCap,
+	// inventory-storage
+	providers.FeatureInventoryRead,
+	providers.FeatureVolumeRead,
+	providers.FeatureVolumeManagement,
+	// firmware-tasks
+	providers.FeatureFirmwareInstall,
+	providers.FeatureFirmwareInstallStatus,
+	providers.FeatureFirmwareUpload,
+	providers.FeatureFirmwareInstallUploaded,
+	providers.FeatureFirmwareUploadInitiateInstall,
+	providers.FeatureFirmwareInstallSteps,
+	providers.FeatureFirmwareTaskStatus,
+	// virtual-media
+	providers.FeatureVirtualMedia,
+	providers.FeatureUnmountFloppyImage,
+	// users-accounts
+	providers.FeatureUserRead,
+	providers.FeatureUserCreate,
+	providers.FeatureUserUpdate,
+	providers.FeatureUserDelete,
+	// logs-sel
+	providers.FeatureGetSystemEventLog,
+	providers.FeatureGetSystemEventLogRaw,
+	providers.FeatureClearSystemEventLog,
+	// bmc-management
+	providers.FeatureBmcReset,
+	providers.FeatureLicenseManagement,
+	providers.FeatureSecureKeyLifecycle,
+	// network-serial
+	providers.FeatureNetworkInterfaceRead,
+	providers.FeatureNetworkInterfaceSet,
+	providers.FeatureNetworkProtocolRead,
+	providers.FeatureNetworkProtocolSet,
+	providers.FeatureSerialRead,
+	providers.FeatureSerialSet,
+	// events-telemetry
+	providers.FeatureEventSubscription,
+	providers.FeatureTelemetry,
+	// jobs-certs-snmp
+	providers.FeatureJobManagement,
+	providers.FeatureCertificateManagement,
+	providers.FeatureSNMP,
+}
+
+// Conn is a connection to a Lenovo XCC BMC.
+//
+// It wraps a [redfishwrapper.Client]; capability methods delegate to the
+// wrapper for standard Redfish behaviour and drop to raw requests only for XCC
+// OEM operations.
+type Conn struct {
+	redfishwrapper *redfishwrapper.Client
+	// failInventoryOnError, when true, makes Inventory return on the first
+	// sub-resource error instead of collecting best-effort. Defaults to false.
+	failInventoryOnError bool
+	Log                  logr.Logger
+}
+
+// Config holds the optional, user-tunable settings for a [Conn].
+type Config struct {
+	// HTTPClient is the HTTP client used for all requests. When nil a default
+	// client is built.
+	HTTPClient *http.Client
+	// Port is the TCP port the XCC Redfish service listens on. Defaults to "443".
+	Port string
+	// VersionsNotCompatible is a list of Redfish version strings to treat as
+	// incompatible. With this set, Registry.FilterForCompatible will skip
+	// devices reporting one of these versions.
+	VersionsNotCompatible []string
+	// RootCAs, when set, enables verified TLS against the given cert pool.
+	RootCAs *x509.CertPool
+	// UseBasicAuth selects HTTP Basic authentication instead of Redfish session
+	// login. See the package documentation on the XCC session cap.
+	UseBasicAuth bool
+	// DisableEtagMatch disables the If-Match Etag header on POST/PATCH requests
+	// to System entity endpoints.
+	DisableEtagMatch bool
+	// SystemName selects a specific ComputerSystem by name on multi-system
+	// devices. Empty means the first/only system.
+	SystemName string
+	// FailInventoryOnError, when true, makes Inventory return on the first
+	// sub-resource error instead of collecting best-effort. Defaults to false.
+	FailInventoryOnError bool
+}
+
+// Option mutates a [Config]. Pass options to [New].
+type Option func(*Config)
+
+// WithHTTPClient sets the HTTP client used for all requests.
+func WithHTTPClient(c *http.Client) Option {
+	return func(cfg *Config) { cfg.HTTPClient = c }
+}
+
+// WithPort sets the XCC Redfish service port (default "443").
+func WithPort(port string) Option {
+	return func(cfg *Config) { cfg.Port = port }
+}
+
+// WithVersionsNotCompatible sets the Redfish versions to treat as incompatible.
+//
+// The version string must match the value returned by the device, e.g.
+// curl -k "https://<xcc>/redfish/v1" | jq .RedfishVersion
+func WithVersionsNotCompatible(versions []string) Option {
+	return func(cfg *Config) { cfg.VersionsNotCompatible = versions }
+}
+
+// WithRootCAs enables verified TLS using the provided cert pool.
+func WithRootCAs(pool *x509.CertPool) Option {
+	return func(cfg *Config) { cfg.RootCAs = pool }
+}
+
+// WithUseBasicAuth selects HTTP Basic authentication instead of Redfish session
+// login.
+func WithUseBasicAuth(use bool) Option {
+	return func(cfg *Config) { cfg.UseBasicAuth = use }
+}
+
+// WithSystemName selects a specific ComputerSystem by name.
+func WithSystemName(name string) Option {
+	return func(cfg *Config) { cfg.SystemName = name }
+}
+
+// WithEtagMatchDisabled disables the If-Match Etag header on POST/PATCH requests
+// to System entity endpoints.
+func WithEtagMatchDisabled(d bool) Option {
+	return func(cfg *Config) { cfg.DisableEtagMatch = d }
+}
+
+// WithFailInventoryOnError makes Inventory return on the first sub-resource
+// error instead of collecting best-effort.
+func WithFailInventoryOnError(fail bool) Option {
+	return func(cfg *Config) { cfg.FailInventoryOnError = fail }
+}
+
+// newConfig builds a [Config] with defaults applied, then applies the given
+// options. Defaults: HTTP client from httpclient.Build, port "443", empty
+// incompatible-versions list.
+func newConfig(opts ...Option) *Config {
+	cfg := &Config{
+		HTTPClient:            httpclient.Build(),
+		Port:                  "443",
+		VersionsNotCompatible: []string{},
+	}
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	return cfg
+}
+
+// New returns a [Conn] for the given XCC host. The connection is not opened
+// until [Conn.Open] is called.
+func New(host, user, pass string, log logr.Logger, opts ...Option) *Conn {
+	cfg := newConfig(opts...)
+
+	rfOpts := []redfishwrapper.Option{
+		redfishwrapper.WithHTTPClient(cfg.HTTPClient),
+		redfishwrapper.WithVersionsNotCompatible(cfg.VersionsNotCompatible),
+		redfishwrapper.WithEtagMatchDisabled(cfg.DisableEtagMatch),
+		redfishwrapper.WithBasicAuthEnabled(cfg.UseBasicAuth),
+		redfishwrapper.WithSystemName(cfg.SystemName),
+	}
+
+	if cfg.RootCAs != nil {
+		rfOpts = append(rfOpts, redfishwrapper.WithSecureTLS(cfg.RootCAs))
+	}
+
+	return &Conn{
+		Log:                  log,
+		failInventoryOnError: cfg.FailInventoryOnError,
+		redfishwrapper:       redfishwrapper.NewClient(host, cfg.Port, user, pass, rfOpts...),
+	}
+}
+
+// Name returns the provider name ("lenovo").
+func (c *Conn) Name() string {
+	return ProviderName
+}
+
+// Open establishes the connection: it opens a Redfish session (or sets up Basic
+// auth when [WithUseBasicAuth] was given).
+func (c *Conn) Open(ctx context.Context) error {
+	return c.redfishwrapper.Open(ctx)
+}
+
+// Close releases the connection.
+//
+// The session is always released so the XCC 16-session cap is respected, even
+// when a preceding operation failed. Under Basic auth there is no session and
+// Close is effectively a no-op.
+func (c *Conn) Close(ctx context.Context) error {
+	return c.redfishwrapper.Close(ctx)
+}
+
+// Compatible reports whether this provider can manage the device.
+//
+// The device is compatible only when a session can be established, the Redfish
+// version is not excluded via [WithVersionsNotCompatible], and the device
+// identifies as Lenovo. It never panics on an unreachable host; it returns
+// false and logs at V(2).
+func (c *Conn) Compatible(ctx context.Context) bool {
+	if err := c.Open(ctx); err != nil {
+		c.Log.V(2).WithValues("provider", c.Name()).
+			Info(bmclibErrs.ErrCompatibilityCheck.Error(), "error", err.Error())
+
+		return false
+	}
+	defer c.Close(ctx)
+
+	if !c.redfishwrapper.VersionCompatible() {
+		c.Log.V(2).WithValues("provider", c.Name()).
+			Info(bmclibErrs.ErrCompatibilityCheck.Error(), "reason", "incompatible redfish version")
+
+		return false
+	}
+
+	ok, err := c.deviceIsLenovo(ctx)
+	if err != nil {
+		c.Log.V(2).WithValues("provider", c.Name()).
+			Info(bmclibErrs.ErrCompatibilityCheck.Error(), "error", err.Error())
+
+		return false
+	}
+
+	return ok
+}
+
+// deviceIsLenovo returns true when the device manufacturer or model identifies
+// as Lenovo.
+//
+// common.VendorLenovo does not exist, so this uses a case-insensitive substring
+// match against the manufacturer and model strings reported by the
+// ComputerSystem.
+func (c *Conn) deviceIsLenovo(ctx context.Context) (bool, error) {
+	vendor, model, err := c.redfishwrapper.DeviceVendorModel(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	if strings.Contains(strings.ToLower(vendor), vendorLenovo) ||
+		strings.Contains(strings.ToLower(model), vendorLenovo) {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/providers/lenovo/lenovo_test.go
+++ b/providers/lenovo/lenovo_test.go
@@ -1,0 +1,251 @@
+package lenovo
+
+import (
+	"context"
+	"crypto/x509"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+// Requirement: Provider identity and registration.
+func TestName(t *testing.T) {
+	if ProviderName != "lenovo" {
+		t.Fatalf("ProviderName = %q, want %q", ProviderName, "lenovo")
+	}
+	c := New("127.0.0.1", "u", "p", logr.Discard())
+	if got := c.Name(); got != ProviderName {
+		t.Fatalf("Name() = %q, want %q", got, ProviderName)
+	}
+}
+
+// Requirement: Connection lifecycle and session management — Open establishes a
+// session.
+func TestOpenCreatesSession(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	defer ts.Close()
+
+	c := ts.client(t)
+	if err := c.Open(context.Background()); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer c.Close(context.Background())
+
+	if !ts.didCreateSession() {
+		t.Fatal("expected a session to be created on Open")
+	}
+}
+
+// Requirement: Connection lifecycle — Close releases the session.
+func TestCloseReleasesSession(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	defer ts.Close()
+
+	c := ts.client(t)
+	if err := c.Open(context.Background()); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := c.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if !ts.didDeleteSession() {
+		t.Fatal("expected the session to be deleted on Close")
+	}
+}
+
+// Requirement: Connection lifecycle — Basic auth bypasses session creation.
+func TestOpenBasicAuthNoSession(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	defer ts.Close()
+
+	c := ts.client(t, WithUseBasicAuth(true))
+	if err := c.Open(context.Background()); err != nil {
+		t.Fatalf("Open (basic auth): %v", err)
+	}
+	defer c.Close(context.Background())
+
+	if ts.didCreateSession() {
+		t.Fatal("did not expect a session to be created under basic auth")
+	}
+}
+
+// Requirement: Connection lifecycle — Open returns a wrapped error on auth
+// failure.
+func TestOpenAuthFailure(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{rejectAuth: true})
+	defer ts.Close()
+
+	c := ts.client(t)
+	if err := c.Open(context.Background()); err == nil {
+		t.Fatal("expected Open to fail when the BMC rejects authentication")
+	}
+}
+
+// Requirement: Vendor compatibility gating.
+func TestCompatible(t *testing.T) {
+	tests := []struct {
+		name          string
+		systemFixture string
+		rejectAuth    bool
+		unreachable   bool
+		want          bool
+	}{
+		{name: "lenovo device is compatible", systemFixture: "system.lenovo.json", want: true},
+		{name: "non-lenovo device is filtered out", systemFixture: "system.nonlenovo.json", want: false},
+		{name: "unreachable device is not compatible", unreachable: true, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newTestServer(t, testServerOpts{systemFixture: tt.systemFixture, rejectAuth: tt.rejectAuth})
+
+			c := ts.client(t)
+
+			if tt.unreachable {
+				// Shut the server down so the host cannot be reached; Compatible
+				// must return false without panicking.
+				ts.Close()
+			} else {
+				defer ts.Close()
+			}
+
+			if got := c.Compatible(context.Background()); got != tt.want {
+				t.Fatalf("Compatible() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Requirement: Configuration options — defaults are applied and options
+// override them.
+func TestConfigDefaultsAndOverrides(t *testing.T) {
+	// Defaults.
+	cfg := newConfig()
+	if cfg.Port != "443" {
+		t.Errorf("default Port = %q, want %q", cfg.Port, "443")
+	}
+	if cfg.HTTPClient == nil {
+		t.Error("default HTTPClient is nil, want a default client")
+	}
+	if cfg.UseBasicAuth {
+		t.Error("default UseBasicAuth = true, want false")
+	}
+
+	// Overrides.
+	hc := &http.Client{}
+	pool := x509.NewCertPool()
+	cfg = newConfig(
+		WithPort("8443"),
+		WithHTTPClient(hc),
+		WithUseBasicAuth(true),
+		WithRootCAs(pool),
+		WithSystemName("Self"),
+		WithEtagMatchDisabled(true),
+		WithVersionsNotCompatible([]string{"1.0.0"}),
+	)
+	if cfg.Port != "8443" {
+		t.Errorf("Port = %q, want %q", cfg.Port, "8443")
+	}
+	if cfg.HTTPClient != hc {
+		t.Error("HTTPClient not overridden")
+	}
+	if !cfg.UseBasicAuth {
+		t.Error("UseBasicAuth not set")
+	}
+	if cfg.RootCAs != pool {
+		t.Error("RootCAs not set")
+	}
+	if cfg.SystemName != "Self" {
+		t.Errorf("SystemName = %q, want %q", cfg.SystemName, "Self")
+	}
+	if !cfg.DisableEtagMatch {
+		t.Error("DisableEtagMatch not set")
+	}
+	if len(cfg.VersionsNotCompatible) != 1 || cfg.VersionsNotCompatible[0] != "1.0.0" {
+		t.Errorf("VersionsNotCompatible = %v, want [1.0.0]", cfg.VersionsNotCompatible)
+	}
+}
+
+// Requirement: Service Root discovery.
+func TestServiceRoot(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	root, err := c.ServiceRoot(context.Background())
+	if err != nil {
+		t.Fatalf("ServiceRoot: %v", err)
+	}
+
+	if root.RedfishVersion != "1.15.0" {
+		t.Errorf("RedfishVersion = %q, want %q", root.RedfishVersion, "1.15.0")
+	}
+	if root.Vendor != "Lenovo" {
+		t.Errorf("Vendor = %q, want %q", root.Vendor, "Lenovo")
+	}
+
+	links := map[string]string{
+		"Systems":       root.Systems.ODataID,
+		"Managers":      root.Managers.ODataID,
+		"UpdateService": root.UpdateService.ODataID,
+	}
+	for name, got := range links {
+		if got == "" {
+			t.Errorf("service root link %s is empty", name)
+		}
+	}
+	if root.Systems.ODataID != "/redfish/v1/Systems" {
+		t.Errorf("Systems link = %q, want /redfish/v1/Systems", root.Systems.ODataID)
+	}
+}
+
+// Requirement: Error mapping including the OEM ExtendedError registry.
+func TestRedfishErrorDetail(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string // substring expected in the detail
+	}{
+		{
+			name: "OEM ExtendedError with resolution",
+			body: `{"error":{"code":"Base.1.8.GeneralError","message":"A general error has occurred",` +
+				`"@Message.ExtendedInfo":[{"MessageId":"Lenovo.ExtendedError.1.2.2.ParamError",` +
+				`"Message":"The parameter is invalid.","Resolution":"Correct the parameter and retry."}]}}`,
+			want: "Correct the parameter and retry",
+		},
+		{
+			name: "top-level code and message only",
+			body: `{"error":{"code":"Base.1.8.MalformedJSON","message":"The request body is malformed."}}`,
+			want: "The request body is malformed.",
+		},
+		{
+			name: "non-redfish body returns empty",
+			body: `not json at all`,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := redfishErrorDetail([]byte(tt.body))
+			if tt.want == "" {
+				if got != "" {
+					t.Fatalf("detail = %q, want empty", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tt.want) {
+				t.Fatalf("detail = %q, want it to contain %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Requirement: Error mapping — parseRedfishError tolerates a nil response.
+func TestParseRedfishErrorNilResponse(t *testing.T) {
+	if err := parseRedfishError(nil); err == nil {
+		t.Fatal("expected an error for a nil response")
+	}
+}

--- a/providers/lenovo/license.go
+++ b/providers/lenovo/license.go
@@ -1,0 +1,80 @@
+package lenovo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+// licensesURI is the XCC License collection.
+const licensesURI = "/redfish/v1/LicenseService/Licenses"
+
+// compile-time assertion that the provider implements the interface.
+var _ bmc.LicenseManager = (*Conn)(nil)
+
+// Licenses returns the installed XCC licenses.
+//
+// Implements bmc.LicenseManager.
+func (c *Conn) Licenses(ctx context.Context) ([]bmc.LicenseInfo, error) {
+	var collection struct {
+		Members []odataID `json:"Members"`
+	}
+	if err := c.getJSON(licensesURI, &collection); err != nil {
+		// Some XCC firmware levels do not expose the LicenseService collection
+		// and return 404 here. Treat an absent service as "no licenses" rather
+		// than failing the read. TODO: resolve the per-firmware LicenseService
+		// path variance (see examples/lenovo-smoketest/HARDWARE-TEST-PLAN.md
+		// TC-BMC-4); other errors still propagate.
+		if errors.Is(err, errResourceNotFound) {
+			return []bmc.LicenseInfo{}, nil
+		}
+		return nil, err
+	}
+
+	out := make([]bmc.LicenseInfo, 0, len(collection.Members))
+	for _, m := range collection.Members {
+		var lic struct {
+			ID            string `json:"Id"`
+			EntitlementID string `json:"EntitlementId"`
+			LicenseType   string `json:"LicenseType"`
+			Removable     bool   `json:"Removable"`
+			Status        struct {
+				State string `json:"State"`
+			} `json:"Status"`
+		}
+		if err := c.getJSON(m.ODataID, &lic); err != nil {
+			return nil, err
+		}
+
+		out = append(out, bmc.LicenseInfo{
+			ID:            lic.ID,
+			EntitlementID: lic.EntitlementID,
+			LicenseType:   lic.LicenseType,
+			State:         lic.Status.State,
+			Removable:     lic.Removable,
+		})
+	}
+
+	return out, nil
+}
+
+// LicenseInstall installs a license by POSTing its license string to the
+// License collection.
+//
+// Implements bmc.LicenseManager.
+func (c *Conn) LicenseInstall(ctx context.Context, license string) error {
+	payload := map[string]any{"LicenseString": license}
+	return checkResponse(c.redfishwrapper.PostWithHeaders(ctx, licensesURI, payload, nil))
+}
+
+// LicenseDelete removes an installed license by Id.
+//
+// Implements bmc.LicenseManager.
+func (c *Conn) LicenseDelete(ctx context.Context, licenseID string) error {
+	if licenseID == "" {
+		return fmt.Errorf("license id is required")
+	}
+	return checkResponse(c.redfishwrapper.Delete(singleTrailingSlashJoin(licensesURI, licenseID)))
+}

--- a/providers/lenovo/logs.go
+++ b/providers/lenovo/logs.go
@@ -1,0 +1,59 @@
+package lenovo
+
+import (
+	"context"
+	"fmt"
+)
+
+// XCC log-service ids. XCC exposes several log services beyond the IPMI SEL;
+// these constants name the ones documented in the XCC REST API guide.
+const (
+	LogServiceActive         = "Active"
+	LogServiceAudit          = "AuditLog"
+	LogServicePlatform       = "PlatformLog"
+	LogServiceMaintenance    = "MaintenanceLog"
+	LogServiceServiceAdvisor = "ServiceAdvisorLog"
+	LogServiceDiagnostic     = "DiagnosticLog"
+)
+
+// EventLog returns the entries of a specific BMC log service, identified by its
+// Redfish LogService Id (e.g. the XCC OEM log types: "AuditLog", "PlatformLog",
+// "MaintenanceLog", "ServiceAdvisorLog", "DiagnosticLog", "Active").
+//
+// Entries are returned as rows of [id, created, severity, message]. A descriptive
+// error is returned when no log service with the given id is present. This is an
+// XCC-specific provider method (the additional log types are not modelled by a
+// bmc.Feature interface).
+func (c *Conn) EventLog(ctx context.Context, logServiceID string) ([][]string, error) {
+	managers, err := c.redfishwrapper.Managers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, m := range managers {
+		logServices, err := m.LogServices()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, ls := range logServices {
+			if ls.ID != logServiceID {
+				continue
+			}
+
+			lentries, err := ls.Entries()
+			if err != nil {
+				return nil, fmt.Errorf("reading entries of log service %q: %w", logServiceID, err)
+			}
+
+			rows := make([][]string, 0, len(lentries))
+			for _, e := range lentries {
+				rows = append(rows, []string{e.ID, e.Created, string(e.Severity), e.Message})
+			}
+
+			return rows, nil
+		}
+	}
+
+	return nil, fmt.Errorf("log service %q not found on this device", logServiceID)
+}

--- a/providers/lenovo/logs_sel_test.go
+++ b/providers/lenovo/logs_sel_test.go
@@ -1,0 +1,79 @@
+package lenovo
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Requirement: Read the System Event Log.
+func TestGetSystemEventLog(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	entries, err := c.GetSystemEventLog(context.Background())
+	if err != nil {
+		t.Fatalf("GetSystemEventLog: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least one SEL entry")
+	}
+	// Each row is [id, created, description, message].
+	if len(entries[0]) != 4 {
+		t.Fatalf("row width = %d, want 4", len(entries[0]))
+	}
+}
+
+// Requirement: Read the raw System Event Log.
+func TestGetSystemEventLogRaw(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	raw, err := c.GetSystemEventLogRaw(context.Background())
+	if err != nil {
+		t.Fatalf("GetSystemEventLogRaw: %v", err)
+	}
+	if !strings.Contains(raw, "System boot completed") {
+		t.Errorf("raw SEL did not contain the expected entry: %s", raw)
+	}
+}
+
+// Requirement: Clear the System Event Log.
+func TestClearSystemEventLog(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if err := c.ClearSystemEventLog(context.Background()); err != nil {
+		t.Fatalf("ClearSystemEventLog: %v", err)
+	}
+	if !ts.didClearSEL() {
+		t.Error("expected a LogService.ClearLog action on the chassis SEL")
+	}
+}
+
+// Requirement: Additional XCC log types — read the audit log.
+func TestEventLogAudit(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	entries, err := c.EventLog(context.Background(), LogServiceAudit)
+	if err != nil {
+		t.Fatalf("EventLog(AuditLog): %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d audit entries, want 1", len(entries))
+	}
+	if !strings.Contains(entries[0][3], "logged in") {
+		t.Errorf("unexpected audit message: %q", entries[0][3])
+	}
+}
+
+// Requirement: Unknown/absent service errors clearly.
+func TestEventLogUnknown(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if _, err := c.EventLog(context.Background(), "NoSuchLog"); err == nil {
+		t.Fatal("expected an error for an absent log service")
+	}
+}

--- a/providers/lenovo/main_test.go
+++ b/providers/lenovo/main_test.go
@@ -1,0 +1,933 @@
+package lenovo
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+const fixturesDir = "./fixtures/v1"
+
+// testServer is an httptest-backed XCC Redfish mock. It serves recorded JSON
+// fixtures and emulates Redfish session create/delete so the provider can be
+// exercised entirely offline.
+//
+// It records whether a session was created and deleted so tests can assert the
+// connection lifecycle (e.g. that Close always releases the session).
+type testServer struct {
+	*httptest.Server
+
+	mu             sync.Mutex
+	sessionCreated bool
+	sessionDeleted bool
+	// lastResetType records the ResetType posted to ComputerSystem.Reset.
+	lastResetType string
+	// biosReset records whether the Bios.ResetBios action was posted.
+	biosReset bool
+	// systemPatched records whether the ComputerSystem was PATCHed (boot set).
+	systemPatched bool
+	// biosPatched records whether the Bios settings target was PATCHed.
+	biosPatched bool
+	// biosPatchBody records the decoded body of the last Bios settings PATCH so
+	// tests can assert XCC-specific payload shape (Attributes-only, no
+	// @Redfish.SettingsApplyTime — which XCC rejects).
+	biosPatchBody map[string]any
+	// secureBootPatched records whether the SecureBoot resource was PATCHed.
+	secureBootPatched bool
+	// secureBootKeysReset records whether the SecureBoot.ResetKeys action ran.
+	secureBootKeysReset bool
+	// powerPatched records whether the Power resource was PATCHed (cap set).
+	powerPatched bool
+	// volumeCreated records whether a volume was POSTed to a Volumes collection.
+	volumeCreated bool
+	// volumeInitialized records whether the Volume.Initialize action ran.
+	volumeInitialized bool
+	// volumeUpdated records whether a Volume was PATCHed.
+	volumeUpdated bool
+	// volumeDeleted records whether a Volume was DELETEd.
+	volumeDeleted bool
+	// claimedBusy records whether UpdateService was PATCHed with busy=true.
+	claimedBusy bool
+	// releasedBusy records whether UpdateService was PATCHed with busy=false.
+	releasedBusy bool
+	// multipartPushed records a POST to the multipart push URI (/mfwupdate).
+	multipartPushed bool
+	// rawPushed records a POST to the raw push URI (/fwupdate).
+	rawPushed bool
+	// simpleUpdated records a POST to UpdateService.SimpleUpdate.
+	simpleUpdated bool
+	// startUpdated records a POST to UpdateService.StartUpdate.
+	startUpdated bool
+	// cdInserted records a VirtualMedia CD insert action.
+	cdInserted bool
+	// floppyEjected records a VirtualMedia Floppy eject action.
+	floppyEjected bool
+	// vmOps records the ordered VirtualMedia PATCH operations as "Slot:insert"
+	// or "Slot:eject", so tests can assert eject-before-insert.
+	vmOps []string
+	// accountPosted records a POST to the accounts collection.
+	accountPosted bool
+	// accountPatched records a PATCH to an account slot.
+	accountPatched bool
+	// rolePosted records a POST to the roles collection.
+	rolePosted bool
+	// selCleared records a LogService.ClearLog action on the chassis SEL.
+	selCleared bool
+	// bmcReset records a Manager.Reset action.
+	bmcReset bool
+	// factoryReset records a Manager.ResetToDefaults action.
+	factoryReset bool
+	// licenseInstalled records a POST to the License collection.
+	licenseInstalled bool
+	// licenseDeleted records a DELETE of a License.
+	licenseDeleted bool
+	// sklmPatched records a PATCH of the SecureKeyLifecycleService.
+	sklmPatched bool
+	// bmcEthPatched records a PATCH of a BMC ethernet interface.
+	bmcEthPatched bool
+	// hostIfacePatched records a PATCH of a host interface.
+	hostIfacePatched bool
+	// netProtoPatched records a PATCH of ManagerNetworkProtocol.
+	netProtoPatched bool
+	// serialPatched records a PATCH of a serial interface.
+	serialPatched bool
+	// subscriptionCreated/Deleted record event subscription create/delete.
+	subscriptionCreated bool
+	subscriptionDeleted bool
+	// testEventSubmitted records a SubmitTestEvent action.
+	testEventSubmitted bool
+	// eventServicePatched records a PATCH of the EventService.
+	eventServicePatched bool
+	// testMetricSubmitted records a SubmitTestMetricReport action.
+	testMetricSubmitted bool
+	// jobScheduleUpdated records a PATCH of a Job's Schedule.
+	jobScheduleUpdated bool
+	// csrGenerated/certReplaced/certRekeyed/certRenewed record certificate actions.
+	csrGenerated bool
+	certReplaced bool
+	certRekeyed  bool
+	certRenewed  bool
+	// snmpPatched records a PATCH of the OEM SNMP resource.
+	snmpPatched bool
+}
+
+// fixtureBytes reads a fixture file from the fixtures dir.
+func fixtureBytes(t *testing.T, file string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(fixturesDir, file))
+	if err != nil {
+		t.Fatalf("failed to read fixture %q: %v", file, err)
+	}
+	return b
+}
+
+// testServerOpts configures a testServer.
+type testServerOpts struct {
+	// systemFixture is the fixture file served for /redfish/v1/Systems/1.
+	systemFixture string
+	// rejectAuth makes the session-create endpoint return HTTP 401.
+	rejectAuth bool
+	// updateServiceFixture is the fixture served for /redfish/v1/UpdateService.
+	updateServiceFixture string
+	// rejectAccountPost makes the accounts-collection POST return HTTP 405,
+	// forcing the Intel-Purley slot-PATCH fallback.
+	rejectAccountPost bool
+	// licenseServiceNotFound drops the LicenseService routes so the mock returns
+	// 404, emulating XCC firmware levels without a LicenseService collection.
+	licenseServiceNotFound bool
+}
+
+// newTestServer builds and starts a TLS mock XCC server.
+func newTestServer(t *testing.T, opts testServerOpts) *testServer {
+	t.Helper()
+
+	if opts.systemFixture == "" {
+		opts.systemFixture = "system.lenovo.json"
+	}
+	if opts.updateServiceFixture == "" {
+		opts.updateServiceFixture = "updateservice.json"
+	}
+
+	ts := &testServer{}
+
+	// path -> fixture file for plain GETs.
+	routes := map[string]string{
+		"/redfish/v1/":                                                "serviceroot.json",
+		"/redfish/v1/Systems":                                         "systems.json",
+		"/redfish/v1/Systems/1":                                       opts.systemFixture,
+		"/redfish/v1/Systems/1/Bios/Pending":                          "bios.pending.json",
+		"/redfish/v1/Systems/1/Bios":                                  "bios.json",
+		"/redfish/v1/Systems/1/SecureBoot":                            "secureboot.json",
+		"/redfish/v1/Chassis":                                         "chassis.json",
+		"/redfish/v1/Chassis/1":                                       "chassis.1.json",
+		"/redfish/v1/Chassis/1/Power":                                 "power.json",
+		"/redfish/v1/Chassis/1/Thermal":                               "thermal.json",
+		"/redfish/v1/Systems/1/Storage":                               "storage.json",
+		"/redfish/v1/Systems/1/Storage/RAID_Slot1":                    "storage.raid.json",
+		"/redfish/v1/Systems/1/Storage/RAID_Slot1/Volumes/1":          "volume.1.json",
+		"/redfish/v1/TaskService":                                     "taskservice.json",
+		"/redfish/v1/TaskService/Tasks":                               "tasks.json",
+		"/redfish/v1/TaskService/Tasks/1":                             "task.1.json",
+		"/redfish/v1/Managers":                                        "managers.json",
+		"/redfish/v1/Managers/1":                                      "manager.1.json",
+		"/redfish/v1/Managers/1/VirtualMedia":                         "managers.1.virtualmedia.json",
+		"/redfish/v1/AccountService":                                  "accountservice.json",
+		"/redfish/v1/AccountService/Accounts/1":                       "account.1.json",
+		"/redfish/v1/AccountService/Accounts/2":                       "account.2.json",
+		"/redfish/v1/AccountService/Roles/Administrator":              "role.administrator.json",
+		"/redfish/v1/AccountService/Roles/Operator":                   "role.operator.json",
+		"/redfish/v1/Managers/1/LogServices":                          "managers.1.logservices.json",
+		"/redfish/v1/Managers/1/LogServices/Sel":                      "ls.sel.json",
+		"/redfish/v1/Managers/1/LogServices/AuditLog":                 "ls.audit.json",
+		"/redfish/v1/Managers/1/LogServices/Sel/Entries":              "ls.sel.entries.json",
+		"/redfish/v1/Managers/1/LogServices/Sel/Entries/1":            "ls.sel.entry.1.json",
+		"/redfish/v1/Managers/1/LogServices/AuditLog/Entries":         "ls.audit.entries.json",
+		"/redfish/v1/Managers/1/LogServices/AuditLog/Entries/1":       "ls.audit.entry.1.json",
+		"/redfish/v1/Chassis/1/LogServices":                           "chassis.1.logservices.json",
+		"/redfish/v1/Chassis/1/LogServices/Sel":                       "chassis.ls.sel.json",
+		"/redfish/v1/LicenseService/Licenses":                         "licenses.json",
+		"/redfish/v1/LicenseService/Licenses/XCC_Advanced":            "license.xcc_advanced.json",
+		"/redfish/v1/Managers/1/Oem/Lenovo/SecureKeyLifecycleService": "sklm.json",
+		"/redfish/v1/Managers/1/EthernetInterfaces":                   "manager.ethernetinterfaces.json",
+		"/redfish/v1/Managers/1/EthernetInterfaces/eth0":              "manager.eth0.json",
+		"/redfish/v1/Managers/1/HostInterfaces":                       "manager.hostinterfaces.json",
+		"/redfish/v1/Managers/1/HostInterfaces/1":                     "manager.hostinterface.1.json",
+		"/redfish/v1/Managers/1/SerialInterfaces":                     "manager.serialinterfaces.json",
+		"/redfish/v1/Managers/1/SerialInterfaces/1":                   "manager.serial.1.json",
+		"/redfish/v1/Managers/1/NetworkProtocol":                      "networkprotocol.json",
+		"/redfish/v1/Systems/1/EthernetInterfaces":                    "system.ethernetinterfaces.json",
+		"/redfish/v1/Systems/1/EthernetInterfaces/NIC.1":              "system.eth.nic1.json",
+		"/redfish/v1/EventService":                                    "eventservice.json",
+		"/redfish/v1/EventService/Subscriptions/1":                    "subscription.1.json",
+		"/redfish/v1/TelemetryService":                                "telemetryservice.json",
+		"/redfish/v1/TelemetryService/MetricReports":                  "metricreports.json",
+		"/redfish/v1/TelemetryService/MetricReports/PowerMetrics":     "metricreport.power.json",
+		"/redfish/v1/TelemetryService/MetricReportDefinitions":        "metricreportdefinitions.json",
+		"/redfish/v1/TelemetryService/MetricDefinitions":              "metricdefinitions.json",
+		"/redfish/v1/JobService":                                      "jobservice.json",
+		"/redfish/v1/JobService/Jobs":                                 "jobs.json",
+		"/redfish/v1/JobService/Jobs/Restart":                         "job.restart.json",
+		"/redfish/v1/CertificateService":                              "certificateservice.json",
+		"/redfish/v1/CertificateService/CertificateLocations":         "certificatelocations.json",
+		"/redfish/v1/Managers/1/NetworkProtocol/HTTPS/Certificates/1": "certificate.1.json",
+		"/redfish/v1/Managers/1/NetworkProtocol/Oem/Lenovo/SNMP":      "snmp.json",
+	}
+
+	if opts.licenseServiceNotFound {
+		delete(routes, "/redfish/v1/LicenseService/Licenses")
+		delete(routes, "/redfish/v1/LicenseService/Licenses/XCC_Advanced")
+	}
+
+	mux := http.NewServeMux()
+
+	// ComputerSystem.Reset action — records the requested ResetType.
+	mux.HandleFunc("/redfish/v1/Systems/1/Actions/ComputerSystem.Reset", func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			ResetType string `json:"ResetType"`
+		}
+		if body, err := io.ReadAll(r.Body); err == nil {
+			_ = json.Unmarshal(body, &payload)
+		}
+		ts.mu.Lock()
+		ts.lastResetType = payload.ResetType
+		ts.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	// Bios.ResetBios action.
+	mux.HandleFunc("/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios", func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		ts.biosReset = true
+		ts.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	// SecureBoot.ResetKeys action.
+	mux.HandleFunc("/redfish/v1/Systems/1/SecureBoot/Actions/SecureBoot.ResetKeys", func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		ts.secureBootKeysReset = true
+		ts.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	// Volumes collection: GET serves the fixture, POST creates a volume and
+	// returns its Location.
+	mux.HandleFunc("/redfish/v1/Systems/1/Storage/RAID_Slot1/Volumes", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			ts.mu.Lock()
+			ts.volumeCreated = true
+			ts.mu.Unlock()
+			w.Header().Set("Location", "/redfish/v1/Systems/1/Storage/RAID_Slot1/Volumes/2")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"@odata.id":"/redfish/v1/Systems/1/Storage/RAID_Slot1/Volumes/2","Id":"2"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixtureBytes(t, "volumes.json"))
+	})
+
+	// Volume.Initialize action.
+	mux.HandleFunc("/redfish/v1/Systems/1/Storage/RAID_Slot1/Volumes/1/Actions/Volume.Initialize", func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		ts.volumeInitialized = true
+		ts.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	// UpdateService: GET serves the (variant) fixture; PATCH records the
+	// HttpPushUriTargetsBusy claim/release.
+	mux.HandleFunc("/redfish/v1/UpdateService", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			var payload struct {
+				Busy *bool `json:"HttpPushUriTargetsBusy"`
+			}
+			if body, err := io.ReadAll(r.Body); err == nil {
+				_ = json.Unmarshal(body, &payload)
+			}
+			ts.mu.Lock()
+			if payload.Busy != nil {
+				if *payload.Busy {
+					ts.claimedBusy = true
+				} else {
+					ts.releasedBusy = true
+				}
+			}
+			ts.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixtureBytes(t, opts.updateServiceFixture))
+	})
+
+	// Firmware push endpoints (note: these live outside the /redfish/v1/ tree).
+	mux.HandleFunc("/mfwupdate", func(w http.ResponseWriter, r *http.Request) {
+		// Drain the (multipart) body before responding, else the client may see
+		// a connection reset when the server closes early.
+		_, _ = io.Copy(io.Discard, r.Body)
+		ts.mu.Lock()
+		ts.multipartPushed = true
+		ts.mu.Unlock()
+		w.Header().Set("Location", "/redfish/v1/TaskService/Tasks/1")
+		w.WriteHeader(http.StatusAccepted)
+	})
+	mux.HandleFunc("/fwupdate", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		ts.mu.Lock()
+		ts.rawPushed = true
+		ts.mu.Unlock()
+		w.Header().Set("Location", "/redfish/v1/TaskService/Tasks/1")
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	// UpdateService.SimpleUpdate and UpdateService.StartUpdate actions.
+	mux.HandleFunc("/redfish/v1/UpdateService/Actions/UpdateService.SimpleUpdate", func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		ts.simpleUpdated = true
+		ts.mu.Unlock()
+		w.Header().Set("Location", "/redfish/v1/TaskService/Tasks/1")
+		w.WriteHeader(http.StatusAccepted)
+	})
+	mux.HandleFunc("/redfish/v1/UpdateService/Actions/UpdateService.StartUpdate", func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		ts.startUpdated = true
+		ts.mu.Unlock()
+		w.Header().Set("Location", "/redfish/v1/TaskService/Tasks/1")
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	// XCC inserts/ejects virtual media via PATCH on the VirtualMedia resource
+	// (not the InsertMedia/EjectMedia actions). These per-slot handlers serve the
+	// slot fixture on GET and record insert/eject on PATCH (insert => Inserted
+	// true with an Image; eject => Inserted false / null Image).
+	vmHandler := func(slotID, fixture string) func(http.ResponseWriter, *http.Request) {
+		return func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write(fixtureBytes(t, fixture))
+				return
+			}
+
+			var body struct {
+				Inserted *bool       `json:"Inserted"`
+				Image    interface{} `json:"Image"`
+			}
+			if b, err := io.ReadAll(r.Body); err == nil {
+				_ = json.Unmarshal(b, &body)
+			}
+			op := "eject"
+			if body.Inserted != nil && *body.Inserted {
+				op = "insert"
+			}
+
+			ts.mu.Lock()
+			ts.vmOps = append(ts.vmOps, slotID+":"+op)
+			if slotID == "CD" && op == "insert" {
+				ts.cdInserted = true
+			}
+			if slotID == "Floppy" && op == "eject" {
+				ts.floppyEjected = true
+			}
+			ts.mu.Unlock()
+
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}
+	mux.HandleFunc("/redfish/v1/Managers/1/VirtualMedia/CD", vmHandler("CD", "vm.cd.json"))
+	mux.HandleFunc("/redfish/v1/Managers/1/VirtualMedia/Floppy", vmHandler("Floppy", "vm.floppy.json"))
+
+	// Accounts collection: GET serves the fixture (also used by gofish for an
+	// etag), POST creates an account (or returns 405 to force the slot fallback).
+	mux.HandleFunc("/redfish/v1/AccountService/Accounts", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			if opts.rejectAccountPost {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			ts.mu.Lock()
+			ts.accountPosted = true
+			ts.mu.Unlock()
+			w.Header().Set("Location", "/redfish/v1/AccountService/Accounts/2")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"@odata.id":"/redfish/v1/AccountService/Accounts/2","Id":"2","UserName":"ops","RoleId":"Operator","Enabled":true}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixtureBytes(t, "accounts.json"))
+	})
+
+	// Manager.Reset and Manager.ResetToDefaults actions.
+	mux.HandleFunc("/redfish/v1/Managers/1/Actions/Manager.Reset", func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		ts.bmcReset = true
+		ts.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/redfish/v1/Managers/1/Actions/Manager.ResetToDefaults", func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		ts.factoryReset = true
+		ts.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	// LogService.ClearLog actions (manager + chassis SEL). ClearSystemEventLog
+	// clears via the chassis log services.
+	mux.HandleFunc("/redfish/v1/Managers/1/LogServices/Sel/Actions/LogService.ClearLog", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/redfish/v1/Chassis/1/LogServices/Sel/Actions/LogService.ClearLog", func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		ts.selCleared = true
+		ts.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	// CertificateService actions.
+	mux.HandleFunc("/redfish/v1/CertificateService/Actions/CertificateService.GenerateCSR", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		ts.mu.Lock()
+		ts.csrGenerated = true
+		ts.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"CSRString":"-----BEGIN CERTIFICATE REQUEST-----\nMIICFDCC\n-----END CERTIFICATE REQUEST-----"}`))
+	})
+	mux.HandleFunc("/redfish/v1/CertificateService/Actions/CertificateService.ReplaceCertificate", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		ts.mu.Lock()
+		ts.certReplaced = true
+		ts.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/redfish/v1/Managers/1/NetworkProtocol/HTTPS/Certificates/1/Actions/Certificate.Rekey", func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		ts.certRekeyed = true
+		ts.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/redfish/v1/Managers/1/NetworkProtocol/HTTPS/Certificates/1/Actions/Certificate.Renew", func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		ts.certRenewed = true
+		ts.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	// Event subscriptions collection: GET serves the fixture, POST creates a
+	// subscription and returns its Location.
+	mux.HandleFunc("/redfish/v1/EventService/Subscriptions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			_, _ = io.Copy(io.Discard, r.Body)
+			ts.mu.Lock()
+			ts.subscriptionCreated = true
+			ts.mu.Unlock()
+			w.Header().Set("Location", "/redfish/v1/EventService/Subscriptions/2")
+			w.WriteHeader(http.StatusCreated)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixtureBytes(t, "subscriptions.json"))
+	})
+
+	// EventService.SubmitTestEvent and TelemetryService.SubmitTestMetricReport.
+	mux.HandleFunc("/redfish/v1/EventService/Actions/EventService.SubmitTestEvent", func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		ts.testEventSubmitted = true
+		ts.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/redfish/v1/TelemetryService/Actions/TelemetryService.SubmitTestMetricReport", func(w http.ResponseWriter, r *http.Request) {
+		ts.mu.Lock()
+		ts.testMetricSubmitted = true
+		ts.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	// Roles collection: GET serves the fixture, POST creates a custom role.
+	mux.HandleFunc("/redfish/v1/AccountService/Roles", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			ts.mu.Lock()
+			ts.rolePosted = true
+			ts.mu.Unlock()
+			w.Header().Set("Location", "/redfish/v1/AccountService/Roles/custom")
+			w.WriteHeader(http.StatusCreated)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixtureBytes(t, "roles.json"))
+	})
+
+	// Session collection: POST creates a session, anything else is a no-op.
+	mux.HandleFunc("/redfish/v1/SessionService/Sessions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		if opts.rejectAuth {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":{"code":"Base.1.8.GeneralError","message":"login failed",` +
+				`"@Message.ExtendedInfo":[{"MessageId":"Base.1.8.InsufficientPrivilege",` +
+				`"Message":"The credentials provided are not authorized.","Resolution":"Provide valid credentials."}]}}`))
+			return
+		}
+
+		ts.mu.Lock()
+		ts.sessionCreated = true
+		ts.mu.Unlock()
+
+		w.Header().Set("X-Auth-Token", "test-token")
+		w.Header().Set("Location", "/redfish/v1/SessionService/Sessions/1")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"@odata.id":"/redfish/v1/SessionService/Sessions/1","Id":"1","Name":"Session"}`))
+	})
+
+	// A created session is deleted here on Close.
+	mux.HandleFunc("/redfish/v1/SessionService/Sessions/1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			ts.mu.Lock()
+			ts.sessionDeleted = true
+			ts.mu.Unlock()
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Catch-all for the rest of the Redfish tree.
+	//
+	// GETs are served from fixtures. Writes (PATCH/POST/PUT/DELETE) on a known
+	// resource are accepted with 204 and recorded, so tests can assert that a
+	// mutation was issued without modelling full write semantics.
+	mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, r *http.Request) {
+		file, ok := routes[r.URL.Path]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		if r.Method != http.MethodGet {
+			ts.mu.Lock()
+			switch r.URL.Path {
+			case "/redfish/v1/Systems/1":
+				ts.systemPatched = true
+			case "/redfish/v1/Systems/1/Bios", "/redfish/v1/Systems/1/Bios/Pending":
+				// XCC exposes a @Redfish.Settings SettingsObject at /Bios/Pending;
+				// gofish PATCHes there. Record the body either way.
+				ts.biosPatched = true
+				if b, err := io.ReadAll(r.Body); err == nil {
+					var body map[string]any
+					if json.Unmarshal(b, &body) == nil {
+						ts.biosPatchBody = body
+					}
+				}
+			case "/redfish/v1/Systems/1/SecureBoot":
+				ts.secureBootPatched = true
+			case "/redfish/v1/Chassis/1/Power":
+				ts.powerPatched = true
+			case "/redfish/v1/Systems/1/Storage/RAID_Slot1/Volumes/1":
+				if r.Method == http.MethodDelete {
+					ts.volumeDeleted = true
+				} else {
+					ts.volumeUpdated = true
+				}
+			case "/redfish/v1/AccountService/Accounts/1", "/redfish/v1/AccountService/Accounts/2":
+				ts.accountPatched = true
+			case "/redfish/v1/LicenseService/Licenses":
+				ts.licenseInstalled = true
+			case "/redfish/v1/LicenseService/Licenses/XCC_Advanced":
+				ts.licenseDeleted = true
+			case "/redfish/v1/Managers/1/Oem/Lenovo/SecureKeyLifecycleService":
+				ts.sklmPatched = true
+			case "/redfish/v1/Managers/1/EthernetInterfaces/eth0":
+				ts.bmcEthPatched = true
+			case "/redfish/v1/Managers/1/HostInterfaces/1":
+				ts.hostIfacePatched = true
+			case "/redfish/v1/Managers/1/NetworkProtocol":
+				ts.netProtoPatched = true
+			case "/redfish/v1/Managers/1/SerialInterfaces/1":
+				ts.serialPatched = true
+			case "/redfish/v1/EventService/Subscriptions/1":
+				ts.subscriptionDeleted = true
+			case "/redfish/v1/EventService":
+				ts.eventServicePatched = true
+			case "/redfish/v1/JobService/Jobs/Restart":
+				ts.jobScheduleUpdated = true
+			case "/redfish/v1/Managers/1/NetworkProtocol/Oem/Lenovo/SNMP":
+				ts.snmpPatched = true
+			}
+			ts.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		body, err := os.ReadFile(filepath.Join(fixturesDir, file))
+		if err != nil {
+			t.Errorf("failed to read fixture %q for %s: %v", file, r.URL.Path, err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	})
+
+	ts.Server = httptest.NewTLSServer(mux)
+
+	return ts
+}
+
+// client returns a *Conn pointed at the mock server. Extra options are appended
+// after the mandatory port option.
+func (ts *testServer) client(t *testing.T, opts ...Option) *Conn {
+	t.Helper()
+
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("parse mock url: %v", err)
+	}
+
+	opts = append([]Option{WithPort(u.Port())}, opts...)
+
+	return New(u.Hostname(), "user", "pass", logr.Discard(), opts...)
+}
+
+// openedClient returns a *Conn with an established session and registers Close
+// + server shutdown for cleanup.
+func (ts *testServer) openedClient(t *testing.T, opts ...Option) *Conn {
+	t.Helper()
+
+	c := ts.client(t, opts...)
+	if err := c.Open(context.Background()); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = c.Close(context.Background())
+		ts.Close()
+	})
+
+	return c
+}
+
+func (ts *testServer) didCreateSession() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.sessionCreated
+}
+
+func (ts *testServer) didDeleteSession() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.sessionDeleted
+}
+
+func (ts *testServer) resetType() string {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.lastResetType
+}
+
+func (ts *testServer) didResetBios() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.biosReset
+}
+
+func (ts *testServer) didPatchSystem() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.systemPatched
+}
+
+func (ts *testServer) didPatchBios() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.biosPatched
+}
+
+func (ts *testServer) didPatchSecureBoot() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.secureBootPatched
+}
+
+func (ts *testServer) didResetSecureBootKeys() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.secureBootKeysReset
+}
+
+func (ts *testServer) didPatchPower() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.powerPatched
+}
+
+func (ts *testServer) didCreateVolume() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.volumeCreated
+}
+
+func (ts *testServer) didInitializeVolume() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.volumeInitialized
+}
+
+func (ts *testServer) didUpdateVolume() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.volumeUpdated
+}
+
+func (ts *testServer) didDeleteVolume() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.volumeDeleted
+}
+
+func (ts *testServer) didClaimBusy() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.claimedBusy
+}
+
+func (ts *testServer) didReleaseBusy() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.releasedBusy
+}
+
+func (ts *testServer) didMultipartPush() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.multipartPushed
+}
+
+func (ts *testServer) didRawPush() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.rawPushed
+}
+
+func (ts *testServer) didSimpleUpdate() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.simpleUpdated
+}
+
+func (ts *testServer) didStartUpdate() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.startUpdated
+}
+
+func (ts *testServer) didInsertCD() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.cdInserted
+}
+
+func (ts *testServer) didEjectFloppy() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.floppyEjected
+}
+
+func (ts *testServer) vmOperations() []string {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return append([]string(nil), ts.vmOps...)
+}
+
+func (ts *testServer) didPostAccount() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.accountPosted
+}
+
+func (ts *testServer) didPatchAccount() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.accountPatched
+}
+
+func (ts *testServer) didPostRole() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.rolePosted
+}
+
+func (ts *testServer) didClearSEL() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.selCleared
+}
+
+func (ts *testServer) didBmcReset() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.bmcReset
+}
+
+func (ts *testServer) didFactoryReset() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.factoryReset
+}
+
+func (ts *testServer) didInstallLicense() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.licenseInstalled
+}
+
+func (ts *testServer) didDeleteLicense() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.licenseDeleted
+}
+
+func (ts *testServer) didPatchSKLM() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.sklmPatched
+}
+
+func (ts *testServer) didPatchBMCEth() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.bmcEthPatched
+}
+
+func (ts *testServer) didPatchHostIface() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.hostIfacePatched
+}
+
+func (ts *testServer) didPatchNetProto() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.netProtoPatched
+}
+
+func (ts *testServer) didPatchSerial() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.serialPatched
+}
+
+func (ts *testServer) didCreateSubscription() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.subscriptionCreated
+}
+
+func (ts *testServer) didDeleteSubscription() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.subscriptionDeleted
+}
+
+func (ts *testServer) didSubmitTestEvent() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.testEventSubmitted
+}
+
+func (ts *testServer) didPatchEventService() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.eventServicePatched
+}
+
+func (ts *testServer) didSubmitTestMetric() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.testMetricSubmitted
+}
+
+func (ts *testServer) didUpdateJobSchedule() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.jobScheduleUpdated
+}
+
+func (ts *testServer) didGenerateCSR() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.csrGenerated
+}
+
+func (ts *testServer) didReplaceCertificate() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.certReplaced
+}
+
+func (ts *testServer) didRekeyCertificate() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.certRekeyed
+}
+
+func (ts *testServer) didRenewCertificate() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.certRenewed
+}
+
+func (ts *testServer) didPatchSNMP() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.snmpPatched
+}

--- a/providers/lenovo/network.go
+++ b/providers/lenovo/network.go
@@ -1,0 +1,174 @@
+package lenovo
+
+import (
+	"context"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+	"github.com/stmcginnis/gofish/schemas"
+)
+
+// compile-time assertions that the provider implements the interfaces.
+var (
+	_ bmc.NetworkInterfaceGetter = (*Conn)(nil)
+	_ bmc.NetworkInterfaceSetter = (*Conn)(nil)
+	_ bmc.NetworkProtocolGetter  = (*Conn)(nil)
+	_ bmc.NetworkProtocolSetter  = (*Conn)(nil)
+)
+
+// BMCNetworkInterfaces returns the BMC (manager) ethernet interfaces.
+//
+// Implements bmc.NetworkInterfaceGetter.
+func (c *Conn) BMCNetworkInterfaces(ctx context.Context) ([]bmc.NetworkInterface, error) {
+	manager, err := c.redfishwrapper.Manager(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ifaces, err := manager.EthernetInterfaces()
+	if err != nil {
+		return nil, err
+	}
+
+	return mapEthernetInterfaces(ifaces), nil
+}
+
+// ServerNetworkInterfaces returns the server (system) ethernet interfaces.
+//
+// Implements bmc.NetworkInterfaceGetter.
+func (c *Conn) ServerNetworkInterfaces(ctx context.Context) ([]bmc.NetworkInterface, error) {
+	system, err := c.redfishwrapper.System()
+	if err != nil {
+		return nil, err
+	}
+
+	ifaces, err := system.EthernetInterfaces()
+	if err != nil {
+		return nil, err
+	}
+
+	return mapEthernetInterfaces(ifaces), nil
+}
+
+// SetBMCNetworkInterface PATCHes a BMC ethernet interface.
+//
+// Implements bmc.NetworkInterfaceSetter.
+func (c *Conn) SetBMCNetworkInterface(ctx context.Context, id string, attrs map[string]any) error {
+	manager, err := c.redfishwrapper.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	target := singleTrailingSlashJoin(manager.ODataID, "EthernetInterfaces/"+id)
+
+	return checkResponse(c.redfishwrapper.PatchWithHeaders(ctx, target, attrs, nil))
+}
+
+// SetHostInterfaceEnabled enables or disables a host interface.
+//
+// Implements bmc.NetworkInterfaceSetter.
+func (c *Conn) SetHostInterfaceEnabled(ctx context.Context, id string, enabled bool) error {
+	manager, err := c.redfishwrapper.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	target := singleTrailingSlashJoin(manager.ODataID, "HostInterfaces/"+id)
+	payload := map[string]any{"InterfaceEnabled": enabled}
+
+	return checkResponse(c.redfishwrapper.PatchWithHeaders(ctx, target, payload, nil))
+}
+
+// NetworkProtocols returns the manager network services and their state.
+//
+// Implements bmc.NetworkProtocolGetter.
+func (c *Conn) NetworkProtocols(ctx context.Context) ([]bmc.NetworkProtocol, error) {
+	manager, err := c.redfishwrapper.Manager(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	path := singleTrailingSlashJoin(manager.ODataID, "NetworkProtocol")
+
+	type protoSetting struct {
+		Port            *int `json:"Port"`
+		ProtocolEnabled bool `json:"ProtocolEnabled"`
+	}
+	// Each protocol is a pointer so an absent key (nil) is distinguished from a
+	// present one: XCC only publishes the services it supports (e.g. SR630 V2
+	// exposes no Telnet), and we must not report phantom disabled services.
+	var doc struct {
+		HTTP         *protoSetting `json:"HTTP"`
+		HTTPS        *protoSetting `json:"HTTPS"`
+		SSH          *protoSetting `json:"SSH"`
+		IPMI         *protoSetting `json:"IPMI"`
+		SNMP         *protoSetting `json:"SNMP"`
+		NTP          *protoSetting `json:"NTP"`
+		KVMIP        *protoSetting `json:"KVMIP"`
+		VirtualMedia *protoSetting `json:"VirtualMedia"`
+		SSDP         *protoSetting `json:"SSDP"`
+		Telnet       *protoSetting `json:"Telnet"`
+	}
+	if err := c.getJSON(path, &doc); err != nil {
+		return nil, err
+	}
+
+	services := []struct {
+		name string
+		set  *protoSetting
+	}{
+		{"HTTP", doc.HTTP}, {"HTTPS", doc.HTTPS}, {"SSH", doc.SSH}, {"IPMI", doc.IPMI},
+		{"SNMP", doc.SNMP}, {"NTP", doc.NTP}, {"KVMIP", doc.KVMIP},
+		{"VirtualMedia", doc.VirtualMedia}, {"SSDP", doc.SSDP}, {"Telnet", doc.Telnet},
+	}
+
+	out := make([]bmc.NetworkProtocol, 0, len(services))
+	for _, s := range services {
+		if s.set == nil {
+			continue // protocol not exposed by this XCC
+		}
+		port := 0
+		if s.set.Port != nil {
+			port = *s.set.Port
+		}
+		out = append(out, bmc.NetworkProtocol{Name: s.name, Enabled: s.set.ProtocolEnabled, Port: port})
+	}
+
+	return out, nil
+}
+
+// SetNetworkProtocols PATCHes the ManagerNetworkProtocol resource.
+//
+// Implements bmc.NetworkProtocolSetter.
+func (c *Conn) SetNetworkProtocols(ctx context.Context, attrs map[string]any) error {
+	manager, err := c.redfishwrapper.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	target := singleTrailingSlashJoin(manager.ODataID, "NetworkProtocol")
+
+	return checkResponse(c.redfishwrapper.PatchWithHeaders(ctx, target, attrs, nil))
+}
+
+// mapEthernetInterfaces converts gofish ethernet interfaces to the neutral
+// bmc.NetworkInterface shape.
+func mapEthernetInterfaces(ifaces []*schemas.EthernetInterface) []bmc.NetworkInterface {
+	out := make([]bmc.NetworkInterface, 0, len(ifaces))
+	for _, e := range ifaces {
+		ni := bmc.NetworkInterface{
+			ID:         e.ID,
+			MACAddress: e.MACAddress,
+			HostName:   e.HostName,
+			Enabled:    e.InterfaceEnabled,
+		}
+		for _, a := range e.IPv4Addresses {
+			ni.IPv4Addresses = append(ni.IPv4Addresses, a.Address)
+		}
+		for _, a := range e.IPv6Addresses {
+			ni.IPv6Addresses = append(ni.IPv6Addresses, a.Address)
+		}
+		out = append(out, ni)
+	}
+
+	return out
+}

--- a/providers/lenovo/network_serial_test.go
+++ b/providers/lenovo/network_serial_test.go
@@ -1,0 +1,151 @@
+package lenovo
+
+import (
+	"context"
+	"testing"
+)
+
+// Requirement: Read ethernet interfaces — BMC NIC config.
+func TestBMCNetworkInterfaces(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	ifaces, err := c.BMCNetworkInterfaces(context.Background())
+	if err != nil {
+		t.Fatalf("BMCNetworkInterfaces: %v", err)
+	}
+	if len(ifaces) != 1 {
+		t.Fatalf("got %d BMC interfaces, want 1", len(ifaces))
+	}
+	got := ifaces[0]
+	if got.MACAddress == "" || got.HostName != "XCC-SR650" {
+		t.Errorf("unexpected BMC interface: %+v", got)
+	}
+	if len(got.IPv4Addresses) != 1 || got.IPv4Addresses[0] != "10.0.0.50" {
+		t.Errorf("unexpected IPv4: %v", got.IPv4Addresses)
+	}
+}
+
+// Requirement: Read ethernet interfaces — server NIC config.
+func TestServerNetworkInterfaces(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	ifaces, err := c.ServerNetworkInterfaces(context.Background())
+	if err != nil {
+		t.Fatalf("ServerNetworkInterfaces: %v", err)
+	}
+	if len(ifaces) != 1 || ifaces[0].ID != "NIC.1" {
+		t.Fatalf("unexpected server interfaces: %+v", ifaces)
+	}
+}
+
+// Requirement: Configure BMC ethernet — set a static IPv4 address.
+func TestSetBMCNetworkInterface(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	attrs := map[string]any{
+		"IPv4StaticAddresses": []map[string]any{
+			{"Address": "10.0.0.51", "SubnetMask": "255.255.255.0", "Gateway": "10.0.0.1"},
+		},
+	}
+	if err := c.SetBMCNetworkInterface(context.Background(), "eth0", attrs); err != nil {
+		t.Fatalf("SetBMCNetworkInterface: %v", err)
+	}
+	if !ts.didPatchBMCEth() {
+		t.Error("expected a PATCH of the BMC ethernet interface")
+	}
+}
+
+// Requirement: Configure BMC ethernet — disable the host interface.
+func TestSetHostInterfaceEnabled(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if err := c.SetHostInterfaceEnabled(context.Background(), "1", false); err != nil {
+		t.Fatalf("SetHostInterfaceEnabled: %v", err)
+	}
+	if !ts.didPatchHostIface() {
+		t.Error("expected a PATCH of the host interface")
+	}
+}
+
+// Requirement: Manager network protocols — read network services.
+func TestNetworkProtocols(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	protos, err := c.NetworkProtocols(context.Background())
+	if err != nil {
+		t.Fatalf("NetworkProtocols: %v", err)
+	}
+
+	byName := map[string]struct {
+		enabled bool
+		port    int
+	}{}
+	for _, p := range protos {
+		byName[p.Name] = struct {
+			enabled bool
+			port    int
+		}{p.Enabled, p.Port}
+	}
+
+	if !byName["HTTPS"].enabled || byName["HTTPS"].port != 443 {
+		t.Errorf("unexpected HTTPS protocol: %+v", byName["HTTPS"])
+	}
+	if byName["IPMI"].port != 623 {
+		t.Errorf("unexpected IPMI port: %d", byName["IPMI"].port)
+	}
+	// A protocol absent from the resource (the fixture, like real XCC, has no
+	// Telnet) must not be reported as a phantom disabled service.
+	if _, ok := byName["Telnet"]; ok {
+		t.Errorf("Telnet is absent from the resource but was reported: %+v", protos)
+	}
+}
+
+// Requirement: Manager network protocols — disable a service.
+func TestSetNetworkProtocols(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	attrs := map[string]any{"IPMI": map[string]any{"ProtocolEnabled": false}}
+	if err := c.SetNetworkProtocols(context.Background(), attrs); err != nil {
+		t.Fatalf("SetNetworkProtocols: %v", err)
+	}
+	if !ts.didPatchNetProto() {
+		t.Error("expected a PATCH of ManagerNetworkProtocol")
+	}
+}
+
+// Requirement: Read serial interface.
+func TestSerialInterfaces(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	ifaces, err := c.SerialInterfaces(context.Background())
+	if err != nil {
+		t.Fatalf("SerialInterfaces: %v", err)
+	}
+	if len(ifaces) != 1 {
+		t.Fatalf("got %d serial interfaces, want 1", len(ifaces))
+	}
+	if ifaces[0].BitRate != "115200" || ifaces[0].FlowControl != "None" {
+		t.Errorf("unexpected serial config: %+v", ifaces[0])
+	}
+}
+
+// Requirement: Configure serial interface — change baud rate.
+func TestSetSerialInterface(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	attrs := map[string]any{"BitRate": "57600"}
+	if err := c.SetSerialInterface(context.Background(), "1", attrs); err != nil {
+		t.Fatalf("SetSerialInterface: %v", err)
+	}
+	if !ts.didPatchSerial() {
+		t.Error("expected a PATCH of the serial interface")
+	}
+}

--- a/providers/lenovo/power.go
+++ b/providers/lenovo/power.go
@@ -1,0 +1,36 @@
+package lenovo
+
+import (
+	"context"
+)
+
+// PowerStateGet returns the current power state of the managed system (e.g.
+// "On", "Off"), read from the ComputerSystem PowerState property.
+//
+// Implements bmc.PowerStateGetter.
+func (c *Conn) PowerStateGet(ctx context.Context) (state string, err error) {
+	return c.redfishwrapper.SystemPowerStatus(ctx)
+}
+
+// PowerSet sets the system power state via the ComputerSystem.Reset action.
+//
+// Accepted states (case-insensitive) and the XCC ResetType they map to:
+//
+//	on     -> On             (no-op if already on)
+//	off    -> ForceOff
+//	soft   -> GracefulShutdown
+//	reset  -> ForceRestart (with power-off/on fallback)
+//	cycle  -> ForceRestart
+//
+// Unsupported states return an error. Implements bmc.PowerSetter.
+func (c *Conn) PowerSet(ctx context.Context, state string) (ok bool, err error) {
+	return c.redfishwrapper.PowerSet(ctx, state)
+}
+
+// SendNMI issues a non-maskable interrupt to the host via a ComputerSystem.Reset
+// action with ResetType "Nmi".
+//
+// Implements bmc.NMISender.
+func (c *Conn) SendNMI(ctx context.Context) error {
+	return c.redfishwrapper.SendNMI(ctx)
+}

--- a/providers/lenovo/power_boot_bios_test.go
+++ b/providers/lenovo/power_boot_bios_test.go
@@ -1,0 +1,197 @@
+package lenovo
+
+import (
+	"context"
+	"testing"
+)
+
+// Requirement: Power state read.
+func TestPowerStateGet(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	state, err := c.PowerStateGet(context.Background())
+	if err != nil {
+		t.Fatalf("PowerStateGet: %v", err)
+	}
+	if state != "On" {
+		t.Fatalf("PowerStateGet = %q, want %q", state, "On")
+	}
+}
+
+// Requirement: Power control via ComputerSystem.Reset.
+func TestPowerSet(t *testing.T) {
+	t.Run("power on when already on is a no-op success", func(t *testing.T) {
+		ts := newTestServer(t, testServerOpts{})
+		c := ts.openedClient(t)
+
+		ok, err := c.PowerSet(context.Background(), "on")
+		if err != nil || !ok {
+			t.Fatalf("PowerSet(on) = (%v, %v), want (true, nil)", ok, err)
+		}
+		// The system fixture is already On, so no reset action is posted.
+		if rt := ts.resetType(); rt != "" {
+			t.Fatalf("unexpected reset posted: %q", rt)
+		}
+	})
+
+	t.Run("force off posts ForceOff", func(t *testing.T) {
+		ts := newTestServer(t, testServerOpts{})
+		c := ts.openedClient(t)
+
+		ok, err := c.PowerSet(context.Background(), "off")
+		if err != nil || !ok {
+			t.Fatalf("PowerSet(off) = (%v, %v), want (true, nil)", ok, err)
+		}
+		if rt := ts.resetType(); rt != "ForceOff" {
+			t.Fatalf("reset type = %q, want %q", rt, "ForceOff")
+		}
+	})
+
+	t.Run("unsupported state errors", func(t *testing.T) {
+		ts := newTestServer(t, testServerOpts{})
+		c := ts.openedClient(t)
+
+		if _, err := c.PowerSet(context.Background(), "banana"); err == nil {
+			t.Fatal("expected an error for an unsupported power state")
+		}
+	})
+}
+
+// Requirement: NMI.
+func TestSendNMI(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if err := c.SendNMI(context.Background()); err != nil {
+		t.Fatalf("SendNMI: %v", err)
+	}
+	if rt := ts.resetType(); rt != "Nmi" {
+		t.Fatalf("reset type = %q, want %q", rt, "Nmi")
+	}
+}
+
+// Requirement: Boot device override set.
+func TestBootDeviceSet(t *testing.T) {
+	tests := []struct {
+		name       string
+		device     string
+		persistent bool
+		efi        bool
+		wantErr    bool
+	}{
+		{name: "one-time pxe", device: "pxe"},
+		{name: "one-time uefi cdrom", device: "cdrom", efi: true},
+		// XCC advertises BootSourceOverrideEnabled {Once, Disabled} only — a
+		// persistent (Continuous) override is rejected up front.
+		{name: "persistent rejected on XCC", device: "disk", persistent: true, efi: true, wantErr: true},
+		{name: "unknown device errors", device: "toaster", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newTestServer(t, testServerOpts{})
+			c := ts.openedClient(t)
+
+			ok, err := c.BootDeviceSet(context.Background(), tt.device, tt.persistent, tt.efi)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error for an unknown boot device")
+				}
+				return
+			}
+			if err != nil || !ok {
+				t.Fatalf("BootDeviceSet = (%v, %v), want (true, nil)", ok, err)
+			}
+			if !ts.didPatchSystem() {
+				t.Fatal("expected the ComputerSystem to be PATCHed")
+			}
+		})
+	}
+}
+
+// Requirement: Boot device override read.
+func TestBootDeviceOverrideGet(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	override, err := c.BootDeviceOverrideGet(context.Background())
+	if err != nil {
+		t.Fatalf("BootDeviceOverrideGet: %v", err)
+	}
+	// The fixture reports target Hdd, enabled Once, mode Legacy.
+	if override.IsPersistent {
+		t.Errorf("IsPersistent = true, want false (Once)")
+	}
+	if override.IsEFIBoot {
+		t.Errorf("IsEFIBoot = true, want false (Legacy)")
+	}
+}
+
+// Requirement: Boot progress reporting.
+func TestGetBootProgress(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	bp, err := c.GetBootProgress()
+	if err != nil {
+		t.Fatalf("GetBootProgress: %v", err)
+	}
+	if bp == nil {
+		t.Fatal("GetBootProgress returned nil")
+	}
+}
+
+// Requirement: BIOS configuration read.
+func TestGetBiosConfiguration(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	cfg, err := c.GetBiosConfiguration(context.Background())
+	if err != nil {
+		t.Fatalf("GetBiosConfiguration: %v", err)
+	}
+	if got := cfg["BootModes_SystemBootMode"]; got != "LegacyMode" {
+		t.Fatalf("BootModes_SystemBootMode = %q, want %q", got, "LegacyMode")
+	}
+}
+
+// Requirement: BIOS configuration set.
+func TestSetBiosConfiguration(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	err := c.SetBiosConfiguration(context.Background(), map[string]string{"BootModes_SystemBootMode": "UEFIMode"})
+	if err != nil {
+		t.Fatalf("SetBiosConfiguration: %v", err)
+	}
+	if !ts.didPatchBios() {
+		t.Fatal("expected the Bios settings target to be PATCHed")
+	}
+
+	// XCC rejects the @Redfish.SettingsApplyTime / ApplyTime annotation that the
+	// shared wrapper sends; the lenovo override must PATCH Attributes only.
+	body := ts.biosPatchBody
+	if body == nil {
+		t.Fatal("expected to capture the Bios PATCH body")
+	}
+	if _, ok := body["@Redfish.SettingsApplyTime"]; ok {
+		t.Errorf("Bios PATCH must not send @Redfish.SettingsApplyTime (XCC rejects it); body=%v", body)
+	}
+	if _, ok := body["Attributes"]; !ok {
+		t.Errorf("Bios PATCH must carry an Attributes object; body=%v", body)
+	}
+}
+
+// Requirement: BIOS configuration reset.
+func TestResetBiosConfiguration(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if err := c.ResetBiosConfiguration(context.Background()); err != nil {
+		t.Fatalf("ResetBiosConfiguration: %v", err)
+	}
+	if !ts.didResetBios() {
+		t.Fatal("expected the Bios.ResetBios action to be posted")
+	}
+}

--- a/providers/lenovo/power_cap.go
+++ b/providers/lenovo/power_cap.go
@@ -1,0 +1,78 @@
+package lenovo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+// compile-time assertions that the provider implements the interfaces.
+var (
+	_ bmc.PowerReader    = (*Conn)(nil)
+	_ bmc.PowerCapSetter = (*Conn)(nil)
+)
+
+// ReadPower returns power metrics and supplies from the first chassis that
+// exposes a Power resource.
+//
+// Implements bmc.PowerReader.
+func (c *Conn) ReadPower(ctx context.Context) (bmc.PowerInfo, error) {
+	chassis, err := c.redfishwrapper.Chassis(ctx)
+	if err != nil {
+		return bmc.PowerInfo{}, fmt.Errorf("reading chassis collection: %w", err)
+	}
+
+	for _, ch := range chassis {
+		power, err := ch.Power()
+		if err != nil || power == nil {
+			continue
+		}
+
+		info := bmc.PowerInfo{}
+		if len(power.PowerControl) > 0 {
+			pc := power.PowerControl[0]
+			info.ConsumedWatts = derefFloat32(pc.PowerConsumedWatts)
+			info.CapacityWatts = derefFloat32(pc.PowerCapacityWatts)
+			info.LimitInWatts = pc.PowerLimit.LimitInWatts
+		}
+		for _, ps := range power.PowerSupplies {
+			info.PowerSupplies = append(info.PowerSupplies, bmc.PowerSupplyInfo{
+				Name:          ps.Name,
+				Health:        string(ps.Status.Health),
+				CapacityWatts: derefFloat32(ps.PowerCapacityWatts),
+			})
+		}
+
+		return info, nil
+	}
+
+	return bmc.PowerInfo{}, fmt.Errorf("no chassis exposes a Power resource")
+}
+
+// SetPowerCap sets the chassis power limit by PATCHing
+// PowerControl[0].PowerLimit.LimitInWatts. A nil limitWatts disables power
+// capping (sets LimitInWatts to null). Implements bmc.PowerCapSetter.
+func (c *Conn) SetPowerCap(ctx context.Context, limitWatts *float64) error {
+	chassis, err := c.redfishwrapper.Chassis(ctx)
+	if err != nil {
+		return fmt.Errorf("reading chassis collection: %w", err)
+	}
+
+	for _, ch := range chassis {
+		power, err := ch.Power()
+		if err != nil || power == nil {
+			continue
+		}
+
+		payload := map[string]any{
+			"PowerControl": []map[string]any{
+				{"PowerLimit": map[string]any{"LimitInWatts": limitWatts}},
+			},
+		}
+
+		return checkResponse(c.redfishwrapper.PatchWithHeaders(ctx, power.ODataID, payload, nil))
+	}
+
+	return fmt.Errorf("no chassis exposes a Power resource")
+}

--- a/providers/lenovo/redfishget.go
+++ b/providers/lenovo/redfishget.go
@@ -1,0 +1,86 @@
+package lenovo
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"strings"
+)
+
+// getJSON GETs a Redfish resource and unmarshals its body into out. It maps
+// non-2xx responses to a descriptive error via parseRedfishError.
+func (c *Conn) getJSON(url string, out any) error {
+	resp, err := c.redfishwrapper.Get(url)
+	if err != nil {
+		// gofish returns non-2xx responses as an error; surface 404 as the
+		// errResourceNotFound sentinel so callers can treat an absent resource
+		// gracefully.
+		if isNotFound(err) {
+			return fmt.Errorf("%w: GET %s", errResourceNotFound, url)
+		}
+		return fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		rerr := parseRedfishError(resp)
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("%w: %v", errResourceNotFound, rerr)
+		}
+		return rerr
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("%w: %v", errFailedToParseResponse, err)
+	}
+
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("%w: %v", errFailedToParseResponse, err)
+	}
+
+	return nil
+}
+
+// decodeJSONBody reads and unmarshals an already-open HTTP response body into
+// out. The caller is responsible for closing resp.Body.
+func decodeJSONBody(resp *http.Response, out any) error {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("%w: %v", errFailedToParseResponse, err)
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("%w: %v", errFailedToParseResponse, err)
+	}
+	return nil
+}
+
+// collectionMembers GETs a Redfish collection and returns its member links.
+func (c *Conn) collectionMembers(url string) ([]odataID, error) {
+	var coll struct {
+		Members []odataID `json:"Members"`
+	}
+	if err := c.getJSON(url, &coll); err != nil {
+		return nil, err
+	}
+
+	return coll.Members, nil
+}
+
+// memberIDs GETs a Redfish collection and returns the trailing-segment Id of
+// each member.
+func (c *Conn) memberIDs(url string) ([]string, error) {
+	members, err := c.collectionMembers(url)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]string, 0, len(members))
+	for _, m := range members {
+		ids = append(ids, path.Base(strings.TrimRight(m.ODataID, "/")))
+	}
+
+	return ids, nil
+}

--- a/providers/lenovo/roles.go
+++ b/providers/lenovo/roles.go
@@ -1,0 +1,67 @@
+package lenovo
+
+import (
+	"context"
+)
+
+// RoleInfo describes an XCC account role.
+type RoleInfo struct {
+	// ID is the RoleId (e.g. "Administrator", "Operator", "ReadOnly" or a custom
+	// role name).
+	ID string
+	// Privileges are the Redfish privileges assigned to the role.
+	Privileges []string
+	// Predefined reports whether the role is a built-in (non-removable) role.
+	Predefined bool
+}
+
+// Roles returns the XCC account roles and their assigned privileges.
+//
+// This is an XCC-specific provider method (roles are not modelled by a
+// bmc.Feature interface).
+func (c *Conn) Roles(ctx context.Context) ([]RoleInfo, error) {
+	service, err := c.redfishwrapper.AccountService()
+	if err != nil {
+		return nil, err
+	}
+
+	roles, err := service.Roles()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]RoleInfo, 0, len(roles))
+	for _, role := range roles {
+		privileges := make([]string, 0, len(role.AssignedPrivileges))
+		for _, p := range role.AssignedPrivileges {
+			privileges = append(privileges, string(p))
+		}
+
+		out = append(out, RoleInfo{
+			ID:         role.RoleID,
+			Privileges: privileges,
+			Predefined: role.IsPredefined,
+		})
+	}
+
+	return out, nil
+}
+
+// RoleCreate creates a custom XCC role with the given privileges by POSTing to
+// the AccountService Roles collection.
+//
+// This is an XCC-specific provider method.
+func (c *Conn) RoleCreate(ctx context.Context, roleID string, privileges []string) error {
+	service, err := c.redfishwrapper.AccountService()
+	if err != nil {
+		return err
+	}
+
+	rolesURL := singleTrailingSlashJoin(service.ODataID, "Roles")
+	payload := map[string]any{
+		"RoleId":             roleID,
+		"AssignedPrivileges": privileges,
+	}
+
+	return checkResponse(c.redfishwrapper.PostWithHeaders(ctx, rolesURL, payload, nil))
+}

--- a/providers/lenovo/secureboot.go
+++ b/providers/lenovo/secureboot.go
@@ -1,0 +1,78 @@
+package lenovo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+	"github.com/stmcginnis/gofish/schemas"
+)
+
+// compile-time assertion that the provider implements the interface.
+var _ bmc.SecureBootManager = (*Conn)(nil)
+
+// GetSecureBoot returns the current UEFI Secure Boot state from the
+// ComputerSystem SecureBoot resource.
+//
+// Implements bmc.SecureBootManager.
+func (c *Conn) GetSecureBoot(ctx context.Context) (bmc.SecureBootState, error) {
+	sb, err := c.secureBoot()
+	if err != nil {
+		return bmc.SecureBootState{}, err
+	}
+
+	return bmc.SecureBootState{
+		Enabled:     sb.SecureBootEnable,
+		CurrentBoot: string(sb.SecureBootCurrentBoot),
+		Mode:        string(sb.SecureBootMode),
+	}, nil
+}
+
+// SetSecureBoot enables or disables Secure Boot by PATCHing
+// SecureBoot.SecureBootEnable. The change takes effect on the next boot and only
+// in UEFI boot mode. Implements bmc.SecureBootManager.
+func (c *Conn) SetSecureBoot(ctx context.Context, enabled bool) error {
+	sb, err := c.secureBoot()
+	if err != nil {
+		return err
+	}
+
+	payload := map[string]any{"SecureBootEnable": enabled}
+
+	return checkResponse(c.redfishwrapper.PatchWithHeaders(ctx, sb.ODataID, payload, nil))
+}
+
+// ResetSecureBootKeys resets the Secure Boot key databases via the
+// SecureBoot.ResetKeys action. resetType is a Redfish ResetKeysType such as
+// "ResetAllKeysToDefault", "DeleteAllKeys" or "DeletePK". This is destructive.
+// Implements bmc.SecureBootManager.
+func (c *Conn) ResetSecureBootKeys(ctx context.Context, resetType string) error {
+	sb, err := c.secureBoot()
+	if err != nil {
+		return err
+	}
+
+	if _, err := sb.ResetKeys(schemas.ResetKeysType(resetType)); err != nil {
+		return fmt.Errorf("resetting secure boot keys: %w", err)
+	}
+
+	return nil
+}
+
+// secureBoot resolves the SecureBoot resource of the managed system.
+func (c *Conn) secureBoot() (*schemas.SecureBoot, error) {
+	system, err := c.redfishwrapper.System()
+	if err != nil {
+		return nil, err
+	}
+
+	sb, err := system.SecureBoot()
+	if err != nil {
+		return nil, fmt.Errorf("reading secure boot resource: %w", err)
+	}
+	if sb == nil {
+		return nil, fmt.Errorf("device does not expose a SecureBoot resource")
+	}
+
+	return sb, nil
+}

--- a/providers/lenovo/secureboot_thermal_power_test.go
+++ b/providers/lenovo/secureboot_thermal_power_test.go
@@ -1,0 +1,114 @@
+package lenovo
+
+import (
+	"context"
+	"testing"
+)
+
+// Requirement: Secure Boot management — read state.
+func TestGetSecureBoot(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	state, err := c.GetSecureBoot(context.Background())
+	if err != nil {
+		t.Fatalf("GetSecureBoot: %v", err)
+	}
+	if !state.Enabled {
+		t.Errorf("Enabled = false, want true")
+	}
+	if state.Mode != "SetupMode" {
+		t.Errorf("Mode = %q, want %q", state.Mode, "SetupMode")
+	}
+	if state.CurrentBoot != "Disabled" {
+		t.Errorf("CurrentBoot = %q, want %q", state.CurrentBoot, "Disabled")
+	}
+}
+
+// Requirement: Secure Boot management — enable/disable.
+func TestSetSecureBoot(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if err := c.SetSecureBoot(context.Background(), true); err != nil {
+		t.Fatalf("SetSecureBoot: %v", err)
+	}
+	if !ts.didPatchSecureBoot() {
+		t.Fatal("expected the SecureBoot resource to be PATCHed")
+	}
+}
+
+// Requirement: Secure Boot management — reset keys.
+func TestResetSecureBootKeys(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if err := c.ResetSecureBootKeys(context.Background(), "ResetAllKeysToDefault"); err != nil {
+		t.Fatalf("ResetSecureBootKeys: %v", err)
+	}
+	if !ts.didResetSecureBootKeys() {
+		t.Fatal("expected the SecureBoot.ResetKeys action to be posted")
+	}
+}
+
+// Requirement: Thermal readings.
+func TestThermal(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	reading, err := c.Thermal(context.Background())
+	if err != nil {
+		t.Fatalf("Thermal: %v", err)
+	}
+	if len(reading.Temperatures) != 1 {
+		t.Fatalf("got %d temperatures, want 1", len(reading.Temperatures))
+	}
+	if reading.Temperatures[0].Name != "Ambient Temp" || reading.Temperatures[0].ReadingCelsius != 23 {
+		t.Errorf("unexpected temperature: %+v", reading.Temperatures[0])
+	}
+	if len(reading.Fans) != 1 {
+		t.Fatalf("got %d fans, want 1", len(reading.Fans))
+	}
+	if reading.Fans[0].Reading != 6840 {
+		t.Errorf("fan reading = %d, want 6840", reading.Fans[0].Reading)
+	}
+}
+
+// Requirement: Power metrics read.
+func TestReadPower(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	info, err := c.ReadPower(context.Background())
+	if err != nil {
+		t.Fatalf("ReadPower: %v", err)
+	}
+	if info.ConsumedWatts != 287 {
+		t.Errorf("ConsumedWatts = %v, want 287", info.ConsumedWatts)
+	}
+	if info.LimitInWatts != nil {
+		t.Errorf("LimitInWatts = %v, want nil (no cap)", *info.LimitInWatts)
+	}
+	if len(info.PowerSupplies) != 2 {
+		t.Fatalf("got %d power supplies, want 2", len(info.PowerSupplies))
+	}
+}
+
+// Requirement: Power capping — set a cap.
+func TestSetPowerCap(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	limit := 1200.0
+	if err := c.SetPowerCap(context.Background(), &limit); err != nil {
+		t.Fatalf("SetPowerCap: %v", err)
+	}
+	if !ts.didPatchPower() {
+		t.Fatal("expected the Power resource to be PATCHed")
+	}
+
+	// nil limit disables capping; should also PATCH successfully.
+	if err := c.SetPowerCap(context.Background(), nil); err != nil {
+		t.Fatalf("SetPowerCap(nil): %v", err)
+	}
+}

--- a/providers/lenovo/sel.go
+++ b/providers/lenovo/sel.go
@@ -1,0 +1,33 @@
+package lenovo
+
+import (
+	"context"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+// compile-time assertion that the provider implements the interface.
+var _ bmc.SystemEventLog = (*Conn)(nil)
+
+// GetSystemEventLog returns the System Event Log entries as rows of
+// [id, created, description, message], aggregated from the BMC log services.
+//
+// Implements bmc.SystemEventLog.
+func (c *Conn) GetSystemEventLog(ctx context.Context) (entries [][]string, err error) {
+	return c.redfishwrapper.GetSystemEventLog(ctx)
+}
+
+// GetSystemEventLogRaw returns the raw JSON of the SEL log entries.
+//
+// Implements bmc.SystemEventLog.
+func (c *Conn) GetSystemEventLogRaw(ctx context.Context) (eventlog string, err error) {
+	return c.redfishwrapper.GetSystemEventLogRaw(ctx)
+}
+
+// ClearSystemEventLog clears the BMC log services via the LogService.ClearLog
+// action.
+//
+// Implements bmc.SystemEventLog.
+func (c *Conn) ClearSystemEventLog(ctx context.Context) (err error) {
+	return c.redfishwrapper.ClearSystemEventLog(ctx)
+}

--- a/providers/lenovo/serial.go
+++ b/providers/lenovo/serial.go
@@ -1,0 +1,57 @@
+package lenovo
+
+import (
+	"context"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+// compile-time assertions that the provider implements the interfaces.
+var (
+	_ bmc.SerialInterfaceGetter = (*Conn)(nil)
+	_ bmc.SerialInterfaceSetter = (*Conn)(nil)
+)
+
+// SerialInterfaces returns the BMC serial interfaces.
+//
+// Implements bmc.SerialInterfaceGetter.
+func (c *Conn) SerialInterfaces(ctx context.Context) ([]bmc.SerialInterface, error) {
+	manager, err := c.redfishwrapper.Manager(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ifaces, err := manager.SerialInterfaces()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]bmc.SerialInterface, 0, len(ifaces))
+	for _, s := range ifaces {
+		out = append(out, bmc.SerialInterface{
+			ID:          s.ID,
+			Enabled:     s.InterfaceEnabled,
+			BitRate:     string(s.BitRate),
+			FlowControl: string(s.FlowControl),
+			Parity:      string(s.Parity),
+			StopBits:    string(s.StopBits),
+			DataBits:    string(s.DataBits),
+		})
+	}
+
+	return out, nil
+}
+
+// SetSerialInterface PATCHes a BMC serial interface.
+//
+// Implements bmc.SerialInterfaceSetter.
+func (c *Conn) SetSerialInterface(ctx context.Context, id string, attrs map[string]any) error {
+	manager, err := c.redfishwrapper.Manager(ctx)
+	if err != nil {
+		return err
+	}
+
+	target := singleTrailingSlashJoin(manager.ODataID, "SerialInterfaces/"+id)
+
+	return checkResponse(c.redfishwrapper.PatchWithHeaders(ctx, target, attrs, nil))
+}

--- a/providers/lenovo/serviceroot.go
+++ b/providers/lenovo/serviceroot.go
@@ -1,0 +1,43 @@
+package lenovo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// serviceRootPath is the well-known Redfish service root URI. It is the only
+// resource reachable without authentication.
+const serviceRootPath = "/redfish/v1/"
+
+// ServiceRoot fetches and parses the XCC Redfish service root.
+//
+// Capability code should resolve resource paths (Systems, Managers,
+// UpdateService, ...) from the links returned here rather than hard-coding
+// URIs, so the provider adapts to XCC service-root layout differences across
+// firmware versions.
+func (c *Conn) ServiceRoot(ctx context.Context) (*ServiceRoot, error) {
+	resp, err := c.redfishwrapper.Get(serviceRootPath)
+	if err != nil {
+		return nil, fmt.Errorf("fetching XCC service root: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, parseRedfishError(resp)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", errFailedToParseResponse, err)
+	}
+
+	root := &ServiceRoot{}
+	if err := json.Unmarshal(body, root); err != nil {
+		return nil, fmt.Errorf("%w: %v", errFailedToParseResponse, err)
+	}
+
+	return root, nil
+}

--- a/providers/lenovo/sklm.go
+++ b/providers/lenovo/sklm.go
@@ -1,0 +1,82 @@
+package lenovo
+
+import (
+	"context"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+// sklmSubPath is the XCC OEM Secure Key Lifecycle service, relative to the
+// Manager resource.
+const sklmSubPath = "Oem/Lenovo/SecureKeyLifecycleService"
+
+// compile-time assertion that the provider implements the interface.
+var _ bmc.SecureKeyLifecycle = (*Conn)(nil)
+
+// keyRepoServer mirrors an XCC SecureKeyLifecycleService KeyRepoServers entry.
+type keyRepoServer struct {
+	HostName string `json:"HostName"`
+	Port     int    `json:"Port"`
+}
+
+// secureKeyLifecycleDoc is a partial model of the XCC SecureKeyLifecycleService.
+type secureKeyLifecycleDoc struct {
+	DeviceGroup    string          `json:"DeviceGroup"`
+	KeyRepoServers []keyRepoServer `json:"KeyRepoServers"`
+}
+
+// GetSecureKeyLifecycle reads the XCC Secure Key Lifecycle configuration.
+//
+// Implements bmc.SecureKeyLifecycle.
+func (c *Conn) GetSecureKeyLifecycle(ctx context.Context) (bmc.SecureKeyLifecycleConfig, error) {
+	path, err := c.secureKeyLifecyclePath(ctx)
+	if err != nil {
+		return bmc.SecureKeyLifecycleConfig{}, err
+	}
+
+	var doc secureKeyLifecycleDoc
+	if err := c.getJSON(path, &doc); err != nil {
+		return bmc.SecureKeyLifecycleConfig{}, err
+	}
+
+	cfg := bmc.SecureKeyLifecycleConfig{DeviceGroup: doc.DeviceGroup}
+	for _, s := range doc.KeyRepoServers {
+		cfg.KeyRepoServers = append(cfg.KeyRepoServers, bmc.SecureKeyRepoServer{
+			HostName: s.HostName,
+			Port:     s.Port,
+		})
+	}
+
+	return cfg, nil
+}
+
+// SetSecureKeyRepoServers replaces the configured key-repository servers by
+// PATCHing the SecureKeyLifecycleService.
+//
+// Implements bmc.SecureKeyLifecycle.
+func (c *Conn) SetSecureKeyRepoServers(ctx context.Context, servers []bmc.SecureKeyRepoServer) error {
+	path, err := c.secureKeyLifecyclePath(ctx)
+	if err != nil {
+		return err
+	}
+
+	repo := make([]keyRepoServer, 0, len(servers))
+	for _, s := range servers {
+		repo = append(repo, keyRepoServer{HostName: s.HostName, Port: s.Port})
+	}
+
+	payload := map[string]any{"KeyRepoServers": repo}
+
+	return checkResponse(c.redfishwrapper.PatchWithHeaders(ctx, path, payload, nil))
+}
+
+// secureKeyLifecyclePath resolves the SecureKeyLifecycleService path from the
+// managed Manager resource.
+func (c *Conn) secureKeyLifecyclePath(ctx context.Context) (string, error) {
+	manager, err := c.redfishwrapper.Manager(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return singleTrailingSlashJoin(manager.ODataID, sklmSubPath), nil
+}

--- a/providers/lenovo/snmp.go
+++ b/providers/lenovo/snmp.go
@@ -1,0 +1,89 @@
+package lenovo
+
+import (
+	"context"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+// snmpSubPath is the XCC OEM SNMP resource, relative to the Manager's
+// NetworkProtocol resource.
+const snmpSubPath = "NetworkProtocol/Oem/Lenovo/SNMP"
+
+// compile-time assertion that the provider implements the interface.
+var _ bmc.SNMPConfigurer = (*Conn)(nil)
+
+// SNMP returns the XCC SNMP trap configuration.
+//
+// Implements bmc.SNMPConfigurer.
+func (c *Conn) SNMP(ctx context.Context) (bmc.SNMPConfig, error) {
+	path, err := c.snmpPath(ctx)
+	if err != nil {
+		return bmc.SNMPConfig{}, err
+	}
+
+	// On XCC the OEM SNMP resource carries CommunityNames at the top level (a
+	// sibling of SNMPTraps), not inside SNMPTraps. The trap enable/port live
+	// under SNMPTraps.
+	var doc struct {
+		CommunityNames []string `json:"CommunityNames"`
+		SNMPTraps      struct {
+			SNMPv1TrapEnabled bool `json:"SNMPv1TrapEnabled"`
+			ProtocolEnabled   bool `json:"ProtocolEnabled"`
+			Port              int  `json:"Port"`
+		} `json:"SNMPTraps"`
+	}
+	if err := c.getJSON(path, &doc); err != nil {
+		return bmc.SNMPConfig{}, err
+	}
+
+	return bmc.SNMPConfig{
+		V1TrapEnabled:  doc.SNMPTraps.SNMPv1TrapEnabled,
+		V3TrapEnabled:  doc.SNMPTraps.ProtocolEnabled,
+		TrapPort:       doc.SNMPTraps.Port,
+		CommunityNames: doc.CommunityNames,
+	}, nil
+}
+
+// SetSNMPAlertFilter PATCHes the SNMP trap (SNMPTraps) properties.
+//
+// Implements bmc.SNMPConfigurer.
+func (c *Conn) SetSNMPAlertFilter(ctx context.Context, attrs map[string]any) error {
+	return c.patchSNMPTraps(ctx, attrs)
+}
+
+// EnableSNMPv1Trap enables or disables the SNMPv1 trap.
+//
+// Implements bmc.SNMPConfigurer.
+func (c *Conn) EnableSNMPv1Trap(ctx context.Context, enabled bool) error {
+	return c.patchSNMPTraps(ctx, map[string]any{"SNMPv1TrapEnabled": enabled})
+}
+
+// EnableSNMPv3Trap enables or disables the SNMPv3 trap.
+//
+// Implements bmc.SNMPConfigurer.
+func (c *Conn) EnableSNMPv3Trap(ctx context.Context, enabled bool) error {
+	return c.patchSNMPTraps(ctx, map[string]any{"ProtocolEnabled": enabled})
+}
+
+// patchSNMPTraps PATCHes the SNMP resource with the given SNMPTraps attributes.
+func (c *Conn) patchSNMPTraps(ctx context.Context, traps map[string]any) error {
+	path, err := c.snmpPath(ctx)
+	if err != nil {
+		return err
+	}
+
+	payload := map[string]any{"SNMPTraps": traps}
+
+	return checkResponse(c.redfishwrapper.PatchWithHeaders(ctx, path, payload, nil))
+}
+
+// snmpPath resolves the XCC OEM SNMP resource path from the managed Manager.
+func (c *Conn) snmpPath(ctx context.Context) (string, error) {
+	manager, err := c.redfishwrapper.Manager(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return singleTrailingSlashJoin(manager.ODataID, snmpSubPath), nil
+}

--- a/providers/lenovo/storage.go
+++ b/providers/lenovo/storage.go
@@ -1,0 +1,225 @@
+package lenovo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+	"github.com/stmcginnis/gofish/schemas"
+)
+
+// compile-time assertion that the provider implements the interface.
+var _ bmc.VolumeManager = (*Conn)(nil)
+
+// StorageControllers lists the system's storage controllers.
+//
+// Implements bmc.VolumeManager.
+func (c *Conn) StorageControllers(ctx context.Context) ([]bmc.StorageControllerInfo, error) {
+	storages, err := c.storageControllers()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]bmc.StorageControllerInfo, 0, len(storages))
+	for _, s := range storages {
+		info := bmc.StorageControllerInfo{
+			ID:         s.ID,
+			Name:       s.Name,
+			Health:     string(s.Status.Health),
+			DriveCount: s.DrivesCount,
+		}
+		// XCC populates the deprecated inline StorageControllers array rather
+		// than the Controllers collection, so read the controller model here.
+		if sc := s.StorageControllers; len(sc) > 0 { //nolint:staticcheck
+			info.Model = sc[0].Model
+		}
+		out = append(out, info)
+	}
+
+	return out, nil
+}
+
+// Volumes lists the volumes managed by the given storage controller.
+//
+// Implements bmc.VolumeManager.
+func (c *Conn) Volumes(ctx context.Context, storageID string) ([]bmc.VolumeInfo, error) {
+	storage, err := c.storageByID(storageID)
+	if err != nil {
+		return nil, err
+	}
+
+	volumes, err := storage.Volumes()
+	if err != nil {
+		return nil, fmt.Errorf("listing volumes for controller %q: %w", storageID, err)
+	}
+
+	out := make([]bmc.VolumeInfo, 0, len(volumes))
+	for _, v := range volumes {
+		out = append(out, bmc.VolumeInfo{
+			ID:            v.ID,
+			Name:          v.Name,
+			RAIDType:      string(v.RAIDType),
+			CapacityBytes: int64(derefInt(v.CapacityBytes)),
+			Health:        string(v.Status.Health),
+		})
+	}
+
+	return out, nil
+}
+
+// VolumeCreate creates a volume on the given storage controller by POSTing to
+// its Volumes collection, returning the new volume Id (from the Location header
+// or response body).
+//
+// Implements bmc.VolumeManager.
+func (c *Conn) VolumeCreate(ctx context.Context, storageID string, req bmc.VolumeCreateRequest) (string, error) {
+	storage, err := c.storageByID(storageID)
+	if err != nil {
+		return "", err
+	}
+
+	payload := map[string]any{
+		"Name":     req.Name,
+		"RAIDType": req.RAIDType,
+	}
+	if req.CapacityBytes > 0 {
+		payload["CapacityBytes"] = req.CapacityBytes
+	}
+	if len(req.Drives) > 0 {
+		drives := make([]map[string]string, 0, len(req.Drives))
+		for _, d := range req.Drives {
+			drives = append(drives, map[string]string{"@odata.id": d})
+		}
+		payload["Links"] = map[string]any{"Drives": drives}
+	}
+
+	volumesURL := singleTrailingSlashJoin(storage.ODataID, "Volumes")
+
+	resp, err := c.redfishwrapper.PostWithHeaders(ctx, volumesURL, payload, nil)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", parseRedfishError(resp)
+	}
+
+	// Prefer the created resource location; fall back to the body Id.
+	if loc := resp.Header.Get("Location"); loc != "" {
+		return path.Base(strings.TrimRight(loc, "/")), nil
+	}
+
+	var created struct {
+		ID string `json:"Id"`
+	}
+	if body, rerr := io.ReadAll(resp.Body); rerr == nil {
+		_ = json.Unmarshal(body, &created)
+	}
+
+	return created.ID, nil
+}
+
+// VolumeInitialize initializes a volume via the Volume.Initialize action.
+//
+// The Redfish action target is derived from the volume path; only the
+// InitializeType is sent so the controller's default InitializeMethod applies.
+// Implements bmc.VolumeManager.
+func (c *Conn) VolumeInitialize(ctx context.Context, storageID, volumeID, initType string) error {
+	volume, err := c.volumeByID(storageID, volumeID)
+	if err != nil {
+		return err
+	}
+
+	target := singleTrailingSlashJoin(volume.ODataID, "Actions/Volume.Initialize")
+	payload := map[string]any{"InitializeType": initType}
+
+	return checkResponse(c.redfishwrapper.PostWithHeaders(ctx, target, payload, nil))
+}
+
+// VolumeUpdate updates volume settings via a PATCH of the given attributes.
+//
+// Implements bmc.VolumeManager.
+func (c *Conn) VolumeUpdate(ctx context.Context, storageID, volumeID string, settings map[string]any) error {
+	volume, err := c.volumeByID(storageID, volumeID)
+	if err != nil {
+		return err
+	}
+
+	return checkResponse(c.redfishwrapper.PatchWithHeaders(ctx, volume.ODataID, settings, nil))
+}
+
+// VolumeDelete deletes a volume.
+//
+// Implements bmc.VolumeManager.
+func (c *Conn) VolumeDelete(ctx context.Context, storageID, volumeID string) error {
+	volume, err := c.volumeByID(storageID, volumeID)
+	if err != nil {
+		return err
+	}
+
+	return checkResponse(c.redfishwrapper.Delete(volume.ODataID))
+}
+
+// storageControllers returns the system's gofish Storage resources.
+func (c *Conn) storageControllers() ([]*schemas.Storage, error) {
+	system, err := c.redfishwrapper.System()
+	if err != nil {
+		return nil, err
+	}
+
+	storages, err := system.Storage()
+	if err != nil {
+		return nil, fmt.Errorf("listing storage controllers: %w", err)
+	}
+
+	return storages, nil
+}
+
+// storageByID resolves a gofish Storage resource by its Id.
+func (c *Conn) storageByID(storageID string) (*schemas.Storage, error) {
+	storages, err := c.storageControllers()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, s := range storages {
+		if s.ID == storageID {
+			return s, nil
+		}
+	}
+
+	return nil, fmt.Errorf("storage controller %q not found", storageID)
+}
+
+// volumeByID resolves a gofish Volume resource by controller Id and volume Id.
+func (c *Conn) volumeByID(storageID, volumeID string) (*schemas.Volume, error) {
+	storage, err := c.storageByID(storageID)
+	if err != nil {
+		return nil, err
+	}
+
+	volumes, err := storage.Volumes()
+	if err != nil {
+		return nil, fmt.Errorf("listing volumes for controller %q: %w", storageID, err)
+	}
+
+	for _, v := range volumes {
+		if v.ID == volumeID {
+			return v, nil
+		}
+	}
+
+	return nil, fmt.Errorf("volume %q not found on controller %q", volumeID, storageID)
+}
+
+// singleTrailingSlashJoin joins a Redfish base @odata.id with a sub-path,
+// collapsing any duplicate slash between them.
+func singleTrailingSlashJoin(base, sub string) string {
+	return strings.TrimRight(base, "/") + "/" + strings.TrimLeft(sub, "/")
+}

--- a/providers/lenovo/telemetry.go
+++ b/providers/lenovo/telemetry.go
@@ -1,0 +1,102 @@
+package lenovo
+
+import (
+	"context"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+const (
+	telemetryServiceURI        = "/redfish/v1/TelemetryService"
+	metricReportsURI           = telemetryServiceURI + "/MetricReports"
+	metricReportDefinitionsURI = telemetryServiceURI + "/MetricReportDefinitions"
+	metricDefinitionsURI       = telemetryServiceURI + "/MetricDefinitions"
+	submitTestMetricReportURI  = telemetryServiceURI + "/Actions/TelemetryService.SubmitTestMetricReport"
+)
+
+// compile-time assertion that the provider implements the interface.
+var _ bmc.TelemetryReader = (*Conn)(nil)
+
+// TelemetryService returns the XCC telemetry-service configuration.
+//
+// Implements bmc.TelemetryReader.
+func (c *Conn) TelemetryService(ctx context.Context) (bmc.TelemetryServiceInfo, error) {
+	var doc struct {
+		ServiceEnabled        bool   `json:"ServiceEnabled"`
+		MaxReports            int    `json:"MaxReports"`
+		MinCollectionInterval string `json:"MinCollectionInterval"`
+	}
+	if err := c.getJSON(telemetryServiceURI, &doc); err != nil {
+		return bmc.TelemetryServiceInfo{}, err
+	}
+
+	return bmc.TelemetryServiceInfo{
+		ServiceEnabled:        doc.ServiceEnabled,
+		MaxReports:            doc.MaxReports,
+		MinCollectionInterval: doc.MinCollectionInterval,
+	}, nil
+}
+
+// MetricReports lists the metric report Ids.
+//
+// Implements bmc.TelemetryReader.
+func (c *Conn) MetricReports(ctx context.Context) ([]string, error) {
+	return c.memberIDs(metricReportsURI)
+}
+
+// MetricReport returns a metric report and its values by Id.
+//
+// Implements bmc.TelemetryReader.
+func (c *Conn) MetricReport(ctx context.Context, id string) (bmc.MetricReportInfo, error) {
+	var doc struct {
+		ID           string `json:"Id"`
+		Name         string `json:"Name"`
+		MetricValues []struct {
+			MetricID       string `json:"MetricId"`
+			MetricProperty string `json:"MetricProperty"`
+			MetricValue    string `json:"MetricValue"`
+			Timestamp      string `json:"Timestamp"`
+		} `json:"MetricValues"`
+	}
+	if err := c.getJSON(singleTrailingSlashJoin(metricReportsURI, id), &doc); err != nil {
+		return bmc.MetricReportInfo{}, err
+	}
+
+	report := bmc.MetricReportInfo{ID: doc.ID, Name: doc.Name}
+	for _, v := range doc.MetricValues {
+		report.Values = append(report.Values, bmc.MetricValue{
+			MetricID:       v.MetricID,
+			MetricProperty: v.MetricProperty,
+			Value:          v.MetricValue,
+			Timestamp:      v.Timestamp,
+		})
+	}
+
+	return report, nil
+}
+
+// MetricReportDefinitions lists the metric report definition Ids.
+//
+// Implements bmc.TelemetryReader.
+func (c *Conn) MetricReportDefinitions(ctx context.Context) ([]string, error) {
+	return c.memberIDs(metricReportDefinitionsURI)
+}
+
+// MetricDefinitions lists the metric definition Ids.
+//
+// Implements bmc.TelemetryReader.
+func (c *Conn) MetricDefinitions(ctx context.Context) ([]string, error) {
+	return c.memberIDs(metricDefinitionsURI)
+}
+
+// SubmitTestMetricReport submits a test metric report.
+//
+// Implements bmc.TelemetryReader.
+func (c *Conn) SubmitTestMetricReport(ctx context.Context, reportName string) error {
+	payload := map[string]any{}
+	if reportName != "" {
+		payload["MetricReportName"] = reportName
+	}
+
+	return checkResponse(c.redfishwrapper.PostWithHeaders(ctx, submitTestMetricReportURI, payload, nil))
+}

--- a/providers/lenovo/thermal.go
+++ b/providers/lenovo/thermal.go
@@ -1,0 +1,54 @@
+package lenovo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+// compile-time assertion that the provider implements the interface.
+var _ bmc.ThermalReader = (*Conn)(nil)
+
+// Thermal returns the temperature and fan readings from the first chassis that
+// exposes a Thermal resource.
+//
+// Implements bmc.ThermalReader.
+func (c *Conn) Thermal(ctx context.Context) (bmc.ThermalReading, error) {
+	chassis, err := c.redfishwrapper.Chassis(ctx)
+	if err != nil {
+		return bmc.ThermalReading{}, fmt.Errorf("reading chassis collection: %w", err)
+	}
+
+	for _, ch := range chassis {
+		thermal, err := ch.Thermal()
+		if err != nil || thermal == nil {
+			continue
+		}
+
+		reading := bmc.ThermalReading{}
+		for _, t := range thermal.Temperatures {
+			reading.Temperatures = append(reading.Temperatures, bmc.TemperatureReading{
+				Name:           t.Name,
+				ReadingCelsius: derefFloat64(t.ReadingCelsius),
+				Health:         string(t.Status.Health),
+			})
+		}
+		for _, f := range thermal.Fans {
+			name := f.Name
+			if name == "" {
+				// Fall back to the deprecated FanName for pre-1.1.0 Fan schemas.
+				name = f.FanName //nolint:staticcheck
+			}
+			reading.Fans = append(reading.Fans, bmc.FanReading{
+				Name:    name,
+				Reading: derefInt(f.Reading),
+				Health:  string(f.Status.Health),
+			})
+		}
+
+		return reading, nil
+	}
+
+	return bmc.ThermalReading{}, fmt.Errorf("no chassis exposes a Thermal resource")
+}

--- a/providers/lenovo/types.go
+++ b/providers/lenovo/types.go
@@ -1,0 +1,84 @@
+package lenovo
+
+// derefFloat64 returns the value of p, or 0 if p is nil.
+func derefFloat64(p *float64) float64 {
+	if p == nil {
+		return 0
+	}
+	return *p
+}
+
+// derefFloat32 returns the value of p as a float64, or 0 if p is nil.
+func derefFloat32(p *float32) float64 {
+	if p == nil {
+		return 0
+	}
+	return float64(*p)
+}
+
+// derefInt returns the value of p, or 0 if p is nil.
+func derefInt(p *int) int {
+	if p == nil {
+		return 0
+	}
+	return *p
+}
+
+// odataID is the common Redfish reference link shape: {"@odata.id": "/redfish/..."}.
+type odataID struct {
+	ODataID string `json:"@odata.id"`
+}
+
+// ServiceRoot is a partial model of the XCC Redfish service root
+// ("/redfish/v1/") holding the fields and links the provider needs to discover
+// the rest of the service. It is intentionally not exhaustive — only the links
+// consumed by this provider's capabilities are modelled.
+type ServiceRoot struct {
+	ID             string  `json:"Id"`
+	Name           string  `json:"Name"`
+	Vendor         string  `json:"Vendor"`
+	RedfishVersion string  `json:"RedfishVersion"`
+	UUID           string  `json:"UUID"`
+	Product        string  `json:"Product"`
+	Systems        odataID `json:"Systems"`
+	Managers       odataID `json:"Managers"`
+	Chassis        odataID `json:"Chassis"`
+	UpdateService  odataID `json:"UpdateService"`
+	AccountService odataID `json:"AccountService"`
+	// SessionService is the link to the session service; the Sessions
+	// collection itself is nested under Links.
+	SessionService     odataID `json:"SessionService"`
+	Tasks              odataID `json:"Tasks"`
+	EventService       odataID `json:"EventService"`
+	TelemetryService   odataID `json:"TelemetryService"`
+	JobService         odataID `json:"JobService"`
+	CertificateService odataID `json:"CertificateService"`
+	Registries         odataID `json:"Registries"`
+	Links              struct {
+		Sessions odataID `json:"Sessions"`
+	} `json:"Links"`
+}
+
+// redfishError is the standard Redfish error envelope returned in the body of a
+// failed request. XCC populates @Message.ExtendedInfo with entries that may
+// reference the Lenovo "ExtendedError" registry.
+//
+// See the package documentation and errors.go for how this is mapped into a
+// bmclib error.
+type redfishError struct {
+	Error struct {
+		Code         string                     `json:"code"`
+		Message      string                     `json:"message"`
+		ExtendedInfo []redfishErrorExtendedInfo `json:"@Message.ExtendedInfo"`
+	} `json:"error"`
+}
+
+// redfishErrorExtendedInfo is a single entry of the Redfish extended error
+// information, carrying the registry message id, the human readable message and
+// (for XCC OEM messages) a suggested resolution.
+type redfishErrorExtendedInfo struct {
+	MessageID  string `json:"MessageId"`
+	Message    string `json:"Message"`
+	Resolution string `json:"Resolution"`
+	Severity   string `json:"Severity"`
+}

--- a/providers/lenovo/user.go
+++ b/providers/lenovo/user.go
@@ -1,0 +1,194 @@
+package lenovo
+
+import (
+	"context"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+	"github.com/pkg/errors"
+)
+
+// compile-time assertions that the provider implements the user interfaces.
+var (
+	_ bmc.UserReader  = (*Conn)(nil)
+	_ bmc.UserCreator = (*Conn)(nil)
+	_ bmc.UserUpdater = (*Conn)(nil)
+	_ bmc.UserDeleter = (*Conn)(nil)
+)
+
+var (
+	// ErrUserParams is returned when required user parameters are missing.
+	ErrUserParams = errors.New("user, pass and role are required parameters")
+	// ErrUserExists is returned when creating an account whose username is taken.
+	ErrUserExists = errors.New("user account already exists")
+	// ErrUserNotFound is returned when the named account does not exist.
+	ErrUserNotFound = errors.New("user account not found")
+	// ErrNoUserSlots is returned when no empty account slot is available.
+	ErrNoUserSlots = errors.New("no user account slots available")
+)
+
+// UserRead returns the XCC accounts that have a username assigned.
+//
+// Each entry carries the account id, name, username, role and enabled state.
+// Implements bmc.UserReader.
+func (c *Conn) UserRead(ctx context.Context) (users []map[string]string, err error) {
+	service, err := c.redfishwrapper.AccountService()
+	if err != nil {
+		return nil, err
+	}
+
+	accounts, err := service.Accounts()
+	if err != nil {
+		return nil, err
+	}
+
+	users = make([]map[string]string, 0)
+	for _, account := range accounts {
+		if account.UserName == "" {
+			continue
+		}
+		users = append(users, map[string]string{
+			"ID":       account.ID,
+			"Name":     account.Name,
+			"Username": account.UserName,
+			"RoleID":   account.RoleID,
+			"Enabled":  boolToString(account.Enabled),
+		})
+	}
+
+	return users, nil
+}
+
+// UserCreate creates an XCC account.
+//
+// It first attempts the standard Redfish POST to the accounts collection. When
+// the XCC rejects POST (Intel Purley-based systems), it falls back to PATCHing
+// an empty account slot. Implements bmc.UserCreator.
+func (c *Conn) UserCreate(ctx context.Context, user, pass, role string) (ok bool, err error) {
+	if user == "" || pass == "" || role == "" {
+		return false, ErrUserParams
+	}
+
+	service, err := c.redfishwrapper.AccountService()
+	if err != nil {
+		return false, err
+	}
+
+	accounts, err := service.Accounts()
+	if err != nil {
+		return false, err
+	}
+
+	for _, account := range accounts {
+		if account.UserName == user {
+			return false, errors.Wrap(ErrUserExists, user)
+		}
+	}
+
+	// Primary path: Redfish POST to the accounts collection.
+	if _, postErr := service.CreateAccount(user, pass, role); postErr == nil {
+		return true, nil
+	}
+
+	// Fallback path (Intel Purley-based systems): PATCH an empty account slot.
+	for _, account := range accounts {
+		if account.Enabled || account.UserName != "" {
+			continue
+		}
+
+		account.Enabled = true
+		account.UserName = user
+		account.Password = pass
+		account.RoleID = role
+
+		if err := account.Update(); err != nil {
+			return false, err
+		}
+
+		return true, nil
+	}
+
+	return false, ErrNoUserSlots
+}
+
+// UserUpdate updates an account's password and/or role, matched by username.
+//
+// Implements bmc.UserUpdater.
+func (c *Conn) UserUpdate(ctx context.Context, user, pass, role string) (ok bool, err error) {
+	service, err := c.redfishwrapper.AccountService()
+	if err != nil {
+		return false, err
+	}
+
+	accounts, err := service.Accounts()
+	if err != nil {
+		return false, err
+	}
+
+	for _, account := range accounts {
+		if account.UserName != user {
+			continue
+		}
+
+		var changed bool
+		if pass != "" {
+			account.Password = pass
+			changed = true
+		}
+		if role != "" {
+			account.RoleID = role
+			changed = true
+		}
+
+		if !changed {
+			return true, nil
+		}
+
+		if err := account.Update(); err != nil {
+			return false, err
+		}
+
+		return true, nil
+	}
+
+	return false, ErrUserNotFound
+}
+
+// UserDelete removes an account, matched by username, by clearing the slot
+// (PATCH) — the XCC-compatible delete path. Implements bmc.UserDeleter.
+func (c *Conn) UserDelete(ctx context.Context, user string) (ok bool, err error) {
+	service, err := c.redfishwrapper.AccountService()
+	if err != nil {
+		return false, err
+	}
+
+	accounts, err := service.Accounts()
+	if err != nil {
+		return false, err
+	}
+
+	for _, account := range accounts {
+		if account.UserName != user {
+			continue
+		}
+
+		account.Enabled = false
+		account.UserName = ""
+		account.Password = ""
+
+		if err := account.Update(); err != nil {
+			return false, err
+		}
+
+		return true, nil
+	}
+
+	return false, ErrUserNotFound
+}
+
+// boolToString renders a bool as "true"/"false" for the UserRead string map.
+func boolToString(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}

--- a/providers/lenovo/virtual_media.go
+++ b/providers/lenovo/virtual_media.go
@@ -1,0 +1,279 @@
+package lenovo
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+// compile-time assertion that the provider implements the interface.
+var _ bmc.VirtualMediaSetter = (*Conn)(nil)
+
+// validVirtualMediaKinds are the Redfish VirtualMediaType values accepted by
+// SetVirtualMedia.
+var validVirtualMediaKinds = map[string]bool{
+	"CD": true, "DVD": true, "Floppy": true, "USBStick": true,
+}
+
+// vmSlot is the subset of a VirtualMedia resource the provider needs.
+type vmSlot struct {
+	id         string
+	odataID    string
+	mediaTypes []string
+	inserted   bool
+	image      string
+}
+
+// occupied reports whether the slot currently holds media. Some XCC firmware
+// reports a mounted image via a non-empty Image while Inserted briefly lags (or
+// vice versa), so both are considered.
+func (s vmSlot) occupied() bool {
+	return s.inserted || strings.TrimSpace(s.image) != ""
+}
+
+// ejectPayload is the Redfish body that ejects media from a VirtualMedia slot.
+func ejectPayload() map[string]any {
+	return map[string]any{"Image": nil, "Inserted": false}
+}
+
+// SetVirtualMedia inserts or ejects remote virtual media on the XCC.
+//
+// XCC does NOT implement the Redfish VirtualMedia.InsertMedia/EjectMedia
+// *actions* on its media slots; it expects the client to PATCH the VirtualMedia
+// resource directly (Image/Inserted/WriteProtected/TransferProtocolType), as
+// documented in the XCC REST API guide. This method therefore drives the slots
+// with PATCH rather than the gofish action helpers (which fail on XCC with
+// "does not support insert").
+//
+// kind is a Redfish virtual-media type: "CD", "DVD", "Floppy" or "USBStick".
+// A non-empty mediaURL inserts the image (TransferProtocolType is derived from
+// the URL scheme); an empty mediaURL ejects matching media. Slots are selected
+// by their advertised MediaTypes, preferring free, remote-capable slots — so a
+// remote ISO lands in a "Remote" slot rather than an upload-only "RDOC" slot.
+// Implements bmc.VirtualMediaSetter.
+func (c *Conn) SetVirtualMedia(ctx context.Context, kind string, mediaURL string) (ok bool, err error) {
+	if !validVirtualMediaKinds[kind] {
+		return false, fmt.Errorf("invalid virtual media kind %q (want CD|DVD|Floppy|USBStick)", kind)
+	}
+
+	slots, err := c.virtualMediaSlots(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	candidates := slotsForKind(slots, kind)
+	if len(candidates) == 0 {
+		// Some XCC firmware does not populate MediaTypes; fall back to trying
+		// every slot rather than failing outright.
+		candidates = slots
+	}
+	if len(candidates) == 0 {
+		return false, fmt.Errorf("no virtual media slots found")
+	}
+
+	if mediaURL == "" {
+		return c.ejectVirtualMedia(ctx, candidates)
+	}
+
+	return c.insertVirtualMedia(ctx, candidates, mediaURL)
+}
+
+// insertVirtualMedia mounts mediaURL into a matching slot.
+//
+// To avoid creating a second mount (e.g. media already in EXT2, a new mount
+// landing in EXT3), it first ejects every matching slot that is already
+// occupied, then inserts into the best-ranked now-free slot. This makes
+// repeated inserts idempotent: the device ends up with a single mount.
+func (c *Conn) insertVirtualMedia(ctx context.Context, candidates []vmSlot, mediaURL string) (bool, error) {
+	proto := transferProtocolType(mediaURL)
+
+	// 1) Clear any media already present in matching slots.
+	for i := range candidates {
+		if !candidates[i].occupied() {
+			continue
+		}
+		if err := c.patchVirtualMedia(ctx, candidates[i].odataID, ejectPayload()); err == nil {
+			candidates[i].inserted = false
+			candidates[i].image = ""
+		}
+	}
+
+	// 2) Insert into the best now-free slot (free + remote-capable first).
+	rankSlots(candidates)
+
+	var slotErrs []string
+	for _, s := range candidates {
+		payload := map[string]any{
+			"Image":          mediaURL,
+			"Inserted":       true,
+			"WriteProtected": true,
+		}
+		if proto != "" {
+			payload["TransferProtocolType"] = proto
+		}
+
+		if err := c.patchVirtualMedia(ctx, s.odataID, payload); err == nil {
+			return true, nil
+		} else {
+			// Retry with a minimal payload — some XCC firmware rejects the
+			// Inserted/WriteProtected/TransferProtocolType properties.
+			minimal := map[string]any{"Image": mediaURL, "Inserted": true}
+			if err2 := c.patchVirtualMedia(ctx, s.odataID, minimal); err2 == nil {
+				return true, nil
+			}
+			slotErrs = append(slotErrs, fmt.Sprintf("%s: %v", s.odataID, err))
+		}
+	}
+
+	return false, fmt.Errorf("failed to insert virtual media into any matching slot:\n%s", strings.Join(slotErrs, "\n"))
+}
+
+// ejectVirtualMedia PATCHes any inserted candidate slot to eject its media.
+func (c *Conn) ejectVirtualMedia(ctx context.Context, candidates []vmSlot) (bool, error) {
+	var slotErrs []string
+	var attempted bool
+
+	for _, s := range candidates {
+		if !s.occupied() {
+			continue
+		}
+		attempted = true
+		if err := c.patchVirtualMedia(ctx, s.odataID, ejectPayload()); err != nil {
+			slotErrs = append(slotErrs, fmt.Sprintf("%s: %v", s.odataID, err))
+		}
+	}
+
+	// Nothing was inserted — ejecting is idempotent, so report success.
+	if !attempted {
+		return true, nil
+	}
+	if len(slotErrs) > 0 {
+		return false, fmt.Errorf("failed to eject virtual media:\n%s", strings.Join(slotErrs, "\n"))
+	}
+
+	return true, nil
+}
+
+// patchVirtualMedia PATCHes a VirtualMedia resource and maps the response.
+func (c *Conn) patchVirtualMedia(ctx context.Context, odataID string, payload map[string]any) error {
+	return checkResponse(c.redfishwrapper.PatchWithHeaders(ctx, odataID, payload, nil))
+}
+
+// virtualMediaSlots resolves and reads the VirtualMedia collection, trying the
+// Manager path first and falling back to the System path.
+func (c *Conn) virtualMediaSlots(ctx context.Context) ([]vmSlot, error) {
+	var collectionURL string
+	if manager, err := c.redfishwrapper.Manager(ctx); err == nil {
+		collectionURL = singleTrailingSlashJoin(manager.ODataID, "VirtualMedia")
+	}
+
+	members, err := c.collectionMembersOrEmpty(collectionURL)
+	if len(members) == 0 {
+		if system, serr := c.redfishwrapper.System(); serr == nil {
+			collectionURL = singleTrailingSlashJoin(system.ODataID, "VirtualMedia")
+			members, err = c.collectionMembersOrEmpty(collectionURL)
+		}
+	}
+	if len(members) == 0 {
+		if err != nil {
+			return nil, fmt.Errorf("listing virtual media: %w", err)
+		}
+		return nil, fmt.Errorf("no virtual media slots found at Manager or System paths")
+	}
+
+	slots := make([]vmSlot, 0, len(members))
+	for _, m := range members {
+		var doc struct {
+			ID         string   `json:"Id"`
+			ODataID    string   `json:"@odata.id"`
+			MediaTypes []string `json:"MediaTypes"`
+			Inserted   *bool    `json:"Inserted"`
+			Image      string   `json:"Image"`
+		}
+		if err := c.getJSON(m.ODataID, &doc); err != nil {
+			return nil, err
+		}
+
+		odataID := doc.ODataID
+		if odataID == "" {
+			odataID = m.ODataID
+		}
+		slots = append(slots, vmSlot{
+			id:         doc.ID,
+			odataID:    odataID,
+			mediaTypes: doc.MediaTypes,
+			inserted:   doc.Inserted != nil && *doc.Inserted,
+			image:      doc.Image,
+		})
+	}
+
+	return slots, nil
+}
+
+// collectionMembersOrEmpty returns a collection's members, or an empty slice
+// (and the error) when the URL is empty or the GET fails.
+func (c *Conn) collectionMembersOrEmpty(url string) ([]odataID, error) {
+	if url == "" {
+		return nil, nil
+	}
+	return c.collectionMembers(url)
+}
+
+// slotsForKind returns the slots whose MediaTypes advertise the requested kind.
+func slotsForKind(slots []vmSlot, kind string) []vmSlot {
+	var out []vmSlot
+	for _, s := range slots {
+		for _, mt := range s.mediaTypes {
+			if mt == kind {
+				out = append(out, s)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// rankSlots orders slots best-first for an insert: free slots before occupied
+// ones, and remote-capable ("Remote*") slots before generic ones before
+// upload-only ("RDOC*") slots.
+func rankSlots(slots []vmSlot) {
+	score := func(s vmSlot) int {
+		sc := 0
+		if !s.inserted {
+			sc += 2
+		}
+		id := strings.ToLower(s.id)
+		switch {
+		case strings.HasPrefix(id, "remote"):
+			sc += 4
+		case strings.Contains(id, "rdoc"):
+			sc += 0
+		default:
+			sc += 1
+		}
+		return sc
+	}
+
+	sort.SliceStable(slots, func(i, j int) bool { return score(slots[i]) > score(slots[j]) })
+}
+
+// transferProtocolType derives the Redfish TransferProtocolType from a media URL
+// scheme. It returns "" when the scheme is unknown (the XCC then infers it).
+func transferProtocolType(mediaURL string) string {
+	lower := strings.ToLower(mediaURL)
+	switch {
+	case strings.HasPrefix(lower, "https://"):
+		return "HTTPS"
+	case strings.HasPrefix(lower, "http://"):
+		return "HTTP"
+	case strings.HasPrefix(lower, "nfs://"):
+		return "NFS"
+	case strings.HasPrefix(lower, "cifs://"), strings.HasPrefix(lower, "smb://"):
+		return "CIFS"
+	default:
+		return ""
+	}
+}

--- a/providers/lenovo/virtual_media_test.go
+++ b/providers/lenovo/virtual_media_test.go
@@ -1,0 +1,101 @@
+package lenovo
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Requirement: Insert virtual media by URL + slot selected by kind.
+//
+// XCC mounts via PATCH on the VirtualMedia resource (it does not expose the
+// InsertMedia action), so the provider must PATCH the matching CD slot.
+func TestSetVirtualMediaInsert(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	ok, err := c.SetVirtualMedia(context.Background(), "CD", "http://192.168.1.2/Core-current.iso")
+	if err != nil || !ok {
+		t.Fatalf("SetVirtualMedia(insert) = (%v, %v), want (true, nil)", ok, err)
+	}
+	if !ts.didInsertCD() {
+		t.Error("expected a PATCH inserting media into the CD slot")
+	}
+}
+
+// Requirement: Eject virtual media — ejecting an empty slot is an idempotent
+// success (nothing to PATCH).
+func TestSetVirtualMediaEjectIdempotent(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	// The CD slot fixture is not inserted; ejecting it should succeed without
+	// erroring.
+	ok, err := c.SetVirtualMedia(context.Background(), "CD", "")
+	if err != nil || !ok {
+		t.Fatalf("SetVirtualMedia(eject) = (%v, %v), want (true, nil)", ok, err)
+	}
+}
+
+// Re-mounting into a slot that already holds media must eject it first (so the
+// device ends with a single mount, not a second instance in another slot).
+func TestSetVirtualMediaReplacesExisting(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	// The Floppy slot fixture is already occupied (Inserted + Image).
+	ok, err := c.SetVirtualMedia(context.Background(), "Floppy", "http://192.168.1.2/new.img")
+	if err != nil || !ok {
+		t.Fatalf("SetVirtualMedia(replace) = (%v, %v), want (true, nil)", ok, err)
+	}
+
+	ops := ts.vmOperations()
+	want := []string{"Floppy:eject", "Floppy:insert"}
+	if len(ops) != len(want) {
+		t.Fatalf("vm ops = %v, want %v (eject before insert, same slot)", ops, want)
+	}
+	for i := range want {
+		if ops[i] != want[i] {
+			t.Fatalf("vm ops = %v, want %v", ops, want)
+		}
+	}
+}
+
+// Requirement: Slot selection by kind (Floppy vs CD) — and nondeterministic
+// member ordering is handled by selecting on MediaTypes, not index.
+func TestSetVirtualMediaInvalidKind(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if _, err := c.SetVirtualMedia(context.Background(), "Banana", "http://x/y.iso"); err == nil {
+		t.Fatal("expected an error for an invalid media kind")
+	}
+}
+
+// Requirement: Floppy image upload/eject — unsupported hardware errors clearly.
+func TestMountFloppyImageUnsupported(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	err := c.MountFloppyImage(context.Background(), strings.NewReader("floppy-bytes"))
+	if err == nil {
+		t.Fatal("expected MountFloppyImage to return an error on XCC")
+	}
+	if !errors.Is(err, errFloppyUploadUnsupported) {
+		t.Errorf("error = %v, want errFloppyUploadUnsupported", err)
+	}
+}
+
+// Requirement: Floppy eject is supported (ejects the URL-mounted Floppy media).
+func TestUnmountFloppyImage(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if err := c.UnmountFloppyImage(context.Background()); err != nil {
+		t.Fatalf("UnmountFloppyImage: %v", err)
+	}
+	if !ts.didEjectFloppy() {
+		t.Error("expected a PATCH ejecting the Floppy slot")
+	}
+}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -78,4 +78,61 @@ const (
 
 	// FeatureBootProgress indicates that the implementation supports reading the BootProgress from the BMC
 	FeatureBootProgress registrar.Feature = "bootprogress"
+
+	// FeatureSecureBoot means an implementation can read and manage UEFI Secure Boot
+	FeatureSecureBoot registrar.Feature = "secureboot"
+
+	// FeatureThermalRead means an implementation can read thermal sensors (temperatures, fans)
+	FeatureThermalRead registrar.Feature = "thermalread"
+
+	// FeaturePowerRead means an implementation can read power metrics (consumed watts, power supplies)
+	FeaturePowerRead registrar.Feature = "powerread"
+
+	// FeaturePowerCap means an implementation can set a chassis power limit (power capping)
+	FeaturePowerCap registrar.Feature = "powercap"
+
+	// FeatureVolumeRead means an implementation can read storage controllers and volumes
+	FeatureVolumeRead registrar.Feature = "volumeread"
+
+	// FeatureVolumeManagement means an implementation can create/initialize/update/delete storage volumes
+	FeatureVolumeManagement registrar.Feature = "volumemanagement"
+
+	// FeatureLicenseManagement means an implementation can read/install/delete BMC licenses
+	FeatureLicenseManagement registrar.Feature = "licensemanagement"
+
+	// FeatureSecureKeyLifecycle means an implementation can read/configure the Secure Key Lifecycle service
+	FeatureSecureKeyLifecycle registrar.Feature = "securekeylifecycle"
+
+	// FeatureNetworkInterfaceRead means an implementation can read BMC/server ethernet interfaces
+	FeatureNetworkInterfaceRead registrar.Feature = "networkinterfaceread"
+
+	// FeatureNetworkInterfaceSet means an implementation can configure BMC ethernet/host interfaces
+	FeatureNetworkInterfaceSet registrar.Feature = "networkinterfaceset"
+
+	// FeatureNetworkProtocolRead means an implementation can read manager network protocols
+	FeatureNetworkProtocolRead registrar.Feature = "networkprotocolread"
+
+	// FeatureNetworkProtocolSet means an implementation can configure manager network protocols
+	FeatureNetworkProtocolSet registrar.Feature = "networkprotocolset"
+
+	// FeatureSerialRead means an implementation can read BMC serial interfaces
+	FeatureSerialRead registrar.Feature = "serialread"
+
+	// FeatureSerialSet means an implementation can configure BMC serial interfaces
+	FeatureSerialSet registrar.Feature = "serialset"
+
+	// FeatureEventSubscription means an implementation can read the event service and manage event subscriptions
+	FeatureEventSubscription registrar.Feature = "eventsubscription"
+
+	// FeatureTelemetry means an implementation can read telemetry metric reports and definitions
+	FeatureTelemetry registrar.Feature = "telemetry"
+
+	// FeatureJobManagement means an implementation can read jobs and update job schedules
+	FeatureJobManagement registrar.Feature = "jobmanagement"
+
+	// FeatureCertificateManagement means an implementation can manage BMC certificates
+	FeatureCertificateManagement registrar.Feature = "certificatemanagement"
+
+	// FeatureSNMP means an implementation can read and configure SNMP traps
+	FeatureSNMP registrar.Feature = "snmp"
 )


### PR DESCRIPTION
## What does this PR implement/change/remove?
Adds a new lenovo provider for the Lenovo XClarity Controller (XCC) over Redfish, plus a set of new optional bmc core interfaces that the provider implements. The change is purely additive — it does not modify internal/redfishwrapper, existing bmc interfaces, or any existing provider, so it is backward-compatible by construction.

*Note: This is the initial implementation and the start of ongoing work, not a final/exhaustive one. XCC firmware keeps evolving — newer firmware levels add resources, fields, and behaviors — and there is likely variance across ThinkSystem server generations and models. The provider has been validated end-to-end on a ThinkSystem SR630 V2 (XCC, Redfish 1.14.0) and reconciled against a live resource dump, but additional firmware levels and server models will need to be accommodated as i encounter them. I expect follow-up fixes and extensions, and welcome reports of behavior on other XCC versions/models. Known deferred items: BIOS password change, AccountService LDAP/lockout, real LicenseService path variance, CSR KeyPairAlgorithm/KeyCurveId.*

Commit structure — three self-contained, independently-building commits to ease review (and to allow lifting the core-interfaces commit into its own PR if maintainers prefer):
1. Add optional core interfaces for extended Redfish capabilities — the new bmc interfaces, generic dispatch (bmc/extended.go), Client methods (client_features.go). Builds without the provider.
2. Add Lenovo XClarity Controller (XCC) provider — providers/lenovo/, providers.Feature* consts, and their tests, client.go/option.go wiring, README entry. Builds on top of (1).
3. Add lenovo-smoketest read/write harness — examples/lenovo-smoketest/ and .gitignore.

New provider — providers/lenovo/:
- Built on the existing internal/redfishwrapper / gofish stack; registers itself via client.go like the other Redfish providers.
- Covers the full XCC surface: power & boot, BIOS, secure boot, thermal, power read / power capping, inventory & storage (volume read + management), firmware install (multipart /mfwupdate and raw /fwupdate push protocol with Task polling), virtual media, users / accounts / roles, SEL & audit logs, BMC management (reset, factory reset, license, secure-key-lifecycle), network & serial interfaces, network protocols, events & telemetry, jobs, certificates, and SNMP.

New optional bmc core interfaces implemented by the provider and usable by any future provider:
SecureBootManager, ThermalReader, PowerReader/PowerCapSetter, VolumeManager, LicenseManager, SecureKeyLifecycle, NetworkInterfaceGetter/Setter, NetworkProtocolGetter/Setter, SerialInterfaceGetter/Setter, EventSubscriber, TelemetryReader, JobManager, CertificateManager, SNMPConfigurer (with neutral, provider-agnostic request/response structs).

Client wiring:
- bmc/extended.go — generic *FromInterfaces dispatch helpers, following the existing bmc dispatch pattern.
- client_features.go — new bmclib.Client methods exposing the new interfaces, with the same contract as existing client methods (per-provider timeout, tracing span, metadata, span attributes).
- New providers.Feature* constants in providers/providers.go.

Touched existing files (additive only): client.go (register the provider), option.go (WithLenovoPort/UseBasicAuth/VersionsNotCompatible/WithFailInventoryOnError), providers/providers.go (feature consts), README.md (provider list), .gitignore.

XCC-specific behavior that diverges from stock Redfish handling and is implemented natively in the provider (each validated against hardware — see below):
- Virtual media via PATCH on the VirtualMedia resource (Image/Inserted/WriteProtected/TransferProtocolType) instead of the #VirtualMedia.InsertMedia/EjectMedia actions, which XCC slots do not expose; idempotent eject-before-insert so re-mounts don't accumulate.
- BIOS settings applied without the @Redfish.SettingsApplyTime/ApplyTime annotation (XCC rejects it with PropertyUnknown); writes go to the /Bios/Pending settings target.
- Boot override: XCC only allows Once/Disabled for BootSourceOverrideEnabled — persistent override returns a clear error instead of an opaque dual-400 (persistence is via BootOrder on XCC).
- Absent OEM services (e.g. LicenseService on some FW levels) map 404 to an empty result rather than an error.
- OEM field placement corrected against a real device: SNMP CommunityNames is top-level, telemetry metric values are keyed by MetricProperty, network protocols only report services the device actually exposes.

### Checklist
- [x] Tests added
- [x] Similar commits squashed

### The HW vendor this change applies to (if applicable)
Lenovo

### The HW model number, product name this change applies to (if applicable)
Lenovo ThinkSystem SR630 V2 (validated). The provider is built against the generic XClarity Controller Redfish API and is expected to work across XCC-based ThinkSystem servers, with model/firmware variance handled incrementally as a follow-up.

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)
XClarity Controller (XCC), Redfish service version 1.14.0 on the validated unit (Redfish ≥ 1.13.0 assumed for BootProgress). The full read sweep and targeted writes were exercised against this firmware level; provider behavior was reconciled against a live XCC resource dump. Newer firmware levels may introduce additional resources/fields to be accommodated later.

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)
- Go 1.21
- github.com/stmcginnis/gofish v0.21.6 (transitive, via internal/redfishwrapper)
- No vendor-specific tooling required.

### Description for changelog/release notes
- Add Lenovo XClarity Controller (XCC) provider with full Redfish coverage: power/boot/BIOS, secure boot, thermal, power capping, inventory & storage, firmware install, virtual media, users/roles, SEL & audit logs, BMC/license/secure-key management, network & serial config, events, telemetry, jobs, certificates, and SNMP.
- Introduces optional bmc core interfaces for these capabilities and corresponding bmclib.Client methods.
- Additive and backward-compatible — no changes to existing providers, interfaces, or redfishwrapper.
- Validated on Lenovo ThinkSystem SR630 V2 (XCC, Redfish 1.14.0).
- Initial implementation; further XCC firmware/model variance to be addressed in follow-up work.
