### PR TITLE
fix: fall back when a BMC rejects @Redfish.SettingsApplyTime

### DIFF
--- a/internal/redfishwrapper/bios.go
+++ b/internal/redfishwrapper/bios.go
@@ -2,11 +2,38 @@ package redfishwrapper
 
 import (
 	"context"
+	"errors"
+	"strings"
 
 	"github.com/stmcginnis/gofish/schemas"
 
 	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
 )
+
+// rejectsSettingsApplyTime reports whether err is a Redfish error indicating
+// the BMC doesn't recognize the @Redfish.SettingsApplyTime property at all.
+// Some BMCs don't declare @Redfish.Settings.SupportedApplyTimes on their Bios
+// resource and reject the property outright rather than ignoring it.
+func rejectsSettingsApplyTime(err error) bool {
+	var redfishErr *schemas.Error
+	if !errors.As(err, &redfishErr) {
+		return false
+	}
+
+	for i := range redfishErr.ExtendedInfos {
+		info := &redfishErr.ExtendedInfos[i]
+		if info.MessageID != "Base.1.10.PropertyUnknown" {
+			continue
+		}
+		for _, prop := range info.RelatedProperties {
+			if strings.Contains(prop, "SettingsApplyTime") {
+				return true
+			}
+		}
+	}
+
+	return false
+}
 
 // GetBiosConfiguration returns the current BIOS configuration attributes for the system.
 func (c *Client) GetBiosConfiguration(ctx context.Context) (biosConfig map[string]string, err error) {
@@ -59,7 +86,16 @@ func (c *Client) SetBiosConfiguration(ctx context.Context, biosConfig map[string
 	}
 
 	// TODO(jwb) We should handle passing different apply times here
-	return bios.UpdateBiosAttributesApplyAt(settingsAttributes, schemas.OnResetSettingsApplyTime)
+	err = bios.UpdateBiosAttributesApplyAt(settingsAttributes, schemas.OnResetSettingsApplyTime)
+	if err != nil && rejectsSettingsApplyTime(err) {
+		// This BMC's Bios resource doesn't declare @Redfish.Settings.SupportedApplyTimes
+		// at all and rejects the @Redfish.SettingsApplyTime property outright, rather than
+		// ignoring it. Retry without an apply-time hint - the settings still go through the
+		// resource's separate Settings URI (@Redfish.Settings.SettingsObject), which by
+		// Redfish convention means they're staged rather than applied immediately.
+		return bios.UpdateBiosAttributes(settingsAttributes)
+	}
+	return err
 }
 
 // ResetBiosConfiguration resets the BIOS configuration to its default values.

--- a/internal/redfishwrapper/bios_test.go
+++ b/internal/redfishwrapper/bios_test.go
@@ -9,9 +9,11 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func biosConfigFromFixture(t *testing.T) map[string]string {
@@ -91,4 +93,97 @@ func TestGetBiosConfiguration(t *testing.T) {
 			assert.Equal(t, tc.expectedBiosConfig, biosConfig)
 		})
 	}
