### PR TITLE
feat: add UEFI SecureBoot enable/disable and key reset support

### DIFF
--- a/bmc/secure_boot.go
+++ b/bmc/secure_boot.go
@@ -1,0 +1,212 @@
+package bmc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+
+	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
+)
+
+// SecureBootStateGetter provides retrieval of whether UEFI Secure Boot is enabled.
+type SecureBootStateGetter interface {
+	GetSecureBoot(ctx context.Context) (enabled bool, err error)
+}
+
+type secureBootStateGetterProvider struct {
+	name string
+	SecureBootStateGetter
+}
+
+// SecureBootSetter provides enabling/disabling UEFI Secure Boot.
+type SecureBootSetter interface {
+	SetSecureBoot(ctx context.Context, enable bool) (err error)
+}
+
+type secureBootSetterProvider struct {
+	name string
+	SecureBootSetter
+}
+
+// SecureBootKeysResetter provides resetting the UEFI Secure Boot key databases.
+type SecureBootKeysResetter interface {
+	ResetSecureBootKeys(ctx context.Context, resetType string) (err error)
+}
+
+type secureBootKeysResetterProvider struct {
+	name string
+	SecureBootKeysResetter
+}
+
+func secureBootState(ctx context.Context, generic []secureBootStateGetterProvider) (enabled bool, metadata Metadata, err error) {
+	metadata = newMetadata()
+Loop:
+	for _, elem := range generic {
+		if elem.SecureBootStateGetter == nil {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			err = multierror.Append(err, ctx.Err())
+			break Loop
+		default:
+			metadata.ProvidersAttempted = append(metadata.ProvidersAttempted, elem.name)
+			enabled, vErr := elem.GetSecureBoot(ctx)
+			if vErr != nil {
+				err = multierror.Append(err, errors.WithMessagef(vErr, "provider: %v", elem.name))
+				continue
+			}
+			metadata.SuccessfulProvider = elem.name
+			return enabled, metadata, nil
+		}
+	}
+
+	return enabled, metadata, multierror.Append(err, errors.New("failure to get secure boot state"))
+}
+
+func setSecureBoot(ctx context.Context, generic []secureBootSetterProvider, enable bool) (metadata Metadata, err error) {
+	metadata = newMetadata()
+Loop:
+	for _, elem := range generic {
+		if elem.SecureBootSetter == nil {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			err = multierror.Append(err, ctx.Err())
+			break Loop
+		default:
+			metadata.ProvidersAttempted = append(metadata.ProvidersAttempted, elem.name)
+			vErr := elem.SetSecureBoot(ctx, enable)
+			if vErr != nil {
+				err = multierror.Append(err, errors.WithMessagef(vErr, "provider: %v", elem.name))
+				continue
+			}
+			metadata.SuccessfulProvider = elem.name
+			return metadata, nil
+		}
+	}
+
+	return metadata, multierror.Append(err, errors.New("failure to set secure boot state"))
+}
+
+func resetSecureBootKeys(ctx context.Context, generic []secureBootKeysResetterProvider, resetType string) (metadata Metadata, err error) {
+	metadata = newMetadata()
+Loop:
+	for _, elem := range generic {
+		if elem.SecureBootKeysResetter == nil {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			err = multierror.Append(err, ctx.Err())
+			break Loop
+		default:
+			metadata.ProvidersAttempted = append(metadata.ProvidersAttempted, elem.name)
+			vErr := elem.ResetSecureBootKeys(ctx, resetType)
+			if vErr != nil {
+				err = multierror.Append(err, errors.WithMessagef(vErr, "provider: %v", elem.name))
+				continue
+			}
+			metadata.SuccessfulProvider = elem.name
+			return metadata, nil
+		}
+	}
+
+	return metadata, multierror.Append(err, errors.New("failure to reset secure boot keys"))
+}
+
+// GetSecureBootStateFromInterfaces returns whether UEFI Secure Boot is enabled using
+// the first successful SecureBootStateGetter implementation found in generic.
+func GetSecureBootStateFromInterfaces(ctx context.Context, generic []interface{}) (enabled bool, metadata Metadata, err error) {
+	implementations := make([]secureBootStateGetterProvider, 0)
+	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
+		temp := secureBootStateGetterProvider{name: getProviderName(elem)}
+		switch p := elem.(type) {
+		case SecureBootStateGetter:
+			temp.SecureBootStateGetter = p
+			implementations = append(implementations, temp)
+		default:
+			e := fmt.Sprintf("not a SecureBootStateGetter implementation: %T", p)
+			err = multierror.Append(err, errors.New(e))
+		}
+	}
+	if len(implementations) == 0 {
+		return enabled, metadata, multierror.Append(
+			err,
+			errors.Wrap(
+				bmclibErrs.ErrProviderImplementation,
+				("no SecureBootStateGetter implementations found"),
+			),
+		)
+	}
+
+	return secureBootState(ctx, implementations)
+}
+
+// SetSecureBootFromInterfaces enables/disables UEFI Secure Boot using the first
+// successful SecureBootSetter implementation found in generic.
+func SetSecureBootFromInterfaces(ctx context.Context, generic []interface{}, enable bool) (metadata Metadata, err error) {
+	implementations := make([]secureBootSetterProvider, 0)
+	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
+		temp := secureBootSetterProvider{name: getProviderName(elem)}
+		switch p := elem.(type) {
+		case SecureBootSetter:
+			temp.SecureBootSetter = p
+			implementations = append(implementations, temp)
+		default:
+			e := fmt.Sprintf("not a SecureBootSetter implementation: %T", p)
+			err = multierror.Append(err, errors.New(e))
+		}
+	}
+	if len(implementations) == 0 {
+		return metadata, multierror.Append(
+			err,
+			errors.Wrap(
+				bmclibErrs.ErrProviderImplementation,
+				("no SecureBootSetter implementations found"),
+			),
+		)
+	}
+
+	return setSecureBoot(ctx, implementations, enable)
+}
+
+// ResetSecureBootKeysFromInterfaces resets the UEFI Secure Boot key databases using
+// the first successful SecureBootKeysResetter implementation found in generic.
+func ResetSecureBootKeysFromInterfaces(ctx context.Context, generic []interface{}, resetType string) (metadata Metadata, err error) {
+	implementations := make([]secureBootKeysResetterProvider, 0)
+	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
+		temp := secureBootKeysResetterProvider{name: getProviderName(elem)}
+		switch p := elem.(type) {
+		case SecureBootKeysResetter:
+			temp.SecureBootKeysResetter = p
+			implementations = append(implementations, temp)
+		default:
+			e := fmt.Sprintf("not a SecureBootKeysResetter implementation: %T", p)
+			err = multierror.Append(err, errors.New(e))
+		}
+	}
+	if len(implementations) == 0 {
+		return metadata, multierror.Append(
+			err,
+			errors.Wrap(
+				bmclibErrs.ErrProviderImplementation,
+				("no SecureBootKeysResetter implementations found"),
+			),
+		)
+	}
+
+	return resetSecureBootKeys(ctx, implementations, resetType)
+}

