### PR TITLE
providers/ipmi: fix session lifecycle to use persistent connection

### DIFF
--- a/internal/goipmi/goipmi.go
+++ b/internal/goipmi/goipmi.go
@@ -94,19 +94,16 @@ func toCipherSuiteID(c int) ipmi.CipherSuiteID {
 	return ipmi.CipherSuiteID3
 }
 
-// ensureConnected ensures the IPMI client is connected
-func (i *Ipmi) ensureConnected(ctx context.Context) error {
-	// For go-ipmi, we need to connect before each operation
+func (i *Ipmi) Open(ctx context.Context) error {
 	return i.client.Connect(ctx)
+}
+
+func (i *Ipmi) Close(ctx context.Context) error {
+	return i.client.Close(ctx)
 }
 
 // PowerCycle reboots the machine via bmc
 func (i *Ipmi) PowerCycle(ctx context.Context) (status bool, err error) {
-	if err := i.ensureConnected(ctx); err != nil {
-		return false, fmt.Errorf("failed to connect: %v", err)
-	}
-	defer i.client.Close(ctx)
-	
 	_, err = i.client.ChassisControl(ctx, ipmi.ChassisControlPowerCycle)
 	if err != nil {
 		return false, fmt.Errorf("chassis control failed: %v", err)
@@ -119,11 +116,6 @@ func (i *Ipmi) PowerCycle(ctx context.Context) (status bool, err error) {
 //
 //	Perform an immediate (non-graceful) shutdown, followed by a restart.
 func (i *Ipmi) ForceRestart(ctx context.Context) (status bool, err error) {
-	if err := i.ensureConnected(ctx); err != nil {
-		return false, fmt.Errorf("failed to connect: %v", err)
-	}
-	defer i.client.Close(ctx)
-
 	// Get current power state
 	chassisStatus, err := i.client.GetChassisStatus(ctx)
 	if err != nil {
@@ -146,11 +138,6 @@ func (i *Ipmi) ForceRestart(ctx context.Context) (status bool, err error) {
 
 // PowerReset reboots the machine via bmc
 func (i *Ipmi) PowerReset(ctx context.Context) (status bool, err error) {
-	if err := i.ensureConnected(ctx); err != nil {
-		return false, fmt.Errorf("failed to connect: %v", err)
-	}
-	defer i.client.Close(ctx)
-	
 	_, err = i.client.ChassisControl(ctx, ipmi.ChassisControlHardReset)
 	if err != nil {
 		return false, fmt.Errorf("chassis control failed: %v", err)
@@ -160,11 +147,6 @@ func (i *Ipmi) PowerReset(ctx context.Context) (status bool, err error) {
 
 // PowerCycleBmc reboots the bmc we are connected to
 func (i *Ipmi) PowerCycleBmc(ctx context.Context) (status bool, err error) {
-	if err := i.ensureConnected(ctx); err != nil {
-		return false, fmt.Errorf("failed to connect: %v", err)
-	}
-	defer i.client.Close(ctx)
-	
 	err = i.client.ColdReset(ctx)
 	if err != nil {
 		return false, fmt.Errorf("MC cold reset failed: %v", err)
@@ -174,11 +156,6 @@ func (i *Ipmi) PowerCycleBmc(ctx context.Context) (status bool, err error) {
 
 // PowerResetBmc reboots the bmc we are connected to
 func (i *Ipmi) PowerResetBmc(ctx context.Context, resetType string) (ok bool, err error) {
-	if err := i.ensureConnected(ctx); err != nil {
-		return false, fmt.Errorf("failed to connect: %v", err)
-	}
-	defer i.client.Close(ctx)
-	
 	switch strings.ToLower(resetType) {
 	case "cold":
 		err = i.client.ColdReset(ctx)
@@ -203,11 +180,6 @@ func (i *Ipmi) PowerOn(ctx context.Context) (status bool, err error) {
 	if s {
 		return true, nil
 	}
-
-	if err := i.ensureConnected(ctx); err != nil {
-		return false, fmt.Errorf("failed to connect: %v", err)
-	}
-	defer i.client.Close(ctx)
 	
 	_, err = i.client.ChassisControl(ctx, ipmi.ChassisControlPowerUp)
 	if err != nil {
@@ -218,11 +190,6 @@ func (i *Ipmi) PowerOn(ctx context.Context) (status bool, err error) {
 
 // PowerOnForce power on the machine via bmc even when the machine is already on (Thanks HP!)
 func (i *Ipmi) PowerOnForce(ctx context.Context) (status bool, err error) {
-	if err := i.ensureConnected(ctx); err != nil {
-		return false, fmt.Errorf("failed to connect: %v", err)
-	}
-	defer i.client.Close(ctx)
-	
 	_, err = i.client.ChassisControl(ctx, ipmi.ChassisControlPowerUp)
 	if err != nil {
 		return false, fmt.Errorf("chassis control failed: %v", err)
@@ -235,11 +202,6 @@ func (i *Ipmi) PowerOff(ctx context.Context) (status bool, err error) {
 	if on, err := i.IsOn(ctx); err == nil && !on {
 		return true, nil
 	}
-	
-	if err := i.ensureConnected(ctx); err != nil {
-		return false, fmt.Errorf("failed to connect: %v", err)
-	}
-	defer i.client.Close(ctx)
 	
 	_, err = i.client.ChassisControl(ctx, ipmi.ChassisControlPowerDown)
 	if err != nil {
@@ -254,11 +216,6 @@ func (i *Ipmi) PowerSoft(ctx context.Context) (status bool, err error) {
 	if !on {
 		return true, nil
 	}
-
-	if err := i.ensureConnected(ctx); err != nil {
-		return false, fmt.Errorf("failed to connect: %v", err)
-	}
-	defer i.client.Close(ctx)
 	
 	_, err = i.client.ChassisControl(ctx, ipmi.ChassisControlSoftShutdown)
 	if err != nil {
@@ -269,11 +226,6 @@ func (i *Ipmi) PowerSoft(ctx context.Context) (status bool, err error) {
 
 // PxeOnceEfi makes the machine to boot via pxe once using EFI
 func (i *Ipmi) PxeOnceEfi(ctx context.Context) (status bool, err error) {
-	if err := i.ensureConnected(ctx); err != nil {
-		return false, fmt.Errorf("failed to connect: %v", err)
-	}
-	defer i.client.Close(ctx)
-	
 	err = i.client.SetBootDevice(ctx, ipmi.BootDeviceSelectorForcePXE, ipmi.BIOSBootTypeEFI, false)
 	if err != nil {
 		return false, fmt.Errorf("set boot device failed: %v", err)
@@ -283,11 +235,6 @@ func (i *Ipmi) PxeOnceEfi(ctx context.Context) (status bool, err error) {
 
 // BootDeviceSet sets the next boot device with options
 func (i *Ipmi) BootDeviceSet(ctx context.Context, bootDevice string, setPersistent, efiBoot bool) (ok bool, err error) {
-	if err := i.ensureConnected(ctx); err != nil {
-		return false, fmt.Errorf("failed to connect: %v", err)
-	}
-	defer i.client.Close(ctx)
-	
 	var device ipmi.BootDeviceSelector
 	switch strings.ToLower(bootDevice) {
 	case "pxe":
@@ -322,11 +269,6 @@ func (i *Ipmi) BootDeviceSet(ctx context.Context, bootDevice string, setPersiste
 
 // PxeOnceMbr makes the machine to boot via pxe once using MBR
 func (i *Ipmi) PxeOnceMbr(ctx context.Context) (status bool, err error) {
-	if err := i.ensureConnected(ctx); err != nil {
-		return false, fmt.Errorf("failed to connect: %v", err)
-	}
-	defer i.client.Close(ctx)
-	
 	err = i.client.SetBootDevice(ctx, ipmi.BootDeviceSelectorForcePXE, ipmi.BIOSBootTypeLegacy, false)
 	if err != nil {
 		return false, fmt.Errorf("set boot device failed: %v", err)
@@ -341,11 +283,6 @@ func (i *Ipmi) PxeOnce(ctx context.Context) (status bool, err error) {
 
 // IsOn tells if a machine is currently powered on
 func (i *Ipmi) IsOn(ctx context.Context) (status bool, err error) {
-	if err := i.ensureConnected(ctx); err != nil {
-		return false, fmt.Errorf("failed to connect: %v", err)
-	}
-	defer i.client.Close(ctx)
-	
 	chassisStatus, err := i.client.GetChassisStatus(ctx)
 	if err != nil {
 		return false, fmt.Errorf("failed to get chassis status: %v", err)
@@ -355,11 +292,6 @@ func (i *Ipmi) IsOn(ctx context.Context) (status bool, err error) {
 
 // PowerState returns the current power state of the machine
 func (i *Ipmi) PowerState(ctx context.Context) (state string, err error) {
-	if err := i.ensureConnected(ctx); err != nil {
-		return "", fmt.Errorf("failed to connect: %v", err)
-	}
-	defer i.client.Close(ctx)
-	
 	chassisStatus, err := i.client.GetChassisStatus(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get chassis status: %v", err)
@@ -373,11 +305,6 @@ func (i *Ipmi) PowerState(ctx context.Context) (state string, err error) {
 
 // ReadUsers list all BMC users
 func (i *Ipmi) ReadUsers(ctx context.Context) (users []map[string]string, err error) {
-	if err := i.ensureConnected(ctx); err != nil {
-		return nil, fmt.Errorf("failed to connect: %v", err)
-	}
-	defer i.client.Close(ctx)
-	
 	// Try to get user information for user IDs 1-16 (typical range)
 	// Since GetUsers might not be available, we'll iterate through user IDs
 	for userID := uint8(1); userID <= 16; userID++ {
@@ -414,11 +341,6 @@ func (i *Ipmi) ReadUsers(ctx context.Context) (users []map[string]string, err er
 
 // ClearSystemEventLog clears the system event log
 func (i *Ipmi) ClearSystemEventLog(ctx context.Context) (err error) {
-	if err := i.ensureConnected(ctx); err != nil {
-		return fmt.Errorf("failed to connect: %v", err)
-	}
-	defer i.client.Close(ctx)
-	
 	// Use 0x4321 as the clear operation code (standard IPMI clear operation)
 	_, err = i.client.ClearSEL(ctx, 0x4321)
 	if err != nil {
@@ -440,11 +362,6 @@ func (i *Ipmi) GetSystemEventLog(ctx context.Context) (entries [][]string, err e
 
 // GetSystemEventLogRaw returns the raw SEL output
 func (i *Ipmi) GetSystemEventLogRaw(ctx context.Context) (eventlog string, err error) {
-	if err := i.ensureConnected(ctx); err != nil {
-		return "", fmt.Errorf("failed to connect: %v", err)
-	}
-	defer i.client.Close(ctx)
-	
 	// Get all SEL entries starting from record ID 0
 	selEntries, err := i.client.GetSELEntries(ctx, 0)
 	if err != nil {
@@ -478,11 +395,6 @@ func (i *Ipmi) GetSystemEventLogRaw(ctx context.Context) (eventlog string, err e
 }
 
 func (i *Ipmi) DeactivateSOL(ctx context.Context) (err error) {
-	if err := i.ensureConnected(ctx); err != nil {
-		return fmt.Errorf("failed to connect: %v", err)
-	}
-	defer i.client.Close(ctx)
-
 	_, err = i.client.DeactivatePayload(ctx, &ipmi.DeactivatePayloadRequest{
 		PayloadType:     ipmi.PayloadTypeSOL,
 		PayloadInstance: 0,
@@ -500,11 +412,6 @@ func (i *Ipmi) DeactivateSOL(ctx context.Context) (err error) {
 
 // SendPowerDiag tells the BMC to issue an NMI to the device
 func (i *Ipmi) SendPowerDiag(ctx context.Context) error {
-	if err := i.ensureConnected(ctx); err != nil {
-		return fmt.Errorf("failed to connect: %v", err)
-	}
-	defer i.client.Close(ctx)
-	
 	_, err := i.client.ChassisControl(ctx, ipmi.ChassisControlDiagnosticInterrupt)
 	if err != nil {
 		return errors.Wrap(err, "failed sending power diag")

--- a/internal/goipmi/goipmi.go
+++ b/internal/goipmi/goipmi.go
@@ -65,6 +65,29 @@ func New(username, password, host string, port int, opts ...Option) (c *Ipmi, er
 	return c, nil
 }
 
+// Clone returns a copy of the Ipmi with a fresh, unconnected client. It is used
+// to run isolated operations (such as compatibility checks) without touching the
+// session state of the original connection.
+func (i *Ipmi) Clone() (*Ipmi, error) {
+	cl, err := ipmi.NewClient(i.Host, i.Port, i.Username, i.Password)
+	if err != nil {
+		return nil, err
+	}
+	c := &Ipmi{
+		Username:    i.Username,
+		Password:    i.Password,
+		Host:        i.Host,
+		Port:        i.Port,
+		log:         i.log,
+		cipherSuite: i.cipherSuite,
+		client:      cl,
+	}
+	c.client.WithInterface(ipmi.InterfaceLanplus)
+	c.client.WithCipherSuiteID(toCipherSuiteID(c.cipherSuite))
+
+	return c, nil
+}
+
 // parseSystemEventLogRaw parses the raw output of the system event log. Helper
 // function for GetSystemEventLog to make testing the parser easier.
 func parseSystemEventLog(raw string) (entries [][]string) {

--- a/internal/goipmi/goipmi.go
+++ b/internal/goipmi/goipmi.go
@@ -94,10 +94,12 @@ func toCipherSuiteID(c int) ipmi.CipherSuiteID {
 	return ipmi.CipherSuiteID3
 }
 
+// Open establishes an IPMI LAN+ session to the BMC.
 func (i *Ipmi) Open(ctx context.Context) error {
 	return i.client.Connect(ctx)
 }
 
+// Close tears down the active IPMI session.
 func (i *Ipmi) Close(ctx context.Context) error {
 	return i.client.Close(ctx)
 }
@@ -164,7 +166,7 @@ func (i *Ipmi) PowerResetBmc(ctx context.Context, resetType string) (ok bool, er
 	default:
 		return false, fmt.Errorf("unsupported reset type: %s", resetType)
 	}
-	
+
 	if err != nil {
 		return false, fmt.Errorf("MC reset failed: %v", err)
 	}
@@ -180,7 +182,7 @@ func (i *Ipmi) PowerOn(ctx context.Context) (status bool, err error) {
 	if s {
 		return true, nil
 	}
-	
+
 	_, err = i.client.ChassisControl(ctx, ipmi.ChassisControlPowerUp)
 	if err != nil {
 		return false, fmt.Errorf("chassis control failed: %v", err)
@@ -202,7 +204,7 @@ func (i *Ipmi) PowerOff(ctx context.Context) (status bool, err error) {
 	if on, err := i.IsOn(ctx); err == nil && !on {
 		return true, nil
 	}
-	
+
 	_, err = i.client.ChassisControl(ctx, ipmi.ChassisControlPowerDown)
 	if err != nil {
 		return false, fmt.Errorf("chassis control failed: %v", err)
@@ -212,11 +214,14 @@ func (i *Ipmi) PowerOff(ctx context.Context) (status bool, err error) {
 
 // PowerSoft power off the machine via bmc
 func (i *Ipmi) PowerSoft(ctx context.Context) (status bool, err error) {
-	on, _ := i.IsOn(ctx)
+	on, err := i.IsOn(ctx)
+	if err != nil {
+		return false, errors.Wrap(err, "error checking power state")
+	}
 	if !on {
 		return true, nil
 	}
-	
+
 	_, err = i.client.ChassisControl(ctx, ipmi.ChassisControlSoftShutdown)
 	if err != nil {
 		return false, fmt.Errorf("chassis control failed: %v", err)
@@ -254,12 +259,12 @@ func (i *Ipmi) BootDeviceSet(ctx context.Context, bootDevice string, setPersiste
 	default:
 		device = ipmi.BootDeviceSelectorNoOverride
 	}
-	
+
 	biosBootType := ipmi.BIOSBootTypeLegacy
 	if efiBoot {
 		biosBootType = ipmi.BIOSBootTypeEFI
 	}
-	
+
 	err = i.client.SetBootDevice(ctx, device, biosBootType, setPersistent)
 	if err != nil {
 		return false, fmt.Errorf("set boot device failed: %v", err)
@@ -296,7 +301,7 @@ func (i *Ipmi) PowerState(ctx context.Context) (state string, err error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get chassis status: %v", err)
 	}
-	
+
 	if chassisStatus.PowerIsOn {
 		return "Chassis Power is on", nil
 	}
@@ -313,29 +318,29 @@ func (i *Ipmi) ReadUsers(ctx context.Context) (users []map[string]string, err er
 			// Skip users that don't exist or can't be accessed
 			continue
 		}
-		
+
 		// Get username for this user ID
 		userNameResp, err := i.client.GetUsername(ctx, userID)
 		if err != nil {
 			// Skip users that can't be queried
 			continue
 		}
-		
+
 		if userNameResp.Username == "" {
 			// Skip users without names
 			continue
 		}
-		
+
 		users = append(users, map[string]string{
-			"ID":               fmt.Sprintf("%d", userID),
-			"Name":             userNameResp.Username,
-			"Callin":           fmt.Sprintf("%t", userAccess.CallbackOnly),
-			"Link Auth":        fmt.Sprintf("%t", userAccess.LinkAuthEnabled),
-			"IPMI Msg":         fmt.Sprintf("%t", userAccess.IPMIMessagingEnabled),
+			"ID":                 fmt.Sprintf("%d", userID),
+			"Name":               userNameResp.Username,
+			"Callin":             fmt.Sprintf("%t", userAccess.CallbackOnly),
+			"Link Auth":          fmt.Sprintf("%t", userAccess.LinkAuthEnabled),
+			"IPMI Msg":           fmt.Sprintf("%t", userAccess.IPMIMessagingEnabled),
 			"Channel Priv Limit": fmt.Sprintf("%v", userAccess.MaxPrivLevel),
 		})
 	}
-	
+
 	return users, nil
 }
 
@@ -367,11 +372,11 @@ func (i *Ipmi) GetSystemEventLogRaw(ctx context.Context) (eventlog string, err e
 	if err != nil {
 		return "", fmt.Errorf("failed to get SEL entries: %v", err)
 	}
-	
+
 	// Format SEL entries into the expected raw format for compatibility
 	var lines []string
 	lines = append(lines, "   SEL Record ID          | Date/Time         | Sensor Name      | Event Dir  | Event Data")
-	
+
 	for _, entry := range selEntries {
 		if entry.Standard != nil {
 			timestamp := entry.Standard.Timestamp.Format("01/02/2006 | 15:04:05")
@@ -380,17 +385,17 @@ func (i *Ipmi) GetSystemEventLogRaw(ctx context.Context) (eventlog string, err e
 			if entry.Standard.EventDir == ipmi.EventDirDeassertion {
 				eventDir = "Deasserted"
 			}
-			eventData := fmt.Sprintf("0x%02x 0x%02x 0x%02x", 
+			eventData := fmt.Sprintf("0x%02x 0x%02x 0x%02x",
 				entry.Standard.EventData.EventData1,
 				entry.Standard.EventData.EventData2,
 				entry.Standard.EventData.EventData3)
-			
+
 			line := fmt.Sprintf(" %04x | %s | %-16s | %-10s | %s",
 				entry.RecordID, timestamp, sensorName, eventDir, eventData)
 			lines = append(lines, line)
 		}
 	}
-	
+
 	return strings.Join(lines, "\n"), nil
 }
 

--- a/internal/goipmi/goipmi_test.go
+++ b/internal/goipmi/goipmi_test.go
@@ -1,0 +1,28 @@
+package goipmi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClone(t *testing.T) {
+	orig, err := New("user", "pass", "host", 623, WithCipherSuite("17"))
+	require.NoError(t, err)
+
+	clone, err := orig.Clone()
+	require.NoError(t, err)
+
+	// The clone must carry a fresh, independent client so operations on it
+	// never touch the original's session.
+	assert.NotSame(t, orig, clone)
+	assert.NotSame(t, orig.client, clone.client)
+
+	// All connection parameters must be preserved.
+	assert.Equal(t, orig.Username, clone.Username)
+	assert.Equal(t, orig.Password, clone.Password)
+	assert.Equal(t, orig.Host, clone.Host)
+	assert.Equal(t, orig.Port, clone.Port)
+	assert.Equal(t, orig.cipherSuite, clone.cipherSuite)
+}

--- a/providers/ipmi/ipmi.go
+++ b/providers/ipmi/ipmi.go
@@ -120,11 +120,10 @@ func (c *Conn) Close(ctx context.Context) (err error) {
 	if !c.open {
 		return nil
 	}
-	if err := c.ipmi.Close(ctx); err != nil {
-		return err
-	}
+	// Clear the open state before closing so a failed Close still allows
+	// callers to retry Open; the underlying session is torn down regardless.
 	c.open = false
-	return nil
+	return c.ipmi.Close(ctx)
 }
 
 // openForCompatible opens the connection if not already open.

--- a/providers/ipmi/ipmi.go
+++ b/providers/ipmi/ipmi.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strconv"
 	"strings"
+	"sync"
 
 	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
 	"github.com/bmc-toolbox/bmclib/v2/internal/goipmi"
@@ -37,8 +38,10 @@ var (
 
 // Conn for IPMI connection details
 type Conn struct {
-	ipmi      *goipmi.Ipmi
-	log      logr.Logger
+	ipmi   *goipmi.Ipmi
+	log    logr.Logger
+	openMu sync.Mutex
+	open   bool
 }
 
 type Config struct {
@@ -98,41 +101,67 @@ func New(host, user, pass string, opts ...Option) (*Conn, error) {
 
 // Open a connection to a BMC
 func (c *Conn) Open(ctx context.Context) (err error) {
-	_, err = c.ipmi.PowerState(ctx)
-	if err != nil {
+	c.openMu.Lock()
+	defer c.openMu.Unlock()
+	if c.open {
+		return nil
+	}
+	if err := c.ipmi.Open(ctx); err != nil {
 		return err
 	}
-
+	c.open = true
 	return nil
 }
 
 // Close a connection to a BMC
 func (c *Conn) Close(ctx context.Context) (err error) {
+	c.openMu.Lock()
+	defer c.openMu.Unlock()
+	if !c.open {
+		return nil
+	}
+	if err := c.ipmi.Close(ctx); err != nil {
+		return err
+	}
+	c.open = false
 	return nil
+}
+
+// openForCompatible opens the connection if not already open.
+// Returns true if this call opened it (caller must close it).
+func (c *Conn) openForCompatible(ctx context.Context) (bool, error) {
+	c.openMu.Lock()
+	defer c.openMu.Unlock()
+	if c.open {
+		return false, nil
+	}
+	if err := c.ipmi.Open(ctx); err != nil {
+		return false, err
+	}
+	c.open = true
+	return true, nil
 }
 
 // Compatible tests whether a BMC is compatible with the ipmi provider
 func (c *Conn) Compatible(ctx context.Context) bool {
-	err := c.Open(ctx)
+	// Since this could be called before or after the Conn is opened,
+	// we want the connection state to be the same before and after the compatibility check.
+	opened, err := c.openForCompatible(ctx)
 	if err != nil {
-		c.log.V(2).WithValues(
-			"provider",
-			c.Name(),
-		).Info("warn", bmclibErrs.ErrCompatibilityCheck.Error(), err.Error())
-
+		c.log.V(2).WithValues("provider", c.Name()).
+			Info("warn", bmclibErrs.ErrCompatibilityCheck.Error(), err.Error())
 		return false
 	}
-	defer c.Close(ctx)
-
-	_, err = c.ipmi.PowerState(ctx)
-	if err != nil {
-		c.log.V(2).WithValues(
-			"provider",
-			c.Name(),
-		).Info("warn", bmclibErrs.ErrCompatibilityCheck.Error(), err.Error())
+	if opened {
+		defer c.Close(ctx)
 	}
 
-	return err == nil
+	if _, err := c.ipmi.PowerState(ctx); err != nil {
+		c.log.V(2).WithValues("provider", c.Name()).
+			Info("warn", bmclibErrs.ErrCompatibilityCheck.Error(), err.Error())
+		return false
+	}
+	return true
 }
 
 func (c *Conn) Name() string {

--- a/providers/ipmi/ipmi.go
+++ b/providers/ipmi/ipmi.go
@@ -126,36 +126,25 @@ func (c *Conn) Close(ctx context.Context) (err error) {
 	return c.ipmi.Close(ctx)
 }
 
-// openForCompatible opens the connection if not already open.
-// Returns true if this call opened it (caller must close it).
-func (c *Conn) openForCompatible(ctx context.Context) (bool, error) {
-	c.openMu.Lock()
-	defer c.openMu.Unlock()
-	if c.open {
-		return false, nil
-	}
-	if err := c.ipmi.Open(ctx); err != nil {
-		return false, err
-	}
-	c.open = true
-	return true, nil
-}
-
 // Compatible tests whether a BMC is compatible with the ipmi provider
 func (c *Conn) Compatible(ctx context.Context) bool {
-	// Since this could be called before or after the Conn is opened,
-	// we want the connection state to be the same before and after the compatibility check.
-	opened, err := c.openForCompatible(ctx)
+	// Use an isolated, throwaway connection so the compatibility check never
+	// affects the session state of the caller's connection.
+	clone, err := c.ipmi.Clone()
 	if err != nil {
 		c.log.V(2).WithValues("provider", c.Name()).
 			Info("warn", bmclibErrs.ErrCompatibilityCheck.Error(), err.Error())
 		return false
 	}
-	if opened {
-		defer c.Close(ctx)
+	probe := &Conn{ipmi: clone, log: c.log}
+	if err := probe.Open(ctx); err != nil {
+		c.log.V(2).WithValues("provider", c.Name()).
+			Info("warn", bmclibErrs.ErrCompatibilityCheck.Error(), err.Error())
+		return false
 	}
+	defer probe.Close(ctx)
 
-	if _, err := c.ipmi.PowerState(ctx); err != nil {
+	if _, err := probe.ipmi.PowerState(ctx); err != nil {
 		c.log.V(2).WithValues("provider", c.Name()).
 			Info("warn", bmclibErrs.ErrCompatibilityCheck.Error(), err.Error())
 		return false


### PR DESCRIPTION
## What does this PR implement/change/remove?

The ipmi provider was opening a new RMCP+ session per operation via an internal ensureConnected/defer Close pattern in every goipmi method. go-ipmi assigns per-session request sequence numbers during the RMCP+ handshake; tearing down the session between calls caused the BMC to reject subsequent requests with IPMI LAN: no matching IPMI response (expected rqSeq 0x05, command 0x38) before UDP read deadline after 5 attempt(s). Chained operations (e.g. PowerSet → IsOn → ChassisControl) compounded this: each inner call's defer Close tore down the session the outer call was still using, causing cascading timeouts and a 20s test runtime. The provider now maintains a single persistent session for the duration of an Open/Close lifecycle, with a mutex-guarded open bool to prevent the double-connect (silent session state overwrite) and double-close (close of closed channel panic) that go-ipmi does not protect against itself.

### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes

```
```
