### PR TITLE
fix: split BiosConfigurationSetter into map and file interfaces

### DIFF
--- a/bmc/bios.go
+++ b/bmc/bios.go
@@ -20,16 +20,30 @@ type biosConfigurationGetterProvider struct {
 	BiosConfigurationGetter
 }
 
-// BiosConfigurationSetter provides applying a host's BIOS configuration,
-// either from a map of settings or from a configuration file.
+// BiosConfigurationSetter provides applying a host's BIOS configuration from a
+// map of settings.
 type BiosConfigurationSetter interface {
 	SetBiosConfiguration(ctx context.Context, biosConfig map[string]string) (err error)
-	SetBiosConfigurationFromFile(ctx context.Context, cfg string) (err error)
 }
 
 type biosConfigurationSetterProvider struct {
 	name string
 	BiosConfigurationSetter
+}
+
+// BiosConfigurationFileSetter provides applying a host's BIOS configuration from
+// a vendor-specific configuration file (e.g. a whole-config export/import blob).
+// Split from BiosConfigurationSetter because most Redfish-generic providers only
+// support the map-based SetBiosConfiguration path and have no file-import
+// equivalent, so requiring both on one interface made those providers fail to
+// satisfy BiosConfigurationSetter at all.
+type BiosConfigurationFileSetter interface {
+	SetBiosConfigurationFromFile(ctx context.Context, cfg string) (err error)
+}
+
+type biosConfigurationFileSetterProvider struct {
+	name string
+	BiosConfigurationFileSetter
 }
 
 // BiosConfigurationResetter provides resetting a host's BIOS configuration to defaults.
@@ -96,11 +110,11 @@ Loop:
 	return metadata, multierror.Append(err, errors.New("failure to set bios configuration"))
 }
 