--- a/bmc/secure_boot_test.go
+++ b/bmc/secure_boot_test.go
@@ -1,0 +1,170 @@
+package bmc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockSecureBootStateGetter struct {
+	enabled bool
+	err     error
+}
+
+func (m *mockSecureBootStateGetter) GetSecureBoot(ctx context.Context) (bool, error) {
+	return m.enabled, m.err
+}
+
+func (m *mockSecureBootStateGetter) Name() string {
+	return "mock"
+}
+
+type mockSecureBootSetter struct {
+	err error
+}
+
+func (m *mockSecureBootSetter) SetSecureBoot(ctx context.Context, _ bool) error {
+	return m.err
+}
+
+func (m *mockSecureBootSetter) Name() string {
+	return "mock"
+}
+
+type mockSecureBootKeysResetter struct {
+	err error
+}
+
+func (m *mockSecureBootKeysResetter) ResetSecureBootKeys(ctx context.Context, _ string) error {
+	return m.err
+}
+
+func (m *mockSecureBootKeysResetter) Name() string {
+	return "mock"
+}
+
+func TestGetSecureBootStateFromInterfaces(t *testing.T) {
+	testCases := []struct {
+		name            string
+		generic         []interface{}
+		errMsg          string
+		expectedEnabled bool
+	}{
+		{
+			name:            "success, enabled",
+			generic:         []interface{}{&mockSecureBootStateGetter{enabled: true}},
+			expectedEnabled: true,
+		},
+		{
+			name:    "not an implementation",
+			generic: []interface{}{"foo"},
+			errMsg:  "no SecureBootStateGetter implementations found",
+		},
+		{
+			name:    "no implementations",
+			generic: []interface{}{},
+			errMsg:  "no SecureBootStateGetter implementations found",
+		},
+		{
+			name:    "error from getter",
+			generic: []interface{}{&mockSecureBootStateGetter{err: errors.New("foobar")}},
+			errMsg:  "foobar",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			enabled, _, err := GetSecureBootStateFromInterfaces(context.Background(), tt.generic)
+
+			if tt.errMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.errMsg)
+			}
+
+			assert.Equal(t, tt.expectedEnabled, enabled)
+		})
+	}
+}
+
+func TestSetSecureBootFromInterfaces(t *testing.T) {
+	testCases := []struct {
+		name    string
+		generic []interface{}
+		errMsg  string
+	}{
+		{
+			name:    "success",
+			generic: []interface{}{&mockSecureBootSetter{}},
+		},
+		{
+			name:    "not an implementation",
+			generic: []interface{}{&mockSecureBootStateGetter{}},
+			errMsg:  "no SecureBootSetter implementations found",
+		},
+		{
+			name:    "no implementations",
+			generic: []interface{}{},
+			errMsg:  "no SecureBootSetter implementations found",
+		},
+		{
+			name:    "error from setter",
+			generic: []interface{}{&mockSecureBootSetter{err: errors.New("foobar")}},
+			errMsg:  "foobar",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := SetSecureBootFromInterfaces(context.Background(), tt.generic, true)
+
+			if tt.errMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestResetSecureBootKeysFromInterfaces(t *testing.T) {
+	testCases := []struct {
+		name    string
+		generic []interface{}
+		errMsg  string
+	}{
+		{
+			name:    "success",
+			generic: []interface{}{&mockSecureBootKeysResetter{}},
+		},
+		{
+			name:    "not an implementation",
+			generic: []interface{}{&mockSecureBootStateGetter{}},
+			errMsg:  "no SecureBootKeysResetter implementations found",
+		},
+		{
+			name:    "no implementations",
+			generic: []interface{}{},
+			errMsg:  "no SecureBootKeysResetter implementations found",
+		},
+		{
+			name:    "error from resetter",
+			generic: []interface{}{&mockSecureBootKeysResetter{err: errors.New("foobar")}},
+			errMsg:  "foobar",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ResetSecureBootKeysFromInterfaces(context.Background(), tt.generic, "ResetAllKeysToDefault")
+
+			if tt.errMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.errMsg)
+			}
+		})
+	}
+}

