### PR TITLE
feat: collect the BMC's own management NIC from Manager EthernetInterfaces

### DIFF
--- a/internal/redfishwrapper/fixtures/bmc_nic/ethernet_1.json
+++ b/internal/redfishwrapper/fixtures/bmc_nic/ethernet_1.json
@@ -1,0 +1,14 @@
+{
+    "@odata.type": "#EthernetInterface.v1_6_0.EthernetInterface",
+    "@odata.id": "/redfish/v1/Managers/1/EthernetInterfaces/1",
+    "Id": "1",
+    "Name": "Manager Ethernet Interface",
+    "Description": "Management Network Interface",
+    "Status": {"State": "Enabled", "Health": "OK"},
+    "MACAddress": "00:00:00:00:00:00",
+    "PermanentMACAddress": "00:00:5e:00:53:10",
+    "SpeedMbps": 1000,
+    "AutoNeg": true,
+    "MTUSize": 1500,
+    "LinkStatus": "LinkUp"
+}

--- a/internal/redfishwrapper/fixtures/bmc_nic/ethernet_interfaces.json
+++ b/internal/redfishwrapper/fixtures/bmc_nic/ethernet_interfaces.json
@@ -1,0 +1,11 @@
+{
+    "@odata.type": "#EthernetInterfaceCollection.EthernetInterfaceCollection",
+    "@odata.id": "/redfish/v1/Managers/1/EthernetInterfaces",
+    "Name": "Ethernet Interface Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/1/EthernetInterfaces/1"
+        }
+    ]
+}

