### PR TITLE
fix: don't gate collectDrives on Storage.DrivesCount

### DIFF
--- a/internal/redfishwrapper/fixtures/smc_nvme_storage/drive_bay2.json
+++ b/internal/redfishwrapper/fixtures/smc_nvme_storage/drive_bay2.json
@@ -1,0 +1,18 @@
+{
+    "@odata.type": "#Drive.v1_11_1.Drive",
+    "@odata.id": "/redfish/v1/Chassis/NVMeSSD.0.Group.0.StorageBackplane/Drives/Disk.Bay.2",
+    "Name": "Disk.Bay.2",
+    "Id": "Disk.Bay.2",
+    "Manufacturer": "KIOXIA",
+    "SerialNumber": "TESTDRIVESERIAL01",
+    "Model": "KIOXIA KCD8XVUG6T40",
+    "Revision": "0105",
+    "CapacityBytes": 6401252745216,
+    "CapableSpeedGbs": 15.75,
+    "MediaType": "SSD",
+    "Protocol": "NVMe",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    }
+}

--- a/internal/redfishwrapper/fixtures/smc_nvme_storage/drive_bay3.json
+++ b/internal/redfishwrapper/fixtures/smc_nvme_storage/drive_bay3.json
@@ -1,0 +1,18 @@
+{
+    "@odata.type": "#Drive.v1_11_1.Drive",
+    "@odata.id": "/redfish/v1/Chassis/NVMeSSD.0.Group.0.StorageBackplane/Drives/Disk.Bay.3",
+    "Name": "Disk.Bay.3",
+    "Id": "Disk.Bay.3",
+    "Manufacturer": "KIOXIA",
+    "SerialNumber": "TESTDRIVESERIAL02",
+    "Model": "KIOXIA KCD8XVUG6T40",
+    "Revision": "0105",
+    "CapacityBytes": 6401252745216,
+    "CapableSpeedGbs": 15.75,
+    "MediaType": "SSD",
+    "Protocol": "NVMe",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    }
+}

--- a/internal/redfishwrapper/fixtures/smc_nvme_storage/storage.json
+++ b/internal/redfishwrapper/fixtures/smc_nvme_storage/storage.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#StorageCollection.StorageCollection",
+    "@odata.id": "/redfish/v1/Systems/1/Storage",
+    "Name": "Storage Collection",
+    "Members@odata.count": 1,
+    "Description": "Storage Collection",
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/1/Storage/NVMeSSD"
+        }
+    ]
+}

--- a/internal/redfishwrapper/fixtures/smc_nvme_storage/storage_nvmessd.json
+++ b/internal/redfishwrapper/fixtures/smc_nvme_storage/storage_nvmessd.json
@@ -1,0 +1,32 @@
+{
+    "@odata.type": "#Storage.v1_9_0.Storage",
+    "@odata.id": "/redfish/v1/Systems/1/Storage/NVMeSSD",
+    "Id": "NVMeSSD",
+    "Name": "NVMe Storage System",
+    "StorageControllers": [
+        {
+            "@odata.id": "/redfish/v1/Systems/1/Storage/NVMeSSD#/StorageControllers/0",
+            "MemberId": "0",
+            "FirmwareVersion": "0D",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "SupportedControllerProtocols": ["PCIe"],
+            "SupportedDeviceProtocols": ["NVMe"]
+        }
+    ],
+    "Drives": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/NVMeSSD.0.Group.0.StorageBackplane/Drives/Disk.Bay.2"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/NVMeSSD.0.Group.0.StorageBackplane/Drives/Disk.Bay.3"
+        }
+    ],
+    "Description": "NVMe SSD",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    }
+}