--- a/client.go
+++ b/client.go
@@ -671,6 +671,43 @@ func (c *Client) ResetBiosConfiguration(ctx context.Context) (err error) {
 	return err
 }
 
+// GetSecureBoot returns whether UEFI Secure Boot is currently enabled.
+func (c *Client) GetSecureBoot(ctx context.Context) (enabled bool, err error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "GetSecureBoot")
+	defer span.End()
+
+	enabled, metadata, err := bmc.GetSecureBootStateFromInterfaces(ctx, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return enabled, err
+}
+
+// SetSecureBoot enables or disables UEFI Secure Boot.
+func (c *Client) SetSecureBoot(ctx context.Context, enable bool) (err error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "SetSecureBoot")
+	defer span.End()
+
+	metadata, err := bmc.SetSecureBootFromInterfaces(ctx, c.registry().GetDriverInterfaces(), enable)
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// ResetSecureBootKeys resets the UEFI Secure Boot key databases. resetType is one
+// of ResetAllKeysToDefault, DeleteAllKeys, or DeletePK.
+func (c *Client) ResetSecureBootKeys(ctx context.Context, resetType string) (err error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "ResetSecureBootKeys")
+	defer span.End()
+
+	metadata, err := bmc.ResetSecureBootKeysFromInterfaces(ctx, c.registry().GetDriverInterfaces(), resetType)
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
 // FirmwareInstall pass through library function to upload firmware and install firmware
 func (c *Client) FirmwareInstall(ctx context.Context, component, operationApplyTime string, forceInstall bool, reader io.Reader) (taskID string, err error) {
 	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "FirmwareInstall")

