### PR TITLE
fix: use CapacityMiB for DIMM capacity, not VolatileSizeMiB

### DIFF
--- a/internal/redfishwrapper/fixtures/smc_dimm/memory.json
+++ b/internal/redfishwrapper/fixtures/smc_dimm/memory.json
@@ -1,0 +1,11 @@
+{
+    "@odata.type": "#MemoryCollection.MemoryCollection",
+    "@odata.id": "/redfish/v1/Systems/1/Memory",
+    "Name": "Memory Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/1/Memory/DIMM1"
+        }
+    ]
+}

--- a/internal/redfishwrapper/fixtures/smc_dimm/memory_dimm1.json
+++ b/internal/redfishwrapper/fixtures/smc_dimm/memory_dimm1.json
@@ -1,0 +1,18 @@
+{
+    "@odata.type": "#Memory.v1_11_0.Memory",
+    "@odata.id": "/redfish/v1/Systems/1/Memory/DIMM1",
+    "Id": "DIMM1",
+    "Name": "DIMM1",
+    "Description": "DIMM1",
+    "Manufacturer": "Samsung",
+    "SerialNumber": "TESTDIMMSERIAL01",
+    "PartNumber": "M393A8G40CB4-CWE",
+    "MemoryType": "DRAM",
+    "MemoryDeviceType": "DDR4",
+    "CapacityMiB": 65536,
+    "OperatingSpeedMhz": 3200,
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    }
+}

--- a/internal/redfishwrapper/fixtures/smc_nvdimm/memory.json
+++ b/internal/redfishwrapper/fixtures/smc_nvdimm/memory.json
@@ -1,0 +1,11 @@
+{
+    "@odata.type": "#MemoryCollection.MemoryCollection",
+    "@odata.id": "/redfish/v1/Systems/1/Memory",
+    "Name": "Memory Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/1/Memory/DIMM1"
+        }
+    ]
+}

--- a/internal/redfishwrapper/fixtures/smc_nvdimm/memory_dimm1.json
+++ b/internal/redfishwrapper/fixtures/smc_nvdimm/memory_dimm1.json
@@ -1,0 +1,19 @@
+{
+    "@odata.type": "#Memory.v1_11_0.Memory",
+    "@odata.id": "/redfish/v1/Systems/1/Memory/DIMM1",
+    "Id": "DIMM1",
+    "Name": "DIMM1",
+    "Description": "DIMM1",
+    "Manufacturer": "TESTVENDOR",
+    "SerialNumber": "TESTNVDIMMSERIAL01",
+    "PartNumber": "TEST-NVDIMM-16GB",
+    "MemoryType": "NVDIMM_N",
+    "MemoryDeviceType": "DDR4",
+    "VolatileSizeMiB": 8192,
+    "NonVolatileSizeMiB": 8192,
+    "OperatingSpeedMhz": 2666,
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    }
+}

