### PR TITLE
fix: resolve NIC port MAC misattribution when NetworkPort IDs collide across adapters

### DIFF
--- a/internal/redfishwrapper/fixtures/smc_aoc_disabled_function/ethernet_interfaces.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_disabled_function/ethernet_interfaces.json
@@ -1,0 +1,7 @@
+{
+    "@odata.type": "#EthernetInterfaceCollection.EthernetInterfaceCollection",
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces",
+    "Name": "Ethernet Interface Collection",
+    "Members@odata.count": 0,
+    "Members": []
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_disabled_function/network_adapter.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_disabled_function/network_adapter.json
@@ -1,0 +1,15 @@
+{
+    "@odata.type": "#NetworkAdapter.v1_0_0.NetworkAdapter",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter",
+    "Id": "NIC.Slot.1",
+    "Name": "Add-on Adapter",
+    "Manufacturer": "TESTVENDOR",
+    "Model": "TEST-AOC",
+    "SerialNumber": "TESTAOCSERIAL02",
+    "NetworkPorts": {
+        "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkPorts"
+    },
+    "NetworkDeviceFunctions": {
+        "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkDeviceFunctions"
+    }
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_disabled_function/network_device_function_1.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_disabled_function/network_device_function_1.json
@@ -1,0 +1,14 @@
+{
+    "@odata.type": "#NetworkDeviceFunction.v1_9_0.NetworkDeviceFunction",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkDeviceFunctions/1",
+    "Id": "1",
+    "Name": "Disabled_Function_1",
+    "NetDevFuncType": "Ethernet",
+    "DeviceEnabled": false,
+    "Ethernet": {
+        "MACAddress": "00:00:00:00:00:00"
+    },
+    "Links": {
+        "PhysicalPortAssignment": {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkPorts/1"}
+    }
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_disabled_function/network_device_functions.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_disabled_function/network_device_functions.json
@@ -1,0 +1,9 @@
+{
+    "@odata.type": "#NetworkDeviceFunctionCollection.NetworkDeviceFunctionCollection",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkDeviceFunctions",
+    "Name": "Network Device Function Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkDeviceFunctions/1"}
+    ]
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_disabled_function/network_interface_slot_1.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_disabled_function/network_interface_slot_1.json
@@ -1,0 +1,10 @@
+{
+    "@odata.type": "#NetworkInterface.v1_1_0.NetworkInterface",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1",
+    "Id": "NIC.Slot.1",
+    "Name": "Add-on NIC",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "Links": {
+        "NetworkAdapter": {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter"}
+    }
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_disabled_function/network_interfaces.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_disabled_function/network_interfaces.json
@@ -1,0 +1,9 @@
+{
+    "@odata.type": "#NetworkInterfaceCollection.NetworkInterfaceCollection",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces",
+    "Name": "Network Interface Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1"}
+    ]
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_disabled_function/network_port_1.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_disabled_function/network_port_1.json
@@ -1,0 +1,10 @@
+{
+    "@odata.type": "#NetworkPort.v1_2_0.NetworkPort",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkPorts/1",
+    "Id": "1",
+    "Name": "Port 1",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "ActiveLinkTechnology": "Ethernet",
+    "AssociatedNetworkAddresses": ["00:00:5e:00:53:05"],
+    "CurrentLinkSpeedMbps": 25000
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_disabled_function/network_ports.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_disabled_function/network_ports.json
@@ -1,0 +1,9 @@
+{
+    "@odata.type": "#NetworkPortCollection.NetworkPortCollection",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkPorts",
+    "Name": "Network Port Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkPorts/1"}
+    ]
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_id_collision/ethernet_1.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_id_collision/ethernet_1.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#EthernetInterface.v1_6_0.EthernetInterface",
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/1",
+    "Id": "1",
+    "Name": "OnBoard_NIC1",
+    "Description": "Onboard NIC Port 1",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "MACAddress": "00:00:5e:00:53:01",
+    "SpeedMbps": 1000,
+    "AutoNeg": true,
+    "MTUSize": 1500
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_id_collision/ethernet_2.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_id_collision/ethernet_2.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#EthernetInterface.v1_6_0.EthernetInterface",
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/2",
+    "Id": "2",
+    "Name": "OnBoard_NIC2",
+    "Description": "Onboard NIC Port 2",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "MACAddress": "00:00:5e:00:53:02",
+    "SpeedMbps": 1000,
+    "AutoNeg": true,
+    "MTUSize": 1500
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_id_collision/ethernet_3.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_id_collision/ethernet_3.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#EthernetInterface.v1_6_0.EthernetInterface",
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/3",
+    "Id": "3",
+    "Name": "AOC_NIC1",
+    "Description": "AOC-S25G-m2S Port 1",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "MACAddress": "00:00:5e:00:53:03",
+    "SpeedMbps": 25000,
+    "AutoNeg": false,
+    "MTUSize": 9000
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_id_collision/ethernet_4.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_id_collision/ethernet_4.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#EthernetInterface.v1_6_0.EthernetInterface",
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/4",
+    "Id": "4",
+    "Name": "AOC_NIC2",
+    "Description": "AOC-S25G-m2S Port 2",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "MACAddress": "00:00:5e:00:53:04",
+    "SpeedMbps": 25000,
+    "AutoNeg": false,
+    "MTUSize": 9000
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_id_collision/ethernet_interfaces.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_id_collision/ethernet_interfaces.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#EthernetInterfaceCollection.EthernetInterfaceCollection",
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces",
+    "Name": "Ethernet Interface Collection",
+    "Members@odata.count": 4,
+    "Members": [
+        {"@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/1"},
+        {"@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/2"},
+        {"@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/3"},
+        {"@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/4"}
+    ]
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_adapter_aoc.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_adapter_aoc.json
@@ -1,0 +1,15 @@
+{
+    "@odata.type": "#NetworkAdapter.v1_0_0.NetworkAdapter",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter",
+    "Id": "NIC.Slot.1",
+    "Name": "AOC-S25G-m2S",
+    "Manufacturer": "Supermicro",
+    "Model": "AOC-S25G-m2S",
+    "SerialNumber": "TESTAOCSERIAL01",
+    "NetworkPorts": {
+        "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkPorts"
+    },
+    "NetworkDeviceFunctions": {
+        "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkDeviceFunctions"
+    }
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_adapter_onboard.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_adapter_onboard.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#NetworkAdapter.v1_0_0.NetworkAdapter",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter",
+    "Id": "NIC.Integrated.1",
+    "Name": "Onboard LAN Adapter",
+    "Manufacturer": "Supermicro",
+    "Model": "OnBoard_NIC",
+    "SerialNumber": "SN-ONBOARD",
+    "NetworkPorts": {
+        "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts"
+    }
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_device_function_aoc_1.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_device_function_aoc_1.json
@@ -1,0 +1,13 @@
+{
+    "@odata.type": "#NetworkDeviceFunction.v1_9_0.NetworkDeviceFunction",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkDeviceFunctions/1",
+    "Id": "1",
+    "Name": "AOC_NIC1",
+    "NetDevFuncType": "Ethernet",
+    "Ethernet": {
+        "MACAddress": "00:00:5e:00:53:03"
+    },
+    "Links": {
+        "PhysicalPortAssignment": {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkPorts/1"}
+    }
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_device_function_aoc_2.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_device_function_aoc_2.json
@@ -1,0 +1,13 @@
+{
+    "@odata.type": "#NetworkDeviceFunction.v1_9_0.NetworkDeviceFunction",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkDeviceFunctions/2",
+    "Id": "2",
+    "Name": "AOC_NIC2",
+    "NetDevFuncType": "Ethernet",
+    "Ethernet": {
+        "MACAddress": "00:00:5e:00:53:04"
+    },
+    "Links": {
+        "PhysicalPortAssignment": {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkPorts/2"}
+    }
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_device_functions_aoc.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_device_functions_aoc.json
@@ -1,0 +1,10 @@
+{
+    "@odata.type": "#NetworkDeviceFunctionCollection.NetworkDeviceFunctionCollection",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkDeviceFunctions",
+    "Name": "Network Device Function Collection",
+    "Members@odata.count": 2,
+    "Members": [
+        {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkDeviceFunctions/1"},
+        {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkDeviceFunctions/2"}
+    ]
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_interface_integrated_1.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_interface_integrated_1.json
@@ -1,0 +1,10 @@
+{
+    "@odata.type": "#NetworkInterface.v1_1_0.NetworkInterface",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1",
+    "Id": "NIC.Integrated.1",
+    "Name": "Onboard LAN",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "Links": {
+        "NetworkAdapter": {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter"}
+    }
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_interface_slot_1.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_interface_slot_1.json
@@ -1,0 +1,10 @@
+{
+    "@odata.type": "#NetworkInterface.v1_1_0.NetworkInterface",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1",
+    "Id": "NIC.Slot.1",
+    "Name": "AOC Slot 1",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "Links": {
+        "NetworkAdapter": {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter"}
+    }
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_interfaces.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_interfaces.json
@@ -1,0 +1,10 @@
+{
+    "@odata.type": "#NetworkInterfaceCollection.NetworkInterfaceCollection",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces",
+    "Name": "Network Interface Collection",
+    "Members@odata.count": 2,
+    "Members": [
+        {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1"},
+        {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1"}
+    ]
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_port_aoc_1.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_port_aoc_1.json
@@ -1,0 +1,9 @@
+{
+    "@odata.type": "#NetworkPort.v1_2_0.NetworkPort",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkPorts/1",
+    "Id": "1",
+    "Name": "Port 1",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "ActiveLinkTechnology": "Ethernet",
+    "CurrentLinkSpeedMbps": 25000
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_port_aoc_2.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_port_aoc_2.json
@@ -1,0 +1,9 @@
+{
+    "@odata.type": "#NetworkPort.v1_2_0.NetworkPort",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkPorts/2",
+    "Id": "2",
+    "Name": "Port 2",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "ActiveLinkTechnology": "Ethernet",
+    "CurrentLinkSpeedMbps": 25000
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_port_onboard_1.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_port_onboard_1.json
@@ -1,0 +1,10 @@
+{
+    "@odata.type": "#NetworkPort.v1_2_0.NetworkPort",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts/1",
+    "Id": "1",
+    "Name": "Port 1",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "ActiveLinkTechnology": "Ethernet",
+    "AssociatedNetworkAddresses": ["00:00:5e:00:53:01"],
+    "CurrentLinkSpeedMbps": 1000
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_port_onboard_2.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_port_onboard_2.json
@@ -1,0 +1,10 @@
+{
+    "@odata.type": "#NetworkPort.v1_2_0.NetworkPort",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts/2",
+    "Id": "2",
+    "Name": "Port 2",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "ActiveLinkTechnology": "Ethernet",
+    "AssociatedNetworkAddresses": ["00:00:5e:00:53:02"],
+    "CurrentLinkSpeedMbps": 1000
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_ports_aoc.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_ports_aoc.json
@@ -1,0 +1,10 @@
+{
+    "@odata.type": "#NetworkPortCollection.NetworkPortCollection",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkPorts",
+    "Name": "Network Port Collection",
+    "Members@odata.count": 2,
+    "Members": [
+        {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkPorts/1"},
+        {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkPorts/2"}
+    ]
+}

--- a/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_ports_onboard.json
+++ b/internal/redfishwrapper/fixtures/smc_aoc_id_collision/network_ports_onboard.json
@@ -1,0 +1,10 @@
+{
+    "@odata.type": "#NetworkPortCollection.NetworkPortCollection",
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts",
+    "Name": "Network Port Collection",
+    "Members@odata.count": 2,
+    "Members": [
+        {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts/1"},
+        {"@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts/2"}
+    ]
+}

--- a/internal/redfishwrapper/inventory_collect.go
+++ b/internal/redfishwrapper/inventory_collect.go
@@ -166,6 +166,13 @@ func (c *Client) collectNICs(sys *schemas.ComputerSystem, device *common.Device,
 
 		portFirmwareVersion := getFirmwareVersionFromController(adapter.Controllers, len(ports))
 
+		// NetworkPort.ID is only unique within its own adapter, so a card with
+		// local port IDs "1"/"2" (e.g. an add-on AOC) collides with an unrelated
+		// onboard NIC that also has ports "1"/"2". Resolve each port's MAC
+		// authoritatively via NetworkDeviceFunctions, which links a specific
+		// port to its function by odata.id rather than by the ambiguous local ID.
+		portMACs := c.networkPortMACs(adapter)
+
 		for _, networkPort := range ports {
 			// populate network ports general data
 			nicPort := &common.NICPort{}
@@ -173,7 +180,7 @@ func (c *Client) collectNICs(sys *schemas.ComputerSystem, device *common.Device,
 
 			if networkPort.ActiveLinkTechnology == schemas.EthernetLinkNetworkTechnology {
 				// ethernet specific data
-				c.collectEthernetInfo(nicPort, ethernetInterfaces)
+				c.collectEthernetInfo(nicPort, ethernetInterfaces, portMACs[networkPort.ODataID])
 			}
 			n.NICPorts = append(n.NICPorts, nicPort)
 
@@ -282,16 +289,63 @@ func (c *Client) collectNetworkPortInfo(
 	}
 }
 
-func (c *Client) collectEthernetInfo(nicPort *common.NICPort, ethernetInterfaces []*schemas.EthernetInterface) {
+// networkPortMACs returns a map of NetworkPort odata.id -> MAC address for the
+// given adapter, resolved via its NetworkDeviceFunctions. This is the
+// authoritative link between a physical port and its MAC address: unlike
+// NetworkPort.ID (only unique within the adapter) or EthernetInterface.ID
+// (system-wide, but on some Redfish implementations arbitrarily numbered),
+// NetworkDeviceFunction.PhysicalPortAssignment resolves to the exact NetworkPort
+// resource, keyed by its unique odata.id.
+func (c *Client) networkPortMACs(adapter *schemas.NetworkAdapter) map[string]string {
+	macs := make(map[string]string)
+	if adapter == nil {
+		return macs
+	}
+
+	functions, err := adapter.NetworkDeviceFunctions()
+	if err != nil {
+		return macs
+	}
+
+	for _, function := range functions {
+		mac := function.Ethernet.MACAddress
+		if mac == "" || mac == "00:00:00:00:00:00" {
+			mac = function.Ethernet.PermanentMACAddress
+		}
+		if mac == "" || mac == "00:00:00:00:00:00" {
+			continue
+		}
+
+		port, err := function.PhysicalPortAssignment()
+		if err != nil || port == nil {
+			continue
+		}
+
+		macs[port.ODataID] = mac
+	}
+
+	return macs
+}
+
+func (c *Client) collectEthernetInfo(nicPort *common.NICPort, ethernetInterfaces []*schemas.EthernetInterface, preferredMAC string) {
 	if nicPort == nil {
 		return
 	}
 	// populate mac address et al. from matching ethernet interface
 	for _, ethInterface := range ethernetInterfaces {
-		// the ethernet interface includes the port, position number and function NIC.Slot.3-1-1;
-		// require an exact match or a "-"-delimited prefix so that port "1" does not
-		// incorrectly absorb EthernetInterface "10" (HasPrefix("10","1") is true).
-		if ethInterface.ID != nicPort.ID && !strings.HasPrefix(ethInterface.ID, nicPort.ID+"-") {
+		if preferredMAC != "" {
+			// preferredMAC was resolved authoritatively via the adapter's
+			// NetworkDeviceFunctions; match on it instead of the ambiguous
+			// NetworkPort/EthernetInterface ID so that add-on cards whose local
+			// port IDs collide with an unrelated adapter's IDs (e.g. both using
+			// "1"/"2") don't inherit that adapter's ethernet attributes.
+			if !strings.EqualFold(ethInterface.MACAddress, preferredMAC) {
+				continue
+			}
+		} else if ethInterface.ID != nicPort.ID && !strings.HasPrefix(ethInterface.ID, nicPort.ID+"-") {
+			// the ethernet interface includes the port, position number and function NIC.Slot.3-1-1;
+			// require an exact match or a "-"-delimited prefix so that port "1" does not
+			// incorrectly absorb EthernetInterface "10" (HasPrefix("10","1") is true).
 			continue
 		}
 
@@ -321,6 +375,12 @@ func (c *Client) collectEthernetInfo(nicPort *common.NICPort, ethernetInterfaces
 		// always override mac address
 		nicPort.MacAddress = ethInterface.MACAddress
 		break // stop at first match
+	}
+
+	// preferredMAC is authoritative even if no EthernetInterface matched it
+	// (e.g. the port isn't enumerated in the EthernetInterfaces collection at all).
+	if preferredMAC != "" {
+		nicPort.MacAddress = preferredMAC
 	}
 }
 

--- a/internal/redfishwrapper/inventory_collect_test.go
+++ b/internal/redfishwrapper/inventory_collect_test.go
@@ -170,7 +170,7 @@ func TestInventoryCollectEthernetInfo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := Client{}
-			c.collectEthernetInfo(tt.nicPort, tt.ethernetInterfaces)
+			c.collectEthernetInfo(tt.nicPort, tt.ethernetInterfaces, "")
 		})
 	}
 }

--- a/internal/redfishwrapper/inventory_test.go
+++ b/internal/redfishwrapper/inventory_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -287,4 +288,128 @@ func TestInventoryCollectDrivesWithoutCount(t *testing.T) {
 	}
 	assert.True(t, serials["TESTDRIVESERIAL01"], "Disk.Bay.2 missing from inventory")
 	assert.True(t, serials["TESTDRIVESERIAL02"], "Disk.Bay.3 missing from inventory")
+}
+
+// TestInventoryNICsAdapterIDCollision proves that collectNICs correctly
+// attributes MAC addresses when two distinct NetworkAdapters expose NetworkPorts
+// with the same local IDs ("1"/"2").
+//
+// Scenario (matching a real Supermicro AS-1114S-WN10RT-EU with an AOC-S25G-m2S
+// add-on card): the onboard NIC and the AOC card both have NetworkPorts locally
+// numbered "1" and "2". collectEthernetInfo's ID-based matching is ambiguous
+// here — the AOC's port "1" exact-matches system-wide EthernetInterface "1",
+// which actually belongs to the onboard NIC, not the AOC. Without the
+// NetworkDeviceFunctions-based authoritative MAC resolution, the AOC's ports
+// silently inherit the onboard NIC's MAC addresses (and vice versa is masked
+// because the onboard port's own AssociatedNetworkAddresses already set the
+// correct value first).
+//
+// This test will FAIL until collectNICs resolves each port's MAC via the
+// adapter's NetworkDeviceFunctions rather than matching by ID alone.
+func TestInventoryNICsAdapterIDCollision(t *testing.T) {
+	mux := http.NewServeMux()
+	for path, fixture := range map[string]string{
+		"/redfish/v1/":          "serviceroot.json",
+		"/redfish/v1/Systems":   "systems.json",
+		"/redfish/v1/Systems/1": "systems_1.json",
+
+		"/redfish/v1/Systems/1/NetworkInterfaces":                  "smc_aoc_id_collision/network_interfaces.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1": "smc_aoc_id_collision/network_interface_integrated_1.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1":       "smc_aoc_id_collision/network_interface_slot_1.json",
+
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter":                "smc_aoc_id_collision/network_adapter_onboard.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts":   "smc_aoc_id_collision/network_ports_onboard.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts/1": "smc_aoc_id_collision/network_port_onboard_1.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Integrated.1/NetworkAdapter/NetworkPorts/2": "smc_aoc_id_collision/network_port_onboard_2.json",
+
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter":                          "smc_aoc_id_collision/network_adapter_aoc.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkPorts":             "smc_aoc_id_collision/network_ports_aoc.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkPorts/1":           "smc_aoc_id_collision/network_port_aoc_1.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkPorts/2":           "smc_aoc_id_collision/network_port_aoc_2.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkDeviceFunctions":   "smc_aoc_id_collision/network_device_functions_aoc.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkDeviceFunctions/1": "smc_aoc_id_collision/network_device_function_aoc_1.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkDeviceFunctions/2": "smc_aoc_id_collision/network_device_function_aoc_2.json",
+
+		"/redfish/v1/Systems/1/EthernetInterfaces":   "smc_aoc_id_collision/ethernet_interfaces.json",
+		"/redfish/v1/Systems/1/EthernetInterfaces/1": "smc_aoc_id_collision/ethernet_1.json",
+		"/redfish/v1/Systems/1/EthernetInterfaces/2": "smc_aoc_id_collision/ethernet_2.json",
+		"/redfish/v1/Systems/1/EthernetInterfaces/3": "smc_aoc_id_collision/ethernet_3.json",
+		"/redfish/v1/Systems/1/EthernetInterfaces/4": "smc_aoc_id_collision/ethernet_4.json",
+	} {
+		mux.HandleFunc(path, endpointFunc(t, fixture))
+	}
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := NewClient(u.Hostname(), u.Port(), "", "", WithBasicAuthEnabled(true))
+	require.NoError(t, client.Open(context.Background()))
+	defer client.Close(context.Background())
+
+	device, err := client.Inventory(context.Background(), false)
+	require.NoError(t, err)
+	require.NotNil(t, device)
+
+	macsByAdapter := make(map[string][]string)
+	for _, nic := range device.NICs {
+		for _, p := range nic.NICPorts {
+			macsByAdapter[nic.ID] = append(macsByAdapter[nic.ID], strings.ToLower(p.MacAddress))
+		}
+	}
+
+	assert.ElementsMatch(t, []string{"00:00:5e:00:53:01", "00:00:5e:00:53:02"}, macsByAdapter["NIC.Integrated.1"],
+		"onboard NIC ports have the wrong MACs")
+	assert.ElementsMatch(t, []string{"00:00:5e:00:53:03", "00:00:5e:00:53:04"}, macsByAdapter["NIC.Slot.1"],
+		"AOC NIC ports have the wrong MACs — likely inherited the onboard NIC's MACs due to a NetworkPort ID collision")
+}
+
+// TestInventoryNICsDisabledDeviceFunctionMAC proves that networkPortMACs does
+// not treat "00:00:00:00:00:00" (a placeholder MAC reported by disabled
+// NetworkDeviceFunctions) as an authoritative value. Every other MAC source in
+// this file already filters this placeholder out (AssociatedNetworkAddresses,
+// the EthernetInterfaces fallback); networkPortMACs must too, since
+// collectEthernetInfo unconditionally overwrites nicPort.MacAddress with the
+// preferred MAC once one is resolved, which would otherwise zero out a real
+// MAC already collected from the port's own AssociatedNetworkAddresses.
+func TestInventoryNICsDisabledDeviceFunctionMAC(t *testing.T) {
+	mux := http.NewServeMux()
+	for path, fixture := range map[string]string{
+		"/redfish/v1/":          "serviceroot.json",
+		"/redfish/v1/Systems":   "systems.json",
+		"/redfish/v1/Systems/1": "systems_1.json",
+
+		"/redfish/v1/Systems/1/NetworkInterfaces":                                                    "smc_aoc_disabled_function/network_interfaces.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1":                                         "smc_aoc_disabled_function/network_interface_slot_1.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter":                          "smc_aoc_disabled_function/network_adapter.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkPorts":             "smc_aoc_disabled_function/network_ports.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkPorts/1":           "smc_aoc_disabled_function/network_port_1.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkDeviceFunctions":   "smc_aoc_disabled_function/network_device_functions.json",
+		"/redfish/v1/Systems/1/NetworkInterfaces/NIC.Slot.1/NetworkAdapter/NetworkDeviceFunctions/1": "smc_aoc_disabled_function/network_device_function_1.json",
+
+		"/redfish/v1/Systems/1/EthernetInterfaces": "smc_aoc_disabled_function/ethernet_interfaces.json",
+	} {
+		mux.HandleFunc(path, endpointFunc(t, fixture))
+	}
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := NewClient(u.Hostname(), u.Port(), "", "", WithBasicAuthEnabled(true))
+	require.NoError(t, client.Open(context.Background()))
+	defer client.Close(context.Background())
+
+	device, err := client.Inventory(context.Background(), false)
+	require.NoError(t, err)
+	require.NotNil(t, device)
+
+	require.Len(t, device.NICs, 1)
+	require.Len(t, device.NICs[0].NICPorts, 1)
+	assert.Equal(t, "00:00:5e:00:53:05", strings.ToLower(device.NICs[0].NICPorts[0].MacAddress),
+		"port MAC should come from AssociatedNetworkAddresses, not be zeroed out by a disabled NetworkDeviceFunction's placeholder MAC")
 }


### PR DESCRIPTION
## What does this PR implement/change/remove?

`collectEthernetInfo` matched a `NetworkPort`'s local ID against the system-wide
`EthernetInterfaces` collection by ID (exact match or "-"-delimited prefix).
`NetworkPort.ID` is only unique *within its own adapter*, so an add-on card
whose local port IDs happen to collide with an unrelated adapter's (e.g. both
using "1"/"2") silently inherited that other adapter's MAC address and other
ethernet attributes — a real card can end up reported with a different
physical card's MAC.

This PR resolves each port's MAC authoritatively via the adapter's own
`NetworkDeviceFunctions` (`Ethernet.MACAddress` + `PhysicalPortAssignment`),
which links a specific port by `odata.id` rather than by the ambiguous local
ID, and prefers MAC-based matching in `collectEthernetInfo` when available.
Falls back to the existing ID-based matching for adapters that don't expose
`NetworkDeviceFunctions`.

### Checklist
- [x] Tests added
- [x] Similar commits squashed

### The HW vendor this change applies to (if applicable)

Supermicro

### The HW model number, product name this change applies to (if applicable)

AS-1114S-WN10RT-EU with an AOC-S25G-m2S add-on card (25GbE). Likely affects
any Redfish implementation where an add-on adapter's local `NetworkPort` IDs
collide with unrelated `EthernetInterfaces` IDs.

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

Observed on BMC firmware 01.04.04, BIOS 2.9.

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

N/A

## Description for changelog/release notes

```
fix: NIC ports on add-on adapters (e.g. Supermicro AOC-S25G-m2S) no longer
report the wrong MAC address when their local port IDs collide with an
unrelated adapter's. MACs are now resolved via NetworkDeviceFunctions when
available, which is unambiguous across adapters.
```