--- a/internal/redfishwrapper/inventory.go
+++ b/internal/redfishwrapper/inventory.go
@@ -149,6 +149,10 @@ func (c *Client) bmcAttributes(ctx context.Context, device *common.Device, softw
 
 		// include additional firmware attributes from redfish firmware inventory
 		c.firmwareAttributes("", device.BMC.ID, device.BMC.Firmware, softwareInventory)
+
+		// collect the BMC's own management network interface(s), distinct from
+		// the host NICs collected via ComputerSystem in collectNICs.
+		c.collectBMCNIC(manager, device.BMC)
 	}
 
 	if compatible == 0 {

--- a/internal/redfishwrapper/inventory_collect.go
+++ b/internal/redfishwrapper/inventory_collect.go
@@ -282,6 +282,63 @@ func (c *Client) collectNICs(sys *schemas.ComputerSystem, device *common.Device,
 	return nil
 }
 
+// collectBMCNIC collects the BMC's own management network interface(s),
+// exposed under the Manager resource's EthernetInterfaces — distinct from
+// the host's NICs, which live under ComputerSystem and are collected by
+// collectNICs. Best-effort: the BMC's own NIC is enrichment data, not core
+// inventory, so a missing link or a fetch failure is silently a no-op
+// rather than failing the whole Inventory() call.
+func (c *Client) collectBMCNIC(manager *schemas.Manager, bmc *common.BMC) {
+	if manager == nil || bmc == nil {
+		return
+	}
+
+	interfaces, err := manager.EthernetInterfaces()
+	if err != nil {
+		return
+	}
+
+	var ports []*common.NICPort
+	for _, eth := range interfaces {
+		mac := eth.MACAddress
+		if mac == "" || mac == "00:00:00:00:00:00" {
+			mac = eth.PermanentMACAddress
+		}
+		if mac == "" || mac == "00:00:00:00:00:00" {
+			continue
+		}
+
+		port := &common.NICPort{
+			Common: common.Common{
+				Description: eth.Description,
+				Status: &common.Status{
+					Health: string(eth.Status.Health),
+					State:  string(eth.Status.State),
+				},
+			},
+			ID:         eth.ID,
+			MacAddress: mac,
+			AutoNeg:    eth.AutoNeg,
+			LinkStatus: string(eth.LinkStatus),
+			MTUSize:    gofish.Deref(eth.MTUSize),
+		}
+		if eth.SpeedMbps != nil {
+			port.SpeedBits = int64(gofish.Deref(eth.SpeedMbps)) * int64(math.Pow10(6))
+		}
+
+		ports = append(ports, port)
+	}
+
+	if len(ports) == 0 {
+		return
+	}
+
+	bmc.NIC = &common.NIC{
+		ID:       manager.ID,
+		NICPorts: ports,
+	}
+}
+
 func (c *Client) collectNetworkPortInfo(
 	nicPort *common.NICPort,
 	adapter *schemas.NetworkAdapter,

--- a/internal/redfishwrapper/inventory_test.go
+++ b/internal/redfishwrapper/inventory_test.go
@@ -413,3 +413,57 @@ func TestInventoryNICsDisabledDeviceFunctionMAC(t *testing.T) {
 	assert.Equal(t, "00:00:5e:00:53:05", strings.ToLower(device.NICs[0].NICPorts[0].MacAddress),
 		"port MAC should come from AssociatedNetworkAddresses, not be zeroed out by a disabled NetworkDeviceFunction's placeholder MAC")
 }
+
+// TestInventoryCollectBMCNIC verifies that the BMC's own management network
+// interface, exposed under the Manager resource's EthernetInterfaces, is
+// collected into device.BMC.NIC — distinct from the host NICs collected
+// under ComputerSystem. The fixture's MACAddress is the placeholder
+// "00:00:00:00:00:00", so this also exercises the fallback to
+// PermanentMACAddress.
+func TestInventoryCollectBMCNIC(t *testing.T) {
+	mux := http.NewServeMux()
+	for path, fixture := range map[string]string{
+		"/redfish/v1/":          "serviceroot.json",
+		"/redfish/v1/Systems":   "systems.json",
+		"/redfish/v1/Systems/1": "systems_1.json",
+
+		"/redfish/v1/Managers":                        "managers.json",
+		"/redfish/v1/Managers/1":                      "managers_1.json",
+		"/redfish/v1/Managers/1/EthernetInterfaces":   "bmc_nic/ethernet_interfaces.json",
+		"/redfish/v1/Managers/1/EthernetInterfaces/1": "bmc_nic/ethernet_1.json",
+	} {
+		mux.HandleFunc(path, endpointFunc(t, fixture))
+	}
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := NewClient(u.Hostname(), u.Port(), "", "", WithBasicAuthEnabled(true))
+	require.NoError(t, client.Open(context.Background()))
+	defer client.Close(context.Background())
+
+	device, err := client.Inventory(context.Background(), false)
+	require.NoError(t, err)
+	require.NotNil(t, device)
+
+	require.NotNil(t, device.BMC)
+	require.NotNil(t, device.BMC.NIC, "BMC NIC should be populated from Manager EthernetInterfaces")
+
+	require.Len(t, device.BMC.NIC.NICPorts, 1)
+	port := device.BMC.NIC.NICPorts[0]
+	assert.Equal(t, "00:00:5e:00:53:10", port.MacAddress,
+		"MacAddress should fall back to PermanentMACAddress since MACAddress is the placeholder")
+	assert.Equal(t, int64(1_000_000_000), port.SpeedBits)
+	assert.True(t, port.AutoNeg)
+
+	// The host's NICs must remain unaffected by the BMC's own NIC.
+	for _, nic := range device.NICs {
+		for _, p := range nic.NICPorts {
+			assert.NotEqual(t, "00:00:5e:00:53:10", p.MacAddress,
+				"BMC NIC MAC leaked into host NIC inventory")
+		}
+	}
+}


### PR DESCRIPTION
## What does this PR implement/change/remove?

`device.BMC.NIC` was always left nil: `bmcAttributes` only populated the
BMC's identity/firmware fields (vendor, model, serial, firmware) from the
Manager resource. The BMC's own network interface(s) — the one you actually
connect to for out-of-band management — live under a separate Redfish
subtree, `/redfish/v1/Managers/{id}/EthernetInterfaces`, distinct from the
host's NICs under `ComputerSystem`, which `collectNICs` already handles.

Adds `collectBMCNIC`, wired into `bmcAttributes`, to walk the Manager's
`EthernetInterfaces` and populate `device.BMC.NIC`. Filters the same
`00:00:00:00:00:00` placeholder MAC convention used elsewhere in this
package, falling back to `PermanentMACAddress` when `MACAddress` is empty
or the placeholder. Best-effort: does nothing if the Manager has no
EthernetInterfaces link or every interface lacks a usable MAC.

### Checklist
- [x] Tests added
- [x] Similar commits squashed

### The HW vendor this change applies to (if applicable)

Generic — `Manager.EthernetInterfaces` is a standard Redfish resource, not
vendor-specific. Validated end-to-end on Supermicro.

### The HW model number, product name this change applies to (if applicable)

Validated on a Supermicro AS-1114S-WN10RT-EU, which exposed two Manager
EthernetInterfaces (a dedicated "ToHost" port and a shared NIC port).

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

Observed on BMC firmware 01.04.04.

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

N/A

## Description for changelog/release notes

```
feat: populate device.BMC.NIC (the BMC's own out-of-band management
network interface) from the Manager resource's EthernetInterfaces,
previously never collected. Distinct from device.NICs, which lists the
host's own network interfaces.
```