--- a/internal/redfishwrapper/fixtures/dell/secureboot.json
+++ b/internal/redfishwrapper/fixtures/dell/secureboot.json
@@ -1,0 +1,17 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#SecureBoot.SecureBoot",
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot",
+    "@odata.type": "#SecureBoot.v1_0_4.SecureBoot",
+    "Id": "SecureBoot",
+    "Name": "UEFI Secure Boot",
+    "SecureBootEnable": true,
+    "SecureBootCurrentBoot": "Disabled",
+    "SecureBootMode": "SetupMode",
+    "Actions": {
+        "#SecureBoot.ResetKeys": {
+            "target": "/redfish/v1/Systems/System.Embedded.1/SecureBoot/Actions/SecureBoot.ResetKeys",
+            "title": "ResetKeys",
+            "@Redfish.ActionInfo": "/redfish/v1/Systems/System.Embedded.1/SecureBoot/ResetKeysActionInfo"
+        }
+    }
+}

--- a/internal/redfishwrapper/secure_boot.go
+++ b/internal/redfishwrapper/secure_boot.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/stmcginnis/gofish/schemas"
+
+	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
 )
 
 // GetSecureBoot returns whether UEFI Secure Boot is currently enabled for the system.
@@ -14,7 +16,7 @@ func (c *Client) GetSecureBoot(ctx context.Context) (enabled bool, err error) {
 	}
 
 	if !c.compatibleOdataID(sys.ODataID, knownSystemsOdataIDs) {
-		return false, nil
+		return false, bmclibErrs.ErrRedfishSystemOdataID
 	}
 
 	secureBoot, err := sys.SecureBoot()
@@ -34,7 +36,7 @@ func (c *Client) SetSecureBoot(ctx context.Context, enable bool) (err error) {
 	}
 
 	if !c.compatibleOdataID(sys.ODataID, knownSystemsOdataIDs) {
-		return nil
+		return bmclibErrs.ErrRedfishSystemOdataID
 	}
 
 	secureBoot, err := sys.SecureBoot()
@@ -56,7 +58,7 @@ func (c *Client) ResetSecureBootKeys(ctx context.Context, resetType string) (err
 	}
 
 	if !c.compatibleOdataID(sys.ODataID, knownSystemsOdataIDs) {
-		return nil
+		return bmclibErrs.ErrRedfishSystemOdataID
 	}
 
 	secureBoot, err := sys.SecureBoot()