-func setBiosConfigurationFromFile(ctx context.Context, generic []biosConfigurationSetterProvider, cfg string) (metadata Metadata, err error) {
+func setBiosConfigurationFromFile(ctx context.Context, generic []biosConfigurationFileSetterProvider, cfg string) (metadata Metadata, err error) {
 	metadata = newMetadata()
 Loop:
 	for _, elem := range generic {
-		if elem.BiosConfigurationSetter == nil {
+		if elem.BiosConfigurationFileSetter == nil {
 			continue
 		}
 		select {
@@ -213,20 +227,20 @@ func SetBiosConfigurationInterfaces(ctx context.Context, generic []interface{}, 
 }
 
 // SetBiosConfigurationFromFileInterfaces applies the BIOS configuration from a file
-// using the first successful BiosConfigurationSetter implementation found in generic.
+// using the first successful BiosConfigurationFileSetter implementation found in generic.
 func SetBiosConfigurationFromFileInterfaces(ctx context.Context, generic []interface{}, cfg string) (metadata Metadata, err error) {
-	implementations := make([]biosConfigurationSetterProvider, 0)
+	implementations := make([]biosConfigurationFileSetterProvider, 0)
 	for _, elem := range generic {
 		if elem == nil {
 			continue
 		}
-		temp := biosConfigurationSetterProvider{name: getProviderName(elem)}
+		temp := biosConfigurationFileSetterProvider{name: getProviderName(elem)}
 		switch p := elem.(type) {
-		case BiosConfigurationSetter:
-			temp.BiosConfigurationSetter = p
+		case BiosConfigurationFileSetter:
+			temp.BiosConfigurationFileSetter = p
 			implementations = append(implementations, temp)
 		default:
-			e := fmt.Sprintf("not a BiosConfigurationSetterFromFile implementation: %T", p)
+			e := fmt.Sprintf("not a BiosConfigurationFileSetter implementation: %T", p)
 			err = multierror.Append(err, errors.New(e))
 		}
 	}
@@ -235,7 +249,7 @@ func SetBiosConfigurationFromFileInterfaces(ctx context.Context, generic []inter
 			err,
 			errors.Wrap(
 				bmclibErrs.ErrProviderImplementation,
-				("no BiosConfigurationSetterFromFile implementations found"),
+				("no BiosConfigurationFileSetter implementations found"),
 			),
 		)
 	}

--- a/bmc/bios_test.go
+++ b/bmc/bios_test.go
@@ -1,0 +1,175 @@
+package bmc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockBiosConfigurationMapSetter implements only SetBiosConfiguration, matching
+// providers (e.g. Redfish, iDRAC, Lenovo) that have no file-import equivalent.
+// Regression coverage for the BiosConfigurationSetter/BiosConfigurationFileSetter
+// split: before the split this type failed to satisfy the combined interface at
+// all, so SetBiosConfigurationInterfaces reported "no implementations found"
+// even though SetBiosConfiguration itself worked fine.
+type mockBiosConfigurationMapSetter struct {
+	err error
+}
+
+func (m *mockBiosConfigurationMapSetter) SetBiosConfiguration(ctx context.Context, _ map[string]string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return m.err
+	}
+}
+
+func (m *mockBiosConfigurationMapSetter) Name() string {
+	return "mock"
+}
+
+// mockBiosConfigurationFileSetter implements only SetBiosConfigurationFromFile,
+// matching providers (e.g. Dell SUM-style tools) that only support whole-config
+// file import, not the generic map-based path.
+type mockBiosConfigurationFileSetter struct {
+	err error
+}
+
+func (m *mockBiosConfigurationFileSetter) SetBiosConfigurationFromFile(ctx context.Context, _ string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return m.err
+	}
+}
+
+func (m *mockBiosConfigurationFileSetter) Name() string {
+	return "mock"
+}
+
+func TestSetBiosConfigurationInterfaces(t *testing.T) {
+	testCases := []struct {
+		name             string
+		generic          []interface{}
+		biosConfig       map[string]string
+		errMsg           string
+		expectedMetadata Metadata
+	}{
+		{
+			name:       "success with a map-only setter",
+			generic:    []interface{}{&mockBiosConfigurationMapSetter{}},
+			biosConfig: map[string]string{"NetworkStack": "Enabled"},
+			expectedMetadata: Metadata{
+				SuccessfulProvider:   "mock",
+				ProvidersAttempted:   []string{"mock"},
+				FailedProviderDetail: make(map[string]string),
+			},
+		},
+		{
+			name:             "a file-only setter does not satisfy BiosConfigurationSetter",
+			generic:          []interface{}{&mockBiosConfigurationFileSetter{}},
+			errMsg:           "no BiosConfigurationSetter implementations found",
+			expectedMetadata: Metadata{},
+		},
+		{
+			name:             "no setters",
+			generic:          []interface{}{},
+			errMsg:           "no BiosConfigurationSetter implementations found",
+			expectedMetadata: Metadata{},
+		},
+		{
+			name:    "error from setter",
+			generic: []interface{}{&mockBiosConfigurationMapSetter{err: errors.New("foobar")}},
+			errMsg:  "foobar",
+			expectedMetadata: Metadata{
+				ProvidersAttempted:   []string{"mock"},
+				FailedProviderDetail: map[string]string{},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata, err := SetBiosConfigurationInterfaces(context.Background(), tt.generic, tt.biosConfig)
+
+			if tt.errMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.errMsg)
+			}
+
+			assert.Equal(t, tt.expectedMetadata, metadata)
+		})
+	}
+}
+
+func TestSetBiosConfigurationFromFileInterfaces(t *testing.T) {
+	testCases := []struct {
+		name             string
+		generic          []interface{}
+		errMsg           string
+		expectedMetadata Metadata
+	}{
+		{
+			name:    "success with a file-only setter",
+			generic: []interface{}{&mockBiosConfigurationFileSetter{}},
+			expectedMetadata: Metadata{
+				SuccessfulProvider:   "mock",
+				ProvidersAttempted:   []string{"mock"},
+				FailedProviderDetail: make(map[string]string),
+			},
+		},
+		{
+			name:             "a map-only setter does not satisfy BiosConfigurationFileSetter",
+			generic:          []interface{}{&mockBiosConfigurationMapSetter{}},
+			errMsg:           "no BiosConfigurationFileSetter implementations found",
+			expectedMetadata: Metadata{},
+		},
+		{
+			name:             "no setters",
+			generic:          []interface{}{},
+			errMsg:           "no BiosConfigurationFileSetter implementations found",
+			expectedMetadata: Metadata{},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata, err := SetBiosConfigurationFromFileInterfaces(context.Background(), tt.generic, "cfg")
+
+			if tt.errMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.errMsg)
+			}
+
+			assert.Equal(t, tt.expectedMetadata, metadata)
+		})
+	}
+}
+
+// mockBiosConfigurationSetter implements both SetBiosConfiguration and
+// SetBiosConfigurationFromFile, matching providers (e.g. Supermicro) that
+// support both paths — proves the split doesn't break dual-implementers.
+type mockBiosConfigurationSetter struct {
+	mockBiosConfigurationMapSetter
+	mockBiosConfigurationFileSetter
+}
+
+func (m *mockBiosConfigurationSetter) Name() string {
+	return "mock"
+}
+
+func TestSetBiosConfigurationInterfaces_dualImplementer(t *testing.T) {
+	dual := &mockBiosConfigurationSetter{}
+
+	_, err := SetBiosConfigurationInterfaces(context.Background(), []interface{}{dual}, map[string]string{})
+	assert.NoError(t, err)
+
+	_, err = SetBiosConfigurationFromFileInterfaces(context.Background(), []interface{}{dual}, "cfg")
+	assert.NoError(t, err)
+}

--- a/providers/dell/idrac.go
+++ b/providers/dell/idrac.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jacobweinstock/registrar"
 	"github.com/pkg/errors"
 
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
 	"github.com/bmc-toolbox/bmclib/v2/internal/httpclient"
 	"github.com/bmc-toolbox/bmclib/v2/internal/redfishwrapper"
 	"github.com/bmc-toolbox/bmclib/v2/providers"
