### PR TITLE
fix: populate device.Mainboard from Chassis resource data

### DIFF
--- a/internal/redfishwrapper/inventory.go
+++ b/internal/redfishwrapper/inventory.go
@@ -178,6 +178,11 @@ func (c *Client) chassisAttributes(ctx context.Context, device *common.Device, f
 			return err
 		}
 
+		err = c.collectMainboard(ch, device, softwareInventory)
+		if err != nil && failOnError {
+			return err
+		}
+
 		err = c.collectPSUs(ch, device, softwareInventory)
 		if err != nil && failOnError {
 			return err

--- a/internal/redfishwrapper/inventory_collect.go
+++ b/internal/redfishwrapper/inventory_collect.go
@@ -42,6 +42,46 @@ func (c *Client) collectEnclosure(ch *schemas.Chassis, device *common.Device, so
 	return nil
 }
 
+// collectMainboard collects motherboard information.
+//
+// Some vendors (e.g. Supermicro) don't expose a dedicated motherboard
+// resource: the Chassis resource's Model is the board's own model, while
+// PartNumber/SerialNumber describe the case rather than the board itself.
+// Vendor-specific providers may fill in additional Mainboard attributes
+// (e.g. the board's own serial number) after Inventory returns.
+//
+// chassisAttributes calls this once per compatible Chassis member, and some
+// vendors (e.g. Dell) have more than one compatible Chassis ID. device.Mainboard
+// is a single field, not a slice, so only populate it from the first chassis
+// that provides a model — don't let an unrelated chassis (e.g. a drive
+// enclosure/backplane with its own Model set) silently overwrite it later.
+func (c *Client) collectMainboard(ch *schemas.Chassis, device *common.Device, softwareInventory []*schemas.SoftwareInventory) (err error) {
+	if ch == nil || ch.Model == "" || (device.Mainboard != nil && device.Mainboard.Model != "") {
+		return nil
+	}
+
+	m := &common.Mainboard{
+		Common: common.Common{
+			Vendor: common.FormatVendorName(ch.Manufacturer),
+			Model:  ch.Model,
+			Status: &common.Status{
+				Health: string(ch.Status.Health),
+				State:  string(ch.Status.State),
+			},
+			Firmware: &common.Firmware{},
+		},
+
+		PhysicalID: ch.ID,
+	}
+
+	// include additional firmware attributes from redfish firmware inventory
+	c.firmwareAttributes(common.SlugMainboard, "", m.Firmware, softwareInventory)
+
+	device.Mainboard = m
+
+	return nil
+}
+
 // collectPSUs collects Power Supply Unit component information
 func (c *Client) collectPSUs(ch *schemas.Chassis, device *common.Device, softwareInventory []*schemas.SoftwareInventory) (err error) {
 	power, err := ch.Power()

--- a/internal/redfishwrapper/inventory_collect_test.go
+++ b/internal/redfishwrapper/inventory_collect_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/bmc-toolbox/common"
 	"github.com/stmcginnis/gofish"
 	"github.com/stmcginnis/gofish/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInventoryCollectNetworkPortInfo(t *testing.T) {
@@ -208,4 +210,123 @@ func TestInventoryCollectBIOS(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInventoryCollectMainboard(t *testing.T) {
+	tests := []struct {
+		name         string
+		chassis      *schemas.Chassis
+		wantedDevice func() *common.Device
+	}{
+		{
+			name:    "nil chassis",
+			chassis: nil,
+			wantedDevice: func() *common.Device {
+				d := common.NewDevice()
+				return &d
+			},
+		},
+		{
+			name:    "chassis without a board model",
+			chassis: &schemas.Chassis{Manufacturer: "Supermicro"},
+			wantedDevice: func() *common.Device {
+				d := common.NewDevice()
+				return &d
+			},
+		},
+		{
+			// Real-world Supermicro shape: the board model/manufacturer are on
+			// Chassis.Model/Manufacturer, while PartNumber/SerialNumber
+			// describe the case rather than the board itself. The board's own
+			// serial is filled in later, by whichever provider serves the request.
+			name: "supermicro chassis",
+			chassis: &schemas.Chassis{
+				Entity:       schemas.Entity{ID: "1"},
+				Manufacturer: "Supermicro",
+				Model:        "H12SSW-NTR",
+				SerialNumber: "TESTCHASSISSERIAL01",
+				PartNumber:   "CSE-116TS-RWNBP2-N10-2",
+				Status:       schemas.Status{State: "Enabled", Health: "OK"},
+			},
+			wantedDevice: func() *common.Device {
+				d := common.NewDevice()
+				d.Mainboard = &common.Mainboard{
+					Common: common.Common{
+						Vendor:   "supermicro",
+						Model:    "H12SSW-NTR",
+						Status:   &common.Status{State: "Enabled", Health: "OK"},
+						Firmware: &common.Firmware{},
+					},
+					PhysicalID: "1",
+				}
+				return &d
+			},
+		},
+		{
+			name: "dell chassis",
+			chassis: &schemas.Chassis{
+				Entity:       schemas.Entity{ID: "1"},
+				Manufacturer: "Dell Inc.",
+				Model:        "0ABC123",
+				Status:       schemas.Status{State: "Enabled", Health: "OK"},
+			},
+			wantedDevice: func() *common.Device {
+				d := common.NewDevice()
+				d.Mainboard = &common.Mainboard{
+					Common: common.Common{
+						Vendor:   "dell",
+						Model:    "0ABC123",
+						Status:   &common.Status{State: "Enabled", Health: "OK"},
+						Firmware: &common.Firmware{},
+					},
+					PhysicalID: "1",
+				}
+				return &d
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Client{}
+			device := common.NewDevice()
+			err := c.collectMainboard(tt.chassis, &device, nil)
+			if err != nil {
+				t.Fatalf("collectMainboard() error = %v", err)
+			}
+			if !reflect.DeepEqual(device.Mainboard, tt.wantedDevice().Mainboard) {
+				t.Errorf("collectMainboard() gotMainboard = %+v, want %+v", device.Mainboard, tt.wantedDevice().Mainboard)
+			}
+		})
+	}
+}
+
+// TestInventoryCollectMainboardDoesNotOverwrite proves that collectMainboard
+// only populates device.Mainboard from the first chassis that provides a
+// model. chassisAttributes calls this once per compatible Chassis member, and
+// some vendors (e.g. Dell) have more than one compatible Chassis ID; since
+// device.Mainboard is a single field, not a slice, a second, unrelated
+// chassis (e.g. a drive enclosure/backplane with its own Model set) must not
+// silently overwrite the motherboard entry already found.
+func TestInventoryCollectMainboardDoesNotOverwrite(t *testing.T) {
+	c := Client{}
+	device := common.NewDevice()
+
+	motherboard := &schemas.Chassis{
+		Entity:       schemas.Entity{ID: "System.Embedded.1"},
+		Manufacturer: "Dell Inc.",
+		Model:        "0ABC123",
+	}
+	backplane := &schemas.Chassis{
+		Entity:       schemas.Entity{ID: "Enclosure.Internal.0-1"},
+		Manufacturer: "Dell Inc.",
+		Model:        "BP-UNRELATED-SKU",
+	}
+
+	require.NoError(t, c.collectMainboard(motherboard, &device, nil))
+	require.NoError(t, c.collectMainboard(backplane, &device, nil))
+
+	require.NotNil(t, device.Mainboard)
+	assert.Equal(t, "0ABC123", device.Mainboard.Model,
+		"the second chassis's model overwrote the first chassis's mainboard entry")
 }

--- a/providers/redfish/redfish.go
+++ b/providers/redfish/redfish.go
@@ -4,7 +4,6 @@ package redfish
 import (
 	"context"
 	"crypto/x509"
-	"encoding/json"
 	"net/http"
 
 	"github.com/bmc-toolbox/common"
@@ -230,46 +229,7 @@ func (c *Conn) SetVirtualMedia(ctx context.Context, kind, mediaURL string) (ok b
 
 // Inventory collects hardware inventory and install firmware information
 func (c *Conn) Inventory(ctx context.Context) (device *common.Device, err error) {
-	device, err = c.redfishwrapper.Inventory(ctx, c.failInventoryOnError)
-	if err != nil {
-		return device, err
-	}
-
-	// This generic provider may be serving a Supermicro BMC, so apply the
-	// same vendor OEM enrichment providers/supermicro does.
-	populateMainboardSerial(ctx, c.redfishwrapper, device)
-
-	return device, nil
-}
-
-// populateMainboardSerial fills in device.Mainboard.Serial from the Chassis
-// resource's Supermicro OEM extension: Chassis.SerialNumber is the case
-// serial, while the board's own serial is only available under
-// Oem.Supermicro.BoardSerialNumber.
-func populateMainboardSerial(ctx context.Context, rf *redfishwrapper.Client, device *common.Device) {
-	if rf == nil || device == nil || device.Mainboard == nil || device.Mainboard.Serial != "" {
-		return
-	}
-
-	chassis, err := rf.Chassis(ctx)
-	if err != nil {
-		return
-	}
-
-	for _, ch := range chassis {
-		if ch.ID != device.Mainboard.PhysicalID || len(ch.OEM) == 0 {
-			continue
-		}
-
-		var v struct {
-			Supermicro struct{ BoardSerialNumber string }
-		}
-		if json.Unmarshal(ch.OEM, &v) == nil {
-			device.Mainboard.Serial = v.Supermicro.BoardSerialNumber
-		}
-
-		return
-	}
+	return c.redfishwrapper.Inventory(ctx, c.failInventoryOnError)
 }
 
 // GetBiosConfiguration return bios configuration

--- a/providers/redfish/redfish.go
+++ b/providers/redfish/redfish.go
@@ -4,6 +4,7 @@ package redfish
 import (
 	"context"
 	"crypto/x509"
+	"encoding/json"
 	"net/http"
 
 	"github.com/bmc-toolbox/common"
@@ -229,7 +230,46 @@ func (c *Conn) SetVirtualMedia(ctx context.Context, kind, mediaURL string) (ok b
 
 // Inventory collects hardware inventory and install firmware information
 func (c *Conn) Inventory(ctx context.Context) (device *common.Device, err error) {
-	return c.redfishwrapper.Inventory(ctx, c.failInventoryOnError)
+	device, err = c.redfishwrapper.Inventory(ctx, c.failInventoryOnError)
+	if err != nil {
+		return device, err
+	}
+
+	// This generic provider may be serving a Supermicro BMC, so apply the
+	// same vendor OEM enrichment providers/supermicro does.
+	populateMainboardSerial(ctx, c.redfishwrapper, device)
+
+	return device, nil
+}
+
+// populateMainboardSerial fills in device.Mainboard.Serial from the Chassis
+// resource's Supermicro OEM extension: Chassis.SerialNumber is the case
+// serial, while the board's own serial is only available under
+// Oem.Supermicro.BoardSerialNumber.
+func populateMainboardSerial(ctx context.Context, rf *redfishwrapper.Client, device *common.Device) {
+	if rf == nil || device == nil || device.Mainboard == nil || device.Mainboard.Serial != "" {
+		return
+	}
+
+	chassis, err := rf.Chassis(ctx)
+	if err != nil {
+		return
+	}
+
+	for _, ch := range chassis {
+		if ch.ID != device.Mainboard.PhysicalID || len(ch.OEM) == 0 {
+			continue
+		}
+
+		var v struct {
+			Supermicro struct{ BoardSerialNumber string }
+		}
+		if json.Unmarshal(ch.OEM, &v) == nil {
+			device.Mainboard.Serial = v.Supermicro.BoardSerialNumber
+		}
+
+		return
+	}
 }
 
 // GetBiosConfiguration return bios configuration

--- a/providers/supermicro/supermicro.go
+++ b/providers/supermicro/supermicro.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -269,7 +270,44 @@ func (c *Client) Inventory(ctx context.Context) (device *common.Device, err erro
 		return nil, errors.Wrap(bmclibErrs.ErrLoginFailed, "client not initialized")
 	}
 
-	return c.serviceClient.redfish.Inventory(ctx, false)
+	device, err = c.serviceClient.redfish.Inventory(ctx, false)
+	if err != nil {
+		return device, err
+	}
+
+	populateMainboardSerial(ctx, c.serviceClient.redfish, device)
+
+	return device, nil
+}
+
+// populateMainboardSerial fills in device.Mainboard.Serial from the Chassis
+// resource's Supermicro OEM extension: Chassis.SerialNumber is the case
+// serial, while the board's own serial is only available under
+// Oem.Supermicro.BoardSerialNumber.
+func populateMainboardSerial(ctx context.Context, rf *redfishwrapper.Client, device *common.Device) {
+	if rf == nil || device == nil || device.Mainboard == nil || device.Mainboard.Serial != "" {
+		return
+	}
+
+	chassis, err := rf.Chassis(ctx)
+	if err != nil {
+		return
+	}
+
+	for _, ch := range chassis {
+		if ch.ID != device.Mainboard.PhysicalID || len(ch.OEM) == 0 {
+			continue
+		}
+
+		var v struct {
+			Supermicro struct{ BoardSerialNumber string }
+		}
+		if json.Unmarshal(ch.OEM, &v) == nil {
+			device.Mainboard.Serial = v.Supermicro.BoardSerialNumber
+		}
+
+		return
+	}
 }
 
 // GetBiosConfiguration return bios configuration


### PR DESCRIPTION
## What does this PR implement/change/remove?

`device.Mainboard` was never populated for any vendor — no code path set it,
so it always stayed at `common.NewDevice()`'s empty default.

Some vendors (e.g. Supermicro) don't expose a dedicated motherboard
resource: on a real Supermicro AS-1114S-WN10RT-EU, `Chassis.Model` is the
board's own model (`H12SSW-NTR`) while `Chassis.PartNumber`/`SerialNumber`
describe the case, and the board's own serial number is under the
Supermicro OEM extension (`Oem.Supermicro.BoardSerialNumber`), distinct
from the case serial.

Adds `collectMainboard`, wired alongside the existing `collectEnclosure`, to
populate `device.Mainboard` from these fields. Best-effort: falls back to no
serial number on chassis without the Supermicro OEM extension, and does
nothing on chassis without a board model at all.

`chassisAttributes` calls this once per compatible `Chassis` member, and
some vendors (e.g. Dell) have more than one compatible Chassis ID in
`KnownChassisOdataIDs`. Since `device.Mainboard` is a single field, not a
slice, `collectMainboard` only populates it from the first chassis that
provides a model — this prevents an unrelated chassis processed later (e.g.
a drive enclosure/backplane with its own `Model` set) from silently
overwriting a correct motherboard entry.

### Checklist
- [x] Tests added
- [x] Similar commits squashed

### The HW vendor this change applies to (if applicable)

Supermicro (data source), but the "don't overwrite" guard is written
generically for any vendor with multiple compatible Chassis resources
(e.g. Dell).

### The HW model number, product name this change applies to (if applicable)

Observed on a Supermicro AS-1114S-WN10RT-EU (motherboard: H12SSW-NTR).

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

Observed on BMC firmware 01.04.04, BIOS 2.9.

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

N/A

## Description for changelog/release notes

```
feat: populate device.Mainboard (vendor, model, serial) from the Chassis
resource, previously always empty for every vendor. On Supermicro,
extracts the board's own serial from the vendor OEM extension, distinct
from the case serial.
```