+}
+
+// biosWithoutSettingsApplyTimes is a Bios resource with no @Redfish.Settings
+// block at all - matching a BMC that doesn't declare
+// @Redfish.Settings.SupportedApplyTimes and rejects the
+// @Redfish.SettingsApplyTime property outright (confirmed live against a
+// Supermicro AS-1114S-WN10RT-EU).
+const biosWithoutSettingsApplyTimes = `{
+	"@odata.type": "#Bios.v1_2_3.Bios",
+	"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios",
+	"Id": "Bios",
+	"Name": "BIOS Configuration",
+	"AttributeRegistry": "BiosAttributeRegistryU32.v1_0_0",
+	"Attributes": {
+		"BootModeSelect": "UEFI"
+	}
+}`
+
+// propertyUnknownSettingsApplyTime is the exact error shape returned live by
+// a Supermicro BMC when @Redfish.SettingsApplyTime is included in a PATCH to
+// a Bios resource that doesn't support it.
+const propertyUnknownSettingsApplyTime = `{"error":{"code":"Base.v1_10_3.GeneralError","message":"A general error has occurred. See ExtendedInfo for more information.","@Message.ExtendedInfo":[{"MessageId":"Base.1.10.PropertyUnknown","Severity":"Warning","Resolution":"Remove the unknown property from the request body and resubmit the request if the operation failed.","Message":"The property @Redfish.SettingsApplyTime is not in the list of valid properties for the resource.","MessageArgs":["@Redfish.SettingsApplyTime"],"RelatedProperties":["@Redfish.SettingsApplyTime"]}]}}`
+
+func TestSetBiosConfiguration_ApplyTimeUnsupportedFallback(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/", endpointFunc(t, "/dell/serviceroot.json"))
+	mux.HandleFunc("/redfish/v1/Systems", endpointFunc(t, "/dell/systems.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1", endpointFunc(t, "/dell/system.embedded.1.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/Bios", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(biosWithoutSettingsApplyTimes))
+		case http.MethodPatch:
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			if strings.Contains(string(body), "SettingsApplyTime") {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(propertyUnknownSettingsApplyTime))
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	client := NewClient(parsedURL.Hostname(), parsedURL.Port(), "", "", WithBasicAuthEnabled(true))
+	require.NoError(t, client.Open(ctx))
+	defer client.Close(ctx)
+
+	err = client.SetBiosConfiguration(ctx, map[string]string{"BootModeSelect": "Legacy"})
+	assert.NoError(t, err, "expected fallback retry without the apply-time hint to succeed")
+}
+
+func TestSetBiosConfiguration_ApplyTimeRejectedWithoutFallbackTrigger(t *testing.T) {
+	// A BMC that rejects the PATCH for an unrelated reason should not trigger
+	// the apply-time fallback, and the original error should propagate.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/", endpointFunc(t, "/dell/serviceroot.json"))
+	mux.HandleFunc("/redfish/v1/Systems", endpointFunc(t, "/dell/systems.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1", endpointFunc(t, "/dell/system.embedded.1.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/Bios", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(biosWithoutSettingsApplyTimes))
+		case http.MethodPatch:
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"code":"Base.v1_10_3.GeneralError","message":"unrelated failure","@Message.ExtendedInfo":[{"MessageId":"Base.1.10.PropertyValueNotInList","RelatedProperties":["BootModeSelect"]}]}}`))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	client := NewClient(parsedURL.Hostname(), parsedURL.Port(), "", "", WithBasicAuthEnabled(true))
+	require.NoError(t, client.Open(ctx))
+	defer client.Close(ctx)
+
+	err = client.SetBiosConfiguration(ctx, map[string]string{"BootModeSelect": "Legacy"})
+	assert.ErrorContains(t, err, "PropertyValueNotInList")
 }


### PR DESCRIPTION
## What does this PR implement/change/remove?

`SetBiosConfiguration` always sends `@Redfish.SettingsApplyTime: OnReset` (hardcoded since `a46f75c0`, which added the `// TODO(jwb) We should handle passing different apply times here` comment still present in `bios.go` today). Some BMCs don't declare `@Redfish.Settings.SupportedApplyTimes` on their `Bios` resource at all and reject the property outright (`Base.1.10.PropertyUnknown`) instead of ignoring it - confirmed live against a Supermicro AS-1114S-WN10RT-EU. gofish's own `AllowedAttributeUpdateApplyTimes()` can't be used to detect this ahead of time: it returns all 4 possible apply times as a fallback when none are declared, not a confirmation that any are actually supported.

On that specific error, this retries once without the apply-time hint. The settings still go through the resource's separate Settings URI (`@Redfish.Settings.SettingsObject`), which by Redfish convention means they're staged rather than applied immediately - dropping the hint doesn't reintroduce the immediate-apply risk `OnReset` was originally added to avoid.

Kept separate from #456 (interface-satisfaction fix) despite touching the same code area: different root cause/origin commit, and this one only surfaced *because* of the #456 fix - before it, dispatch failed before any network call was ever made, so this was invisible.

### Checklist
- [x] Tests added
- [x] Similar commits squashed

### The HW vendor this change applies to (if applicable)
Supermicro, confirmed live. Likely applies to any BMC that doesn't declare `@Redfish.Settings.SupportedApplyTimes` on its `Bios` resource.

### The HW model number, product name this change applies to (if applicable)
Confirmed live against a Supermicro AS-1114S-WN10RT-EU.

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)
Whatever firmware this specific AS-1114S-WN10RT-EU unit is currently running (not separately version-pinned in this PR).

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)
None.

## Description for changelog/release notes

```
Fall back to no apply-time hint when a BMC rejects @Redfish.SettingsApplyTime on SetBiosConfiguration.
```