--- a/internal/redfishwrapper/secure_boot.go
+++ b/internal/redfishwrapper/secure_boot.go
@@ -1,0 +1,70 @@
+package redfishwrapper
+
+import (
+	"context"
+
+	"github.com/stmcginnis/gofish/schemas"
+)
+
+// GetSecureBoot returns whether UEFI Secure Boot is currently enabled for the system.
+func (c *Client) GetSecureBoot(ctx context.Context) (enabled bool, err error) {
+	sys, err := c.System()
+	if err != nil {
+		return false, err
+	}
+
+	if !c.compatibleOdataID(sys.ODataID, knownSystemsOdataIDs) {
+		return false, nil
+	}
+
+	secureBoot, err := sys.SecureBoot()
+	if err != nil {
+		return false, err
+	}
+
+	return secureBoot.SecureBootEnable, nil
+}
+
+// SetSecureBoot enables or disables UEFI Secure Boot for the system. The system
+// must be in UEFI boot mode for this to take effect.
+func (c *Client) SetSecureBoot(ctx context.Context, enable bool) (err error) {
+	sys, err := c.System()
+	if err != nil {
+		return err
+	}
+
+	if !c.compatibleOdataID(sys.ODataID, knownSystemsOdataIDs) {
+		return nil
+	}
+
+	secureBoot, err := sys.SecureBoot()
+	if err != nil {
+		return err
+	}
+
+	secureBoot.SecureBootEnable = enable
+
+	return secureBoot.Update()
+}
+
+// ResetSecureBootKeys resets the UEFI Secure Boot key databases. resetType is one
+// of ResetAllKeysToDefault, DeleteAllKeys, or DeletePK.
+func (c *Client) ResetSecureBootKeys(ctx context.Context, resetType string) (err error) {
+	sys, err := c.System()
+	if err != nil {
+		return err
+	}
+
+	if !c.compatibleOdataID(sys.ODataID, knownSystemsOdataIDs) {
+		return nil
+	}
+
+	secureBoot, err := sys.SecureBoot()
+	if err != nil {
+		return err
+	}
+
+	_, err = secureBoot.ResetKeys(schemas.ResetKeysType(resetType))
+
+	return err
+}

--- a/internal/redfishwrapper/secure_boot_test.go
+++ b/internal/redfishwrapper/secure_boot_test.go
@@ -1,0 +1,86 @@
+package redfishwrapper
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newDellSecureBootClient(t *testing.T, mux *http.ServeMux) *Client {
+	t.Helper()
+
+	mux.HandleFunc("/redfish/v1/", endpointFunc(t, "dell/serviceroot.json"))
+	mux.HandleFunc("/redfish/v1/Systems", endpointFunc(t, "dell/systems.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1", endpointFunc(t, "dell/system.embedded.1.json"))
+
+	server := httptest.NewTLSServer(mux)
+	t.Cleanup(server.Close)
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := NewClient(parsedURL.Hostname(), parsedURL.Port(), "", "", WithBasicAuthEnabled(true))
+
+	ctx := context.Background()
+	require.NoError(t, client.Open(ctx))
+	t.Cleanup(func() { _ = client.Close(ctx) })
+
+	return client
+}
+
+func TestGetSecureBoot(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/SecureBoot", endpointFunc(t, "dell/secureboot.json"))
+	client := newDellSecureBootClient(t, mux)
+
+	enabled, err := client.GetSecureBoot(context.Background())
+	assert.NoError(t, err)
+	assert.True(t, enabled)
+}
+
+func TestSetSecureBoot(t *testing.T) {
+	var patchAttempts int
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/SecureBoot", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write(mustReadFile(t, "dell/secureboot.json"))
+		case http.MethodPatch:
+			patchAttempts++
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+	client := newDellSecureBootClient(t, mux)
+
+	err := client.SetSecureBoot(context.Background(), false)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, patchAttempts, "expected SetSecureBoot to PATCH the SecureBoot resource once")
+}
+
+func TestResetSecureBootKeys(t *testing.T) {
+	var resetAttempts int
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/SecureBoot", endpointFunc(t, "dell/secureboot.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/SecureBoot/Actions/SecureBoot.ResetKeys", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		resetAttempts++
+		w.WriteHeader(http.StatusNoContent)
+	})
+	client := newDellSecureBootClient(t, mux)
+
+	err := client.ResetSecureBootKeys(context.Background(), "ResetAllKeysToDefault")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, resetAttempts, "expected ResetSecureBootKeys to POST to the ResetKeys action once")
+}

--- a/providers/dell/idrac.go
+++ b/providers/dell/idrac.go
@@ -48,6 +48,9 @@ var (
 		providers.FeatureGetBiosConfiguration,
 		providers.FeatureSetBiosConfiguration,
 		providers.FeatureResetBiosConfiguration,
+		providers.FeatureGetSecureBoot,
+		providers.FeatureSetSecureBoot,
+		providers.FeatureResetSecureBootKeys,
 	}
 
 	errManufacturerUnknown = errors.New("error identifying device manufacturer")
