### PR TITLE
fix: populate device.BIOS.Vendor from system manufacturer

### DIFF
--- a/internal/redfishwrapper/inventory_collect.go
+++ b/internal/redfishwrapper/inventory_collect.go
@@ -339,6 +339,7 @@ func getFirmwareVersionFromController(controllers []schemas.Controllers, portCou
 func (c *Client) collectBIOS(sys *schemas.ComputerSystem, device *common.Device, softwareInventory []*schemas.SoftwareInventory) (err error) {
 	device.BIOS = &common.BIOS{
 		Common: common.Common{
+			Vendor: common.FormatVendorName(sys.Manufacturer),
 			Firmware: &common.Firmware{
 				Installed: sys.BiosVersion,
 			},

--- a/internal/redfishwrapper/inventory_collect_test.go
+++ b/internal/redfishwrapper/inventory_collect_test.go
@@ -173,3 +173,38 @@ func TestInventoryCollectEthernetInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestInventoryCollectBIOS(t *testing.T) {
+	tests := []struct {
+		name       string
+		sys        *schemas.ComputerSystem
+		wantVendor string
+	}{
+		{
+			name:       "vendor populated from system manufacturer",
+			sys:        &schemas.ComputerSystem{Manufacturer: "Supermicro", BiosVersion: "1.4"},
+			wantVendor: "supermicro",
+		},
+		{
+			name:       "no manufacturer",
+			sys:        &schemas.ComputerSystem{BiosVersion: "1.4"},
+			wantVendor: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Client{}
+			device := common.NewDevice()
+			if err := c.collectBIOS(tt.sys, &device, nil); err != nil {
+				t.Fatalf("collectBIOS() error = %v", err)
+			}
+			if device.BIOS.Vendor != tt.wantVendor {
+				t.Errorf("collectBIOS() Vendor = %q, want %q", device.BIOS.Vendor, tt.wantVendor)
+			}
+			if device.BIOS.Firmware.Installed != tt.sys.BiosVersion {
+				t.Errorf("collectBIOS() Firmware.Installed = %q, want %q", device.BIOS.Firmware.Installed, tt.sys.BiosVersion)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR implement/change/remove?

`collectBIOS` never set `BIOS.Vendor`, so it stayed empty for every vendor.
Sets it from the `ComputerSystem`'s own `Manufacturer` field, the same
source already used elsewhere in this file for other components' vendor
(e.g. `collectEnclosure`, `collectPSUs`).

### Checklist
- [x] Tests added
- [x] Similar commits squashed

### The HW vendor this change applies to (if applicable)

Supermicro (observed), but this affects every vendor — `BIOS.Vendor` was
unconditionally empty regardless of BMC make.

### The HW model number, product name this change applies to (if applicable)

Observed on a Supermicro AS-1114S-WN10RT-EU.

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

Observed on BMC firmware 01.04.04, BIOS 2.9.

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

N/A

## Description for changelog/release notes

```
fix: BIOS.Vendor is now populated from the system manufacturer. It was
previously always empty regardless of vendor.
```