@@ -98,6 +99,12 @@ func WithUseBasicAuth(useBasicAuth bool) Option {
 		c.UseBasicAuth = useBasicAuth
 	}
 }
+
+// compile-time assertions that the provider implements the BIOS configuration interfaces.
+var (
+	_ bmc.BiosConfigurationGetter = (*Conn)(nil)
+	_ bmc.BiosConfigurationSetter = (*Conn)(nil)
+)
 
 // Conn details for redfish client
 type Conn struct {

--- a/providers/lenovo/bios.go
+++ b/providers/lenovo/bios.go
@@ -5,7 +5,14 @@ import (
 
 	"github.com/stmcginnis/gofish/schemas"
 
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
 	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
+)
+
+// compile-time assertions that the provider implements the BIOS configuration interfaces.
+var (
+	_ bmc.BiosConfigurationGetter = (*Conn)(nil)
+	_ bmc.BiosConfigurationSetter = (*Conn)(nil)
 )
 
 // GetBiosConfiguration returns the current BIOS attributes as a key/value map,

--- a/providers/redfish/redfish.go
+++ b/providers/redfish/redfish.go
@@ -42,6 +42,12 @@ var Features = registrar.Features{
 	providers.FeatureResetBiosConfiguration,
 }
 
+// compile-time assertions that the provider implements the BIOS configuration interfaces.
+var (
+	_ bmc.BiosConfigurationGetter = (*Conn)(nil)
+	_ bmc.BiosConfigurationSetter = (*Conn)(nil)
+)
+
 // Conn details for redfish client
 type Conn struct {
 	redfishwrapper       *redfishwrapper.Client

--- a/providers/supermicro/supermicro.go
+++ b/providers/supermicro/supermicro.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bmc-toolbox/common"
 	"github.com/stmcginnis/gofish/schemas"
 
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
 	"github.com/bmc-toolbox/bmclib/v2/constants"
 	"github.com/bmc-toolbox/bmclib/v2/internal/httpclient"
 	"github.com/bmc-toolbox/bmclib/v2/internal/redfishwrapper"
@@ -107,6 +108,13 @@ func WithPort(port string) Option {
 		c.Port = port
 	}
 }
+
+// compile-time assertions that the provider implements the BIOS configuration interfaces.
+var (
+	_ bmc.BiosConfigurationGetter     = (*Client)(nil)
+	_ bmc.BiosConfigurationSetter     = (*Client)(nil)
+	_ bmc.BiosConfigurationFileSetter = (*Client)(nil)
+)
 
 // Client is a Supermicro BMC connection.
 type Client struct {


### PR DESCRIPTION
## What does this PR implement/change/remove?

`BiosConfigurationSetter` currently requires implementing **both** `SetBiosConfiguration` and `SetBiosConfigurationFromFile`. `providers/redfish`, `providers/dell/idrac`, and `providers/lenovo` only implement `SetBiosConfiguration` - the file-import path is a Dell/Supermicro-SUM-specific whole-config-blob import with no generic Redfish equivalent - so none of them satisfy the interface today. `Client.SetBiosConfiguration()` fails with `no BiosConfigurationSetter implementations found` on those providers even though the underlying call works fine.

Confirmed live against a real Supermicro AS-1114S-WN10RT-EU BMC: on current `main`, `SetBiosConfiguration` fails with `not a BiosConfigurationSetter implementation: *redfish.Conn` (and `*lenovo.Conn`) before any network request is even made; after this fix, dispatch correctly selects those providers and the request goes out.

Splits `BiosConfigurationSetter` (map only) from a new `BiosConfigurationFileSetter` (file only), dispatched independently. `providers/supermicro`, which implements both, is unaffected.

Also adds `var _ Interface = (*Conn)(nil)` compile-time assertions (the pattern already used in `providers/lenovo`'s `bmc.go`/`virtual_media.go`/`sel.go`/etc., but never applied to the BIOS interfaces) to `redfish`, `dell/idrac`, `lenovo`, and `supermicro`, so this exact class of bug can't regress silently again - applying the same assertions to unmodified `main` fails to compile in exactly the three affected providers.

### Checklist
- [x] Tests added
- [x] Similar commits squashed

### The HW vendor this change applies to (if applicable)
Any BMC reached via the generic Redfish, Dell iDRAC, or Lenovo XClarity providers. Confirmed live against Supermicro.

### The HW model number, product name this change applies to (if applicable)
Confirmed live against a Supermicro AS-1114S-WN10RT-EU.

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)
N/A - this is a Go interface-satisfaction bug, not firmware-dependent.

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)
None.

## Description for changelog/release notes

```
Fix BiosConfigurationSetter so the redfish, dell/idrac, and lenovo providers are recognized as implementing SetBiosConfiguration.
```