@@ -249,6 +252,21 @@ func (c *Conn) SetBiosConfiguration(ctx context.Context, biosConfig map[string]s
 // ResetBiosConfiguration resets the BIOS configuration settings back to 'factory defaults' via the BMC
 func (c *Conn) ResetBiosConfiguration(ctx context.Context) (err error) {
 	return c.redfishwrapper.ResetBiosConfiguration(ctx)
+}
+
+// GetSecureBoot returns whether UEFI Secure Boot is currently enabled
+func (c *Conn) GetSecureBoot(ctx context.Context) (enabled bool, err error) {
+	return c.redfishwrapper.GetSecureBoot(ctx)
+}
+
+// SetSecureBoot enables or disables UEFI Secure Boot
+func (c *Conn) SetSecureBoot(ctx context.Context, enable bool) (err error) {
+	return c.redfishwrapper.SetSecureBoot(ctx, enable)
+}
+
+// ResetSecureBootKeys resets the UEFI Secure Boot key databases
+func (c *Conn) ResetSecureBootKeys(ctx context.Context, resetType string) (err error) {
+	return c.redfishwrapper.ResetSecureBootKeys(ctx, resetType)
 }
 
 // SendNMI tells the BMC to issue an NMI to the device

--- a/providers/lenovo/lenovo.go
+++ b/providers/lenovo/lenovo.go
@@ -77,6 +77,9 @@ var Features = registrar.Features{
 	providers.FeatureGetBiosConfiguration,
 	providers.FeatureSetBiosConfiguration,
 	providers.FeatureResetBiosConfiguration,
+	providers.FeatureGetSecureBoot,
+	providers.FeatureSetSecureBoot,
+	providers.FeatureResetSecureBootKeys,
 	// inventory-storage
 	providers.FeatureInventoryRead,
 	// firmware-tasks

--- a/providers/lenovo/main_test.go
+++ b/providers/lenovo/main_test.go
@@ -680,6 +680,18 @@ func (ts *testServer) didResetBios() bool {
 	return ts.biosReset
 }
 
+func (ts *testServer) didPatchSecureBoot() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.secureBootPatched
+}
+
+func (ts *testServer) didResetSecureBootKeys() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.secureBootKeysReset
+}
+
 func (ts *testServer) didPatchSystem() bool {
 	ts.mu.Lock()
 	defer ts.mu.Unlock()

--- a/providers/lenovo/power_boot_bios_test.go
+++ b/providers/lenovo/power_boot_bios_test.go
@@ -195,3 +195,44 @@ func TestResetBiosConfiguration(t *testing.T) {
 		t.Fatal("expected the Bios.ResetBios action to be posted")
 	}
 }
+
+// Requirement: Secure Boot state read.
+func TestGetSecureBoot(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	enabled, err := c.GetSecureBoot(context.Background())
+	if err != nil {
+		t.Fatalf("GetSecureBoot: %v", err)
+	}
+	// The fixture reports SecureBootEnable true.
+	if !enabled {
+		t.Fatalf("GetSecureBoot = %v, want %v", enabled, true)
+	}
+}
+
+// Requirement: Secure Boot enable/disable.
+func TestSetSecureBoot(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if err := c.SetSecureBoot(context.Background(), false); err != nil {
+		t.Fatalf("SetSecureBoot: %v", err)
+	}
+	if !ts.didPatchSecureBoot() {
+		t.Fatal("expected the SecureBoot resource to be PATCHed")
+	}
+}
+
+// Requirement: Secure Boot key database reset.
+func TestResetSecureBootKeys(t *testing.T) {
+	ts := newTestServer(t, testServerOpts{})
+	c := ts.openedClient(t)
+
+	if err := c.ResetSecureBootKeys(context.Background(), "ResetAllKeysToDefault"); err != nil {
+		t.Fatalf("ResetSecureBootKeys: %v", err)
+	}
+	if !ts.didResetSecureBootKeys() {
+		t.Fatal("expected the SecureBoot.ResetKeys action to be posted")
+	}
+}