--- a/internal/redfishwrapper/inventory_collect.go
+++ b/internal/redfishwrapper/inventory_collect.go
@@ -367,10 +367,13 @@ func (c *Client) collectDrives(sys *schemas.ComputerSystem, device *common.Devic
 	}
 
 	for _, member := range storage {
-		if member.DrivesCount == 0 {
-			continue
-		}
-
+		// DrivesCount comes from the optional "Drives@odata.count" property.
+		// Some implementations populate the "Drives" link array without ever
+		// including a count property, which gofish reports as DrivesCount==0
+		// even though real drives are linked. member.Drives() reads the
+		// underlying link list directly and safely returns an empty slice
+		// when there's genuinely nothing there, so skip the DrivesCount gate
+		// entirely rather than short-circuiting on a field that may be unset.
 		drives, err := member.Drives()
 		if err != nil {
 			return err

--- a/internal/redfishwrapper/inventory_test.go
+++ b/internal/redfishwrapper/inventory_test.go
@@ -241,3 +241,50 @@ func TestInventoryCollectDIMMCapacityNVDIMMFallback(t *testing.T) {
 	assert.Equal(t, int64(8192+8192)*1024*1024, dimm.SizeBytes,
 		"DIMM SizeBytes should fall back to VolatileSizeMiB+NonVolatileSizeMiB (8GiB+8GiB) when CapacityMiB is absent")
 }
+
+// TestInventoryCollectDrivesWithoutCount proves that collectDrives must not
+// gate on Storage.DrivesCount ("Drives@odata.count"). Some implementations
+// embed the "Drives" link array without ever including a count property, so
+// DrivesCount parses to 0 even though real drives are linked — the old code
+// skipped the Storage member entirely and every drive silently disappeared
+// from the inventory.
+func TestInventoryCollectDrivesWithoutCount(t *testing.T) {
+	mux := http.NewServeMux()
+	for path, fixture := range map[string]string{
+		"/redfish/v1/":          "serviceroot.json",
+		"/redfish/v1/Systems":   "systems.json",
+		"/redfish/v1/Systems/1": "systems_1.json",
+
+		"/redfish/v1/Systems/1/Storage":                                            "smc_nvme_storage/storage.json",
+		"/redfish/v1/Systems/1/Storage/NVMeSSD":                                    "smc_nvme_storage/storage_nvmessd.json",
+		"/redfish/v1/Chassis/NVMeSSD.0.Group.0.StorageBackplane/Drives/Disk.Bay.2": "smc_nvme_storage/drive_bay2.json",
+		"/redfish/v1/Chassis/NVMeSSD.0.Group.0.StorageBackplane/Drives/Disk.Bay.3": "smc_nvme_storage/drive_bay3.json",
+	} {
+		mux.HandleFunc(path, endpointFunc(t, fixture))
+	}
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := NewClient(u.Hostname(), u.Port(), "", "", WithBasicAuthEnabled(true))
+	require.NoError(t, client.Open(context.Background()))
+	defer client.Close(context.Background())
+
+	device, err := client.Inventory(context.Background(), false)
+	require.NoError(t, err)
+	require.NotNil(t, device)
+
+	require.Len(t, device.Drives, 2, "expected both drives despite Storage member reporting DrivesCount=0")
+
+	serials := map[string]bool{}
+	for _, d := range device.Drives {
+		serials[d.Serial] = true
+		assert.Equal(t, "KIOXIA KCD8XVUG6T40", d.Model)
+		assert.Equal(t, int64(6401252745216), d.CapacityBytes)
+	}
+	assert.True(t, serials["TESTDRIVESERIAL01"], "Disk.Bay.2 missing from inventory")
+	assert.True(t, serials["TESTDRIVESERIAL02"], "Disk.Bay.3 missing from inventory")
+}


### PR DESCRIPTION
## What does this PR implement/change/remove?

`collectDrives` skipped a `Storage` member entirely when `DrivesCount`
(`Drives@odata.count`) was `0`, even if the `Drives` link array itself was
populated with real, linked drives. `DrivesCount` comes from an *optional*
Redfish property — some implementations populate the `Drives` array without
ever including that count property, so it parses to `0` even though real
drives are linked. The old code treated that as "no drives" and **silently
dropped every drive on that Storage member from the inventory**.

`member.Drives()` reads the underlying link list directly and already
returns an empty, error-free slice when there's genuinely nothing linked, so
this drops the `DrivesCount` gate entirely rather than short-circuiting on a
field that may simply be unset.

### Checklist
- [x] Tests added
- [x] Similar commits squashed

### The HW vendor this change applies to (if applicable)

Supermicro (observed), but this is a spec-level field misuse — likely
affects any Redfish implementation that links drives without also
populating the optional count property.

### The HW model number, product name this change applies to (if applicable)

Observed on a Supermicro AS-1114S-WN10RT-EU with two KIOXIA KCD8XVUG6T40
NVMe SSDs — both were missing from inventory before this fix.

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

Observed on BMC firmware 01.04.04, BIOS 2.9.

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

N/A

## Description for changelog/release notes

```
fix: drives are no longer silently missing from inventory when a Storage
resource links real drives but omits the optional Drives@odata.count
property. collectDrives no longer gates on DrivesCount, which is only
sometimes populated.
```