### PR TITLE
fix: add EthernetInterfaces fallback for NICs missing from NetworkInterfaces

### DIFF
--- a/internal/redfishwrapper/fixtures/smc_aoc/ethernet_1.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc/ethernet_1.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#EthernetInterface.v1_6_0.EthernetInterface",
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/1",
+    "Id": "1",
+    "Name": "Onboard LAN 1",
+    "Description": "Onboard Ethernet Interface 1",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "MACAddress": "3c:ec:ef:10:20:01",
+    "SpeedMbps": 10000,
+    "AutoNeg": true,
+    "MTUSize": 9000
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc/ethernet_2.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc/ethernet_2.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#EthernetInterface.v1_6_0.EthernetInterface",
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/2",
+    "Id": "2",
+    "Name": "Onboard LAN 2",
+    "Description": "Onboard Ethernet Interface 2",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "MACAddress": "3c:ec:ef:10:20:02",
+    "SpeedMbps": 10000,
+    "AutoNeg": true,
+    "MTUSize": 9000
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc/ethernet_3.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc/ethernet_3.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#EthernetInterface.v1_6_0.EthernetInterface",
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/3",
+    "Id": "3",
+    "Name": "AOC LAN 1",
+    "Description": "AOC-S25G-m2S Port 1",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "MACAddress": "3c:ec:ef:20:30:01",
+    "SpeedMbps": 25000,
+    "AutoNeg": false,
+    "MTUSize": 9000
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc/ethernet_4.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc/ethernet_4.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#EthernetInterface.v1_6_0.EthernetInterface",
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/4",
+    "Id": "4",
+    "Name": "AOC LAN 2",
+    "Description": "AOC-S25G-m2S Port 2",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "MACAddress": "3c:ec:ef:20:30:02",
+    "SpeedMbps": 25000,
+    "AutoNeg": false,
+    "MTUSize": 9000
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc/ethernet_interfaces.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc/ethernet_interfaces.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#EthernetInterfaceCollection.EthernetInterfaceCollection",
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces",
+    "Name": "Ethernet Interface Collection",
+    "Members@odata.count": 4,
+    "Members": [
+        {"@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/1"},
+        {"@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/2"},
+        {"@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/3"},
+        {"@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/4"}
+    ]
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc/network_adapter.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc/network_adapter.json
@@ -1,0 +1,20 @@
+{
+    "@odata.type": "#NetworkAdapter.v1_0_0.NetworkAdapter",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter",
+    "Id": "NIC.Integrated.1",
+    "Name": "Onboard LAN Adapter",
+    "Manufacturer": "Acme",
+    "Model": "2-Port 10GbE",
+    "SerialNumber": "SN123456",
+    "Controllers": [
+        {
+            "ControllerCapabilities": {
+                "NetworkPortCount": 2
+            },
+            "FirmwarePackageVersion": "1.2.3"
+        }
+    ],
+    "NetworkPorts": {
+        "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts"
+    }
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc/network_interface_integrated_1.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc/network_interface_integrated_1.json
@@ -1,0 +1,10 @@
+{
+    "@odata.type": "#NetworkInterface.v1_1_0.NetworkInterface",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1",
+    "Id": "NIC.Integrated.1",
+    "Name": "Onboard LAN",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "Links": {
+        "NetworkAdapter": {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter"}
+    }
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc/network_interfaces.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc/network_interfaces.json
@@ -1,0 +1,9 @@
+{
+    "@odata.type": "#NetworkInterfaceCollection.NetworkInterfaceCollection",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces",
+    "Name": "Network Interface Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1"}
+    ]
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc/network_port_1.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc/network_port_1.json
@@ -1,0 +1,10 @@
+{
+    "@odata.type": "#NetworkPort.v1_2_0.NetworkPort",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts/1",
+    "Id": "1",
+    "Name": "Port 1",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "ActiveLinkTechnology": "Ethernet",
+    "AssociatedNetworkAddresses": ["3c:ec:ef:10:20:01"],
+    "CurrentLinkSpeedMbps": 10000
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc/network_port_2.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc/network_port_2.json
@@ -1,0 +1,10 @@
+{
+    "@odata.type": "#NetworkPort.v1_2_0.NetworkPort",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts/2",
+    "Id": "2",
+    "Name": "Port 2",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "ActiveLinkTechnology": "Ethernet",
+    "AssociatedNetworkAddresses": ["3c:ec:ef:10:20:02"],
+    "CurrentLinkSpeedMbps": 10000
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc/network_ports.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc/network_ports.json
@@ -1,0 +1,10 @@
+{
+    "@odata.type": "#NetworkPortCollection.NetworkPortCollection",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts",
+    "Name": "Network Port Collection",
+    "Members@odata.count": 2,
+    "Members": [
+        {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts/1"},
+        {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts/2"}
+    ]
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_prefix/ethernet_10.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_prefix/ethernet_10.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#EthernetInterface.v1_6_0.EthernetInterface",
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/10",
+    "Id": "10",
+    "Name": "AOC LAN 1",
+    "Description": "AOC-S25G-m2S Port 1",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "MACAddress": "3c:ec:ef:20:30:01",
+    "SpeedMbps": 25000,
+    "AutoNeg": false,
+    "MTUSize": 9000
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_prefix/ethernet_interfaces.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_prefix/ethernet_interfaces.json
@@ -1,0 +1,11 @@
+{
+    "@odata.type": "#EthernetInterfaceCollection.EthernetInterfaceCollection",
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces",
+    "Name": "Ethernet Interface Collection",
+    "Members@odata.count": 3,
+    "Members": [
+        {"@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/10"},
+        {"@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/1"},
+        {"@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/2"}
+    ]
+}

--- a/internal/redfishwrapper/inventory_collect.go
+++ b/internal/redfishwrapper/inventory_collect.go
@@ -127,6 +127,10 @@ func (c *Client) collectNICs(sys *schemas.ComputerSystem, device *common.Device,
 		return err
 	}
 
+	// Fallback: add any EthernetInterfaces not discovered via NetworkInterfaces.
+	// Some adapters (e.g. Supermicro AOC add-on cards) only appear in EthernetInterfaces.
+	discoveredMACs := make(map[string]struct{})
+
 	for _, nic := range nics {
 		// collect network interface adaptor information
 		adapter, err := nic.NetworkAdapter()
@@ -171,6 +175,10 @@ func (c *Client) collectNICs(sys *schemas.ComputerSystem, device *common.Device,
 				c.collectEthernetInfo(nicPort, ethernetInterfaces)
 			}
 			n.NICPorts = append(n.NICPorts, nicPort)
+
+			if nicPort.MacAddress != "" {
+				discoveredMACs[strings.ToLower(nicPort.MacAddress)] = struct{}{}
+			}
 		}
 
 		// include additional firmware attributes from redfish firmware inventory
@@ -183,6 +191,44 @@ func (c *Client) collectNICs(sys *schemas.ComputerSystem, device *common.Device,
 		}
 
 		device.NICs = append(device.NICs, n)
+	}
+	for _, eth := range ethernetInterfaces {
+		mac := strings.ToLower(eth.MACAddress)
+		if mac == "" || mac == "00:00:00:00:00:00" {
+			continue
+		}
+		if _, seen := discoveredMACs[mac]; seen {
+			continue
+		}
+
+		nicPort := &common.NICPort{
+			Common: common.Common{
+				Description: eth.Description,
+				Status: &common.Status{
+					Health: string(eth.Status.Health),
+					State:  string(eth.Status.State),
+				},
+			},
+			ID:         eth.ID,
+			MacAddress: eth.MACAddress,
+			AutoNeg:    eth.AutoNeg,
+			MTUSize:    gofish.Deref(eth.MTUSize),
+		}
+		if eth.SpeedMbps != nil {
+			nicPort.SpeedBits = int64(gofish.Deref(eth.SpeedMbps)) * int64(math.Pow10(6))
+		}
+
+		device.NICs = append(device.NICs, &common.NIC{
+			Common: common.Common{
+				Description: eth.Name,
+				Status: &common.Status{
+					State:  string(eth.Status.State),
+					Health: string(eth.Status.Health),
+				},
+			},
+			ID:       eth.ID,
+			NICPorts: []*common.NICPort{nicPort},
+		})
 	}
 
 	return nil
@@ -244,8 +290,10 @@ func (c *Client) collectEthernetInfo(nicPort *common.NICPort, ethernetInterfaces
 
 	// populate mac address et al. from matching ethernet interface
 	for _, ethInterface := range ethernetInterfaces {
-		// the ethernet interface includes the port, position number and function NIC.Slot.3-1-1
-		if !strings.HasPrefix(ethInterface.ID, nicPort.ID) {
+		// the ethernet interface includes the port, position number and function NIC.Slot.3-1-1;
+		// require an exact match or a "-"-delimited prefix so that port "1" does not
+		// incorrectly absorb EthernetInterface "10" (HasPrefix("10","1") is true).
+		if ethInterface.ID != nicPort.ID && !strings.HasPrefix(ethInterface.ID, nicPort.ID+"-") {
 			continue
 		}
 

--- a/internal/redfishwrapper/inventory_test.go
+++ b/internal/redfishwrapper/inventory_test.go
@@ -1,0 +1,166 @@
+package redfishwrapper
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInventoryNICsHasPrefixIDCollision proves that collectEthernetInfo's
+// strings.HasPrefix match is broken when numeric IDs share a common prefix.
+//
+// Scenario: NetworkPort "1" (onboard) and EthernetInterface "10" (AOC).
+// HasPrefix("10", "1") is true, so when the BMC returns EthernetInterfaces in
+// order ["10", "1", "2"], port "1" steals the AOC MAC from interface "10".
+// The AOC MAC then lands in discoveredMACs via the main loop, so the fallback
+// skips interface "10" entirely — the AOC NIC silently disappears.
+//
+// This test will FAIL until HasPrefix is replaced with an exact-match or a
+// suffix-aware comparison.
+func TestInventoryNICsHasPrefixIDCollision(t *testing.T) {
+	mux := http.NewServeMux()
+	for path, fixture := range map[string]string{
+		"/redfish/v1/":      "serviceroot.json",
+		"/redfish/v1/Systems":   "systems.json",
+		"/redfish/v1/Systems/1": "systems_1.json",
+
+		"/redfish/v1/Systems/1/NetworkInterfaces":                                                        "smc_aoc/network_interfaces.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1":                                      "smc_aoc/network_interface_integrated_1.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter":                       "smc_aoc/network_adapter.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts":          "smc_aoc/network_ports.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts/1":        "smc_aoc/network_port_1.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts/2":        "smc_aoc/network_port_2.json",
+
+		// EthernetInterfaces returned in order [10, 1, 2] — AOC "10" is first,
+		// causing HasPrefix("10","1") to fire before the correct match on "1".
+		"/redfish/v1/Systems/1/EthernetInterfaces":    "smc_aoc_prefix/ethernet_interfaces.json",
+		"/redfish/v1/Systems/1/EthernetInterfaces/10": "smc_aoc_prefix/ethernet_10.json",
+		"/redfish/v1/Systems/1/EthernetInterfaces/1":  "smc_aoc/ethernet_1.json",
+		"/redfish/v1/Systems/1/EthernetInterfaces/2":  "smc_aoc/ethernet_2.json",
+	} {
+		mux.HandleFunc(path, endpointFunc(t, fixture))
+	}
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := NewClient(u.Hostname(), u.Port(), "", "", WithBasicAuthEnabled(true))
+	require.NoError(t, client.Open(context.Background()))
+	defer client.Close(context.Background())
+
+	device, err := client.Inventory(context.Background(), false)
+	require.NoError(t, err)
+	require.NotNil(t, device)
+
+	// No port on the onboard NIC should carry the AOC MAC.
+	// With the HasPrefix bug, EthernetInterface "10" matches port "1" first
+	// (HasPrefix("10","1")==true) and overwrites both its ID and MAC with the
+	// AOC's values — the onboard port ends up with MAC 3c:ec:ef:20:30:01.
+	for _, nic := range device.NICs {
+		if nic.ID != "NIC.Integrated.1" {
+			continue
+		}
+		for _, p := range nic.NICPorts {
+			assert.NotEqual(t, "3c:ec:ef:20:30:01", p.MacAddress,
+				"onboard NIC port has AOC MAC — HasPrefix collision with EthernetInterface ID '10'")
+		}
+	}
+
+	// The AOC port must appear in the inventory as a fallback NIC.
+	// With the bug, the AOC MAC ends up on the onboard port (above), so
+	// discoveredMACs already contains it and the fallback skips it.
+	aocFound := false
+	for _, nic := range device.NICs {
+		if nic.ID == "NIC.Integrated.1" {
+			continue // skip onboard NIC
+		}
+		for _, p := range nic.NICPorts {
+			if p.MacAddress == "3c:ec:ef:20:30:01" {
+				aocFound = true
+			}
+		}
+	}
+	assert.True(t, aocFound, "AOC NIC (EthernetInterface ID '10') missing from inventory due to HasPrefix collision")
+}
+
+// TestInventoryNICsWithAOCFallback verifies that EthernetInterfaces-only ports
+// (e.g. Supermicro AOC add-on cards absent from NetworkInterfaces) are included
+// in the inventory.
+//
+// Fixture layout:
+//   - NetworkInterfaces: 1 onboard NIC with 2 ports (port IDs "1" and "2")
+//   - EthernetInterfaces: 4 entries — IDs "1" and "2" enrich the onboard ports
+//     via collectEthernetInfo (HasPrefix match); IDs "3" and "4" are AOC ports
+//     that do NOT match any network port and must be added by the fallback.
+func TestInventoryNICsWithAOCFallback(t *testing.T) {
+	mux := http.NewServeMux()
+	for path, fixture := range map[string]string{
+		// gofish bootstrap
+		"/redfish/v1/":      "serviceroot.json",
+		"/redfish/v1/Systems":   "systems.json",
+		"/redfish/v1/Systems/1": "systems_1.json",
+		// NetworkInterfaces hierarchy
+		"/redfish/v1/Systems/1/NetworkInterfaces":                                         "smc_aoc/network_interfaces.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1":                       "smc_aoc/network_interface_integrated_1.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter":        "smc_aoc/network_adapter.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts":   "smc_aoc/network_ports.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts/1": "smc_aoc/network_port_1.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts/2": "smc_aoc/network_port_2.json",
+		// EthernetInterfaces (4 entries: 2 onboard + 2 AOC)
+		"/redfish/v1/Systems/1/EthernetInterfaces":   "smc_aoc/ethernet_interfaces.json",
+		"/redfish/v1/Systems/1/EthernetInterfaces/1": "smc_aoc/ethernet_1.json",
+		"/redfish/v1/Systems/1/EthernetInterfaces/2": "smc_aoc/ethernet_2.json",
+		"/redfish/v1/Systems/1/EthernetInterfaces/3": "smc_aoc/ethernet_3.json",
+		"/redfish/v1/Systems/1/EthernetInterfaces/4": "smc_aoc/ethernet_4.json",
+	} {
+		mux.HandleFunc(path, endpointFunc(t, fixture))
+	}
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := NewClient(u.Hostname(), u.Port(), "", "", WithBasicAuthEnabled(true))
+	require.NoError(t, client.Open(context.Background()))
+	defer client.Close(context.Background())
+
+	device, err := client.Inventory(context.Background(), false)
+	require.NoError(t, err)
+	require.NotNil(t, device)
+
+	// Collect all NIC port MACs for easy assertion.
+	portMACs := make(map[string]bool)
+	totalPorts := 0
+	for _, nic := range device.NICs {
+		for _, p := range nic.NICPorts {
+			portMACs[p.MacAddress] = true
+			totalPorts++
+		}
+	}
+
+	assert.Equal(t, 4, totalPorts, "expected 4 NIC ports (2 onboard + 2 AOC)")
+	assert.True(t, portMACs["3c:ec:ef:10:20:01"], "onboard port 1 MAC missing")
+	assert.True(t, portMACs["3c:ec:ef:10:20:02"], "onboard port 2 MAC missing")
+	assert.True(t, portMACs["3c:ec:ef:20:30:01"], "AOC port 1 MAC missing")
+	assert.True(t, portMACs["3c:ec:ef:20:30:02"], "AOC port 2 MAC missing")
+
+	// AOC ports should carry the speed from the EthernetInterface (25 Gbps).
+	for _, nic := range device.NICs {
+		for _, p := range nic.NICPorts {
+			if p.MacAddress == "3c:ec:ef:20:30:01" || p.MacAddress == "3c:ec:ef:20:30:02" {
+				assert.Equal(t, int64(25_000_000_000), p.SpeedBits,
+					"AOC port %s should have 25 Gbps", p.MacAddress)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What does this PR implement/change/remove?

Adds a fallback in `collectNICs` that picks up EthernetInterfaces entries whose MAC addresses were not discovered via the NetworkInterfaces hierarchy. This fixes Supermicro AOC add-on cards, which appear in `EthernetInterfaces` but are absent from `NetworkInterfaces`.

### Checklist
- [x] Tests added
- [x] Similar commits squashed

### The HW vendor this change applies to (if applicable)

Supermicro

### The HW model number, product name this change applies to (if applicable)

AOC-S25G-m2S (25GbE add-on card). Likely affects other Supermicro AOC add-on cards as well.

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

Unknown — observed on a production system but firmware version was not captured.

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

N/A

## Description for changelog/release notes

```
fix: Supermicro AOC add-on NIC cards (e.g. AOC-S25G-m2S) now appear in inventory.
These adapters are absent from NetworkInterfaces but present in EthernetInterfaces;
bmclib now falls back to EthernetInterfaces for any MAC not already discovered.
```