--- a/providers/lenovo/secure_boot.go
+++ b/providers/lenovo/secure_boot.go
@@ -1,0 +1,26 @@
+package lenovo
+
+import (
+	"context"
+)
+
+// GetSecureBoot returns whether UEFI Secure Boot is currently enabled.
+//
+// Implements bmc.SecureBootStateGetter.
+func (c *Conn) GetSecureBoot(ctx context.Context) (enabled bool, err error) {
+	return c.redfishwrapper.GetSecureBoot(ctx)
+}
+
+// SetSecureBoot enables or disables UEFI Secure Boot.
+//
+// Implements bmc.SecureBootSetter.
+func (c *Conn) SetSecureBoot(ctx context.Context, enable bool) (err error) {
+	return c.redfishwrapper.SetSecureBoot(ctx, enable)
+}
+
+// ResetSecureBootKeys resets the UEFI Secure Boot key databases.
+//
+// Implements bmc.SecureBootKeysResetter.
+func (c *Conn) ResetSecureBootKeys(ctx context.Context, resetType string) (err error) {
+	return c.redfishwrapper.ResetSecureBootKeys(ctx, resetType)
+}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -79,4 +79,13 @@ const (
 
 	// FeatureBootProgress indicates that the implementation supports reading the BootProgress from the BMC
 	FeatureBootProgress registrar.Feature = "bootprogress"
+
+	// FeatureGetSecureBoot means an implementation that can report whether UEFI Secure Boot is enabled
+	FeatureGetSecureBoot registrar.Feature = "getsecureboot"
+
+	// FeatureSetSecureBoot means an implementation that can enable/disable UEFI Secure Boot
+	FeatureSetSecureBoot registrar.Feature = "setsecureboot"
+
+	// FeatureResetSecureBootKeys means an implementation that can reset the UEFI Secure Boot key databases
+	FeatureResetSecureBootKeys registrar.Feature = "resetsecurebootkeys"
 )

--- a/providers/redfish/redfish.go
+++ b/providers/redfish/redfish.go
@@ -40,6 +40,9 @@ var Features = registrar.Features{
 	providers.FeatureGetBiosConfiguration,
 	providers.FeatureSetBiosConfiguration,
 	providers.FeatureResetBiosConfiguration,
+	providers.FeatureGetSecureBoot,
+	providers.FeatureSetSecureBoot,
+	providers.FeatureResetSecureBootKeys,
 }
 
 // compile-time assertions that the provider implements the BIOS configuration interfaces.