--- a/internal/redfishwrapper/inventory_collect.go
+++ b/internal/redfishwrapper/inventory_collect.go
@@ -507,6 +507,17 @@ func (c *Client) collectDIMMs(sys *schemas.ComputerSystem, device *common.Device
 	}
 
 	for _, dimm := range dimms {
+		// CapacityMiB is the overall module capacity and should be populated for
+		// ordinary (volatile-only) DIMMs. VolatileSizeMiB/NonVolatileSizeMiB only
+		// apply to memory with a volatile/non-volatile split (e.g. NVDIMM); fall
+		// back to their sum when CapacityMiB is absent, rather than using
+		// VolatileSizeMiB alone, which is 0 for plain DRAM on some platforms and
+		// silently produced a zero SizeBytes.
+		sizeMiB := gofish.Deref(dimm.CapacityMiB)
+		if sizeMiB == 0 {
+			sizeMiB = gofish.Deref(dimm.VolatileSizeMiB) + gofish.Deref(dimm.NonVolatileSizeMiB)
+		}
+
 		device.Memory = append(device.Memory, &common.Memory{
 			Common: common.Common{
 				Description: dimm.Description,
@@ -521,7 +532,7 @@ func (c *Client) collectDIMMs(sys *schemas.ComputerSystem, device *common.Device
 
 			Slot:         dimm.ID,
 			Type:         string(dimm.MemoryType),
-			SizeBytes:    int64(gofish.Deref(dimm.VolatileSizeMiB) * 1024 * 1024),
+			SizeBytes:    int64(sizeMiB) * 1024 * 1024,
 			FormFactor:   "",
 			PartNumber:   dimm.PartNumber,
 			ClockSpeedHz: int64(gofish.Deref(dimm.OperatingSpeedMhz) * 1000 * 1000),

--- a/internal/redfishwrapper/inventory_test.go
+++ b/internal/redfishwrapper/inventory_test.go
@@ -164,3 +164,80 @@ func TestInventoryNICsWithAOCFallback(t *testing.T) {
 		}
 	}
 }
+
+// TestInventoryCollectDIMMCapacity proves that collectDIMMs must use
+// CapacityMiB — the overall module capacity — rather than VolatileSizeMiB.
+// VolatileSizeMiB/NonVolatileSizeMiB only apply to memory with a
+// volatile/non-volatile split (e.g. NVDIMM); on ordinary DRAM DIMMs (the vast
+// majority of servers), VolatileSizeMiB is 0 even though CapacityMiB is
+// correctly populated, so using it alone silently produces SizeBytes=0 for
+// every normal DIMM.
+func TestInventoryCollectDIMMCapacity(t *testing.T) {
+	mux := http.NewServeMux()
+	for path, fixture := range map[string]string{
+		"/redfish/v1/":                       "serviceroot.json",
+		"/redfish/v1/Systems":                "systems.json",
+		"/redfish/v1/Systems/1":              "systems_1.json",
+		"/redfish/v1/Systems/1/Memory":       "smc_dimm/memory.json",
+		"/redfish/v1/Systems/1/Memory/DIMM1": "smc_dimm/memory_dimm1.json",
+	} {
+		mux.HandleFunc(path, endpointFunc(t, fixture))
+	}
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := NewClient(u.Hostname(), u.Port(), "", "", WithBasicAuthEnabled(true))
+	require.NoError(t, client.Open(context.Background()))
+	defer client.Close(context.Background())
+
+	device, err := client.Inventory(context.Background(), false)
+	require.NoError(t, err)
+	require.NotNil(t, device)
+
+	require.Len(t, device.Memory, 1, "expected exactly one DIMM in inventory")
+	dimm := device.Memory[0]
+	assert.Equal(t, "TESTDIMMSERIAL01", dimm.Serial)
+	assert.Equal(t, int64(65536)*1024*1024, dimm.SizeBytes,
+		"DIMM SizeBytes should come from CapacityMiB (64GiB), not VolatileSizeMiB (0 for ordinary DRAM)")
+}
+
+// TestInventoryCollectDIMMCapacityNVDIMMFallback proves that collectDIMMs
+// still falls back to VolatileSizeMiB+NonVolatileSizeMiB when CapacityMiB is
+// absent — the original use case those fields exist for (an NVDIMM's
+// volatile/non-volatile split).
+func TestInventoryCollectDIMMCapacityNVDIMMFallback(t *testing.T) {
+	mux := http.NewServeMux()
+	for path, fixture := range map[string]string{
+		"/redfish/v1/":                       "serviceroot.json",
+		"/redfish/v1/Systems":                "systems.json",
+		"/redfish/v1/Systems/1":              "systems_1.json",
+		"/redfish/v1/Systems/1/Memory":       "smc_nvdimm/memory.json",
+		"/redfish/v1/Systems/1/Memory/DIMM1": "smc_nvdimm/memory_dimm1.json",
+	} {
+		mux.HandleFunc(path, endpointFunc(t, fixture))
+	}
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := NewClient(u.Hostname(), u.Port(), "", "", WithBasicAuthEnabled(true))
+	require.NoError(t, client.Open(context.Background()))
+	defer client.Close(context.Background())
+
+	device, err := client.Inventory(context.Background(), false)
+	require.NoError(t, err)
+	require.NotNil(t, device)
+
+	require.Len(t, device.Memory, 1, "expected exactly one DIMM in inventory")
+	dimm := device.Memory[0]
+	assert.Equal(t, "TESTNVDIMMSERIAL01", dimm.Serial)
+	assert.Equal(t, int64(8192+8192)*1024*1024, dimm.SizeBytes,
+		"DIMM SizeBytes should fall back to VolatileSizeMiB+NonVolatileSizeMiB (8GiB+8GiB) when CapacityMiB is absent")
+}


### PR DESCRIPTION
## What does this PR implement/change/remove?

`collectDIMMs` computed `SizeBytes` from `VolatileSizeMiB` alone.
`VolatileSizeMiB`/`NonVolatileSizeMiB` only apply to memory with a
volatile/non-volatile split (e.g. NVDIMM) — on ordinary DRAM DIMMs (the vast
majority of servers), `VolatileSizeMiB` is `0` even though `CapacityMiB` is
correctly populated by the BMC, so **every normal DIMM silently reported
`SizeBytes=0`**.

This also meant real NVDIMMs were reported at half their actual capacity,
since `NonVolatileSizeMiB` was never added in.

This PR prefers `CapacityMiB` (the correct field for ordinary DIMMs) and
falls back to `VolatileSizeMiB + NonVolatileSizeMiB` only when `CapacityMiB`
is absent — covering the NVDIMM case properly instead of dropping half its
capacity.

### Checklist
- [x] Tests added
- [x] Similar commits squashed

### The HW vendor this change applies to (if applicable)

Supermicro (observed), but this is a spec-level field misuse — likely affects
any Redfish implementation that populates `CapacityMiB` the standard way for
ordinary DIMMs.

### The HW model number, product name this change applies to (if applicable)

Observed on a Supermicro AS-1114S-WN10RT-EU (Samsung DDR4 DIMMs).

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

Observed on BMC firmware 01.04.04, BIOS 2.9.

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

N/A

## Description for changelog/release notes

```
fix: DIMM capacity (Memory.SizeBytes) is no longer reported as 0 for
ordinary DRAM. collectDIMMs now reads CapacityMiB (the field Redfish
populates for normal memory) instead of VolatileSizeMiB, which only
applies to NVDIMM's volatile/non-volatile split and is 0 for plain DRAM.
Also fixes NVDIMM capacity being under-reported by half (NonVolatileSizeMiB
was never added to VolatileSizeMiB).
```