@@ -251,6 +254,21 @@ func (c *Conn) SetBiosConfiguration(ctx context.Context, biosConfig map[string]s
 // ResetBiosConfiguration set bios configuration
 func (c *Conn) ResetBiosConfiguration(ctx context.Context) (err error) {
 	return c.redfishwrapper.ResetBiosConfiguration(ctx)
+}
+
+// GetSecureBoot returns whether UEFI Secure Boot is currently enabled
+func (c *Conn) GetSecureBoot(ctx context.Context) (enabled bool, err error) {
+	return c.redfishwrapper.GetSecureBoot(ctx)
+}
+
+// SetSecureBoot enables or disables UEFI Secure Boot
+func (c *Conn) SetSecureBoot(ctx context.Context, enable bool) (err error) {
+	return c.redfishwrapper.SetSecureBoot(ctx, enable)
+}
+
+// ResetSecureBootKeys resets the UEFI Secure Boot key databases
+func (c *Conn) ResetSecureBootKeys(ctx context.Context, resetType string) (err error) {
+	return c.redfishwrapper.ResetSecureBootKeys(ctx, resetType)
 }
 
 // SendNMI tells the BMC to issue an NMI to the device

--- a/providers/supermicro/supermicro.go
+++ b/providers/supermicro/supermicro.go
@@ -60,6 +60,9 @@ var Features = registrar.Features{
 	providers.FeatureSetBiosConfigurationFromFile,
 	providers.FeatureResetBiosConfiguration,
 	providers.FeatureBootProgress,
+	providers.FeatureGetSecureBoot,
+	providers.FeatureSetSecureBoot,
+	providers.FeatureResetSecureBootKeys,
 }
 
 // supports
@@ -683,6 +686,33 @@ func hostIP(hostURL string) (string, error) {
 	}
 
 	return hostURLParsed.Host, nil
+}
+
+// GetSecureBoot returns whether UEFI Secure Boot is currently enabled
+func (c *Client) GetSecureBoot(ctx context.Context) (enabled bool, err error) {
+	if c.serviceClient == nil || c.serviceClient.redfish == nil {
+		return false, errors.Wrap(bmclibErrs.ErrLoginFailed, "client not initialized")
+	}
+
+	return c.serviceClient.redfish.GetSecureBoot(ctx)
+}
+
+// SetSecureBoot enables or disables UEFI Secure Boot
+func (c *Client) SetSecureBoot(ctx context.Context, enable bool) (err error) {
+	if c.serviceClient == nil || c.serviceClient.redfish == nil {
+		return errors.Wrap(bmclibErrs.ErrLoginFailed, "client not initialized")
+	}
+
+	return c.serviceClient.redfish.SetSecureBoot(ctx, enable)
+}
+
+// ResetSecureBootKeys resets the UEFI Secure Boot key databases
+func (c *Client) ResetSecureBootKeys(ctx context.Context, resetType string) (err error) {
+	if c.serviceClient == nil || c.serviceClient.redfish == nil {
+		return errors.Wrap(bmclibErrs.ErrLoginFailed, "client not initialized")
+	}
+
+	return c.serviceClient.redfish.ResetSecureBootKeys(ctx, resetType)
 }
 
 // SendNMI tells the BMC to issue an NMI to the device


### PR DESCRIPTION
## What does this PR implement/change/remove?

bmclib has no way to enable/disable UEFI SecureBoot or reset its key databases, despite gofish (already a direct dependency) fully supporting both via the ComputerSystem's SecureBoot resource (`SecureBootEnable` + `.Update()`, and `.ResetKeys()`).

Adds the standard three-layer bmclib capability, following the exact pattern of `bmc/bios.go`/`bmc/boot_device.go`:
- `internal/redfishwrapper`: `GetSecureBoot`/`SetSecureBoot`/`ResetSecureBootKeys` wrapping gofish's `schemas.SecureBoot`.
- `bmc`: `SecureBootStateGetter`/`SecureBootSetter`/`SecureBootKeysResetter` interfaces with the usual `FromInterfaces` dispatch.
- `Client.GetSecureBoot`/`SetSecureBoot`/`ResetSecureBootKeys` passthroughs.

Wired into every provider that embeds `redfishwrapper.Client` - `redfish` (generic), `dell`, `supermicro`, and `lenovo` - plus new `Feature*` constants (`FeatureGetSecureBoot`, `FeatureSetSecureBoot`, `FeatureResetSecureBootKeys`) on each. This matches how every other redfishwrapper-backed capability (BIOS config, power state, NMI, ...) is exposed at each provider layer, even though the implementation is the same delegation in every case.

### Checklist
- [x] Tests added
- [x] Similar commits squashed

### The HW vendor this change applies to (if applicable)
Any BMC reached via the generic Redfish, Dell, Supermicro, or Lenovo XCC provider.

### The HW model number, product name this change applies to (if applicable)
N/A - generic Redfish SecureBoot resource, not vendor-specific.

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)
Requires the standard Redfish `SecureBoot` resource under `ComputerSystem`.

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)
gofish (already a direct dependency, `github.com/stmcginnis/gofish/schemas`).

## Description for changelog/release notes

```
Add SetSecureBoot/GetSecureBoot/ResetSecureBootKeys support for the redfish, dell, supermicro, and lenovo providers.
```