### PR TITLE
redfishwrapper: verify boot device set actually took effect

### DIFF
--- a/internal/redfishwrapper/boot_device.go
+++ b/internal/redfishwrapper/boot_device.go
@@ -117,6 +117,7 @@ func (c *Client) SystemBootDeviceSet(_ context.Context, bootDevice string, setPe
 		boot.BootSourceOverrideMode = rf.LegacyBootSourceOverrideMode
 	}
 
+	sent := boot
 	if err = system.SetBoot(boot); err != nil {
 		// Some redfish implementations don't like all the fields we're setting so we
 		// try again here with a minimal set of fields. This has shown to work with the
@@ -127,6 +128,43 @@ func (c *Client) SystemBootDeviceSet(_ context.Context, bootDevice string, setPe
 		if err = system.SetBoot(secondTry); err != nil {
 			return false, err
 		}
+		sent = secondTry
+	}
+
+	// Some redfish implementations (confirmed on a Supermicro
+	// AS-1015CS-TNR-EU, AMI-based) respond 200 OK to this PATCH but
+	// silently store a different BootSourceOverrideMode/Enabled than what
+	// was requested - BootSourceOverrideTarget is the only field guaranteed
+	// to have actually stuck. Re-fetch and compare against what we actually
+	// sent (not `boot`, since the fallback path above only sends Target
+	// and Enabled - deliberately omitting Mode - and would otherwise be
+	// unfairly flagged as a mismatch here) so a caller relying on ok=true
+	// can trust the override will actually be honored at boot, rather than
+	// just that the BMC accepted the request.
+	updated, err := c.System()
+	if err != nil {
+		return false, errors.WithMessage(err, "verifying boot device set")
+	}
+
+	if updated.Boot.BootSourceOverrideTarget != sent.BootSourceOverrideTarget {
+		return false, errors.Errorf(
+			"boot device set was not applied: requested override target %q, BMC now has %q",
+			sent.BootSourceOverrideTarget, updated.Boot.BootSourceOverrideTarget,
+		)
+	}
+
+	if updated.Boot.BootSourceOverrideEnabled != sent.BootSourceOverrideEnabled {
+		return false, errors.Errorf(
+			"boot device set was not applied: requested override enabled state %q, BMC now has %q",
+			sent.BootSourceOverrideEnabled, updated.Boot.BootSourceOverrideEnabled,
+		)
+	}
+
+	if sent.BootSourceOverrideMode != "" && updated.Boot.BootSourceOverrideMode != sent.BootSourceOverrideMode {
+		return false, errors.Errorf(
+			"boot device set was not applied: requested boot mode %q, BMC now has %q",
+			sent.BootSourceOverrideMode, updated.Boot.BootSourceOverrideMode,
+		)
 	}
 
 	return true, nil

--- a/internal/redfishwrapper/boot_device_test.go
+++ b/internal/redfishwrapper/boot_device_test.go
@@ -1,0 +1,124 @@
+package redfishwrapper
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSystemBootDeviceSet_DetectsSupermicroSilentModeDowngrade guards against
+// a real bug seen on a Supermicro AS-1015CS-TNR-EU (AMI-based Redfish,
+// RedfishVersion 1.22.2): SystemBootDeviceSet("pxe", false, true) requests a
+// one-time UEFI PXE override (BootSourceOverrideTarget=Pxe,
+// BootSourceOverrideEnabled=Once, BootSourceOverrideMode=UEFI in a single
+// PATCH, exactly as the function under test builds it), the BMC responds
+// with 200 OK, but a subsequent GET shows BootSourceOverrideMode reverted to
+// "Legacy" (and Enabled to "Disabled") - only BootSourceOverrideTarget stuck
+// as requested.
+//
+// This matters because this system also has CSMSupport (Legacy/CSM boot)
+// disabled in its BIOS - it's UEFI-only - so a boot override that silently
+// downgrades to Legacy mode is not just wrong bookkeeping, it can never
+// actually result in a boot from the requested device. SystemBootDeviceSet
+// now re-fetches and verifies the write instead of trusting the PATCH's 200
+// OK, so callers (e.g. Tinkerbell's rufio controller) get ok=false and a
+// descriptive error instead of a false ok=true.
+//
+// The fixtures here are real captures from the affected hardware - see
+// fixtures/supermicro/README.md.
+func TestSystemBootDeviceSet_DetectsSupermicroSilentModeDowngrade(t *testing.T) {
+	var gotPatchBody []byte
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/", endpointFunc(t, "/supermicro/serviceroot.json"))
+	mux.HandleFunc("/redfish/v1/Systems", endpointFunc(t, "/supermicro/systems.json"))
+	mux.HandleFunc("/redfish/v1/Systems/1", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			// The real BMC never reflects the requested change - every GET,
+			// before or after the PATCH, returns this same Legacy/Disabled
+			// state.
+			w.Write(mustReadFile(t, "/supermicro/system.1.json"))
+		case http.MethodPatch:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("reading PATCH body: %s", err)
+				return
+			}
+			gotPatchBody = body
+			w.Write(mustReadFile(t, "/supermicro/patch-success.json"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	client := NewClient(parsedURL.Hostname(), parsedURL.Port(), "", "", WithBasicAuthEnabled(true))
+	require.NoError(t, client.Open(ctx))
+
+	// Request a one-time UEFI PXE boot override - this is exactly what
+	// Tinkerbell's rufio controller sends for a Hardware's bootDevice
+	// action with device: "pxe", efiBoot: true (no "persistent" field, so
+	// setPersistent defaults to false).
+	ok, err := client.SystemBootDeviceSet(ctx, "pxe", false, true)
+	assert.Contains(t, string(gotPatchBody), `"BootSourceOverrideMode":"UEFI"`,
+		"the PATCH we send does correctly ask for UEFI mode")
+
+	require.Error(t, err, "the BMC's 200 OK alone must not be enough to report success")
+	assert.False(t, ok)
+	assert.Contains(t, err.Error(), "was not applied",
+		"error should say the write wasn't actually applied, not just surface a generic failure")
+}
+
+// TestSystemBootDeviceSet_HappyPath is the counterpart to
+// TestSystemBootDeviceSet_DetectsSupermicroSilentModeDowngrade: a BMC that
+// actually honors the request should still report ok=true, not a false
+// negative from the new verification step.
+func TestSystemBootDeviceSet_HappyPath(t *testing.T) {
+	var patched bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/", endpointFunc(t, "/supermicro/serviceroot.json"))
+	mux.HandleFunc("/redfish/v1/Systems", endpointFunc(t, "/supermicro/systems.json"))
+	mux.HandleFunc("/redfish/v1/Systems/1", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if patched {
+				w.Write(mustReadFile(t, "/supermicro/system.1.after-correct-set.json"))
+			} else {
+				w.Write(mustReadFile(t, "/supermicro/system.1.json"))
+			}
+		case http.MethodPatch:
+			patched = true
+			w.Write(mustReadFile(t, "/supermicro/patch-success.json"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	client := NewClient(parsedURL.Hostname(), parsedURL.Port(), "", "", WithBasicAuthEnabled(true))
+	require.NoError(t, client.Open(ctx))
+
+	ok, err := client.SystemBootDeviceSet(ctx, "pxe", false, true)
+	require.NoError(t, err)
+	assert.True(t, ok)
+}

--- a/internal/redfishwrapper/fixtures/supermicro/README.md
+++ b/internal/redfishwrapper/fixtures/supermicro/README.md
@@ -1,0 +1,28 @@
+Fixtures in this directory are real Redfish responses captured from a
+Supermicro `AS-1015CS-TNR-EU` (BMC firmware AMI-based, `RedfishVersion:
+1.22.2`), gathered while diagnosing why `SystemBootDeviceSet(ctx, "pxe",
+false, true)` never actually resulted in a UEFI PXE boot on this hardware,
+despite the call returning `ok=true`.
+
+- `serviceroot.json`, `systems.json`, `system.1.json`: real `GET` responses.
+- `patch-success.json`: the real response body returned by this BMC for the
+  `PATCH /redfish/v1/Systems/1` request `SystemBootDeviceSet` issues when
+  called with `("pxe", false, true)` - i.e. requesting
+  `BootSourceOverrideTarget: Pxe`, `BootSourceOverrideEnabled: Once`,
+  `BootSourceOverrideMode: UEFI` all in one request, per
+  `boot_device.go`'s `SystemBootDeviceSet`.
+
+`system.1.json` is what a `GET` on `/redfish/v1/Systems/1` returns *after*
+that PATCH: `BootSourceOverrideMode` has silently reverted to `"Legacy"`
+(and `BootSourceOverrideEnabled` to `"Disabled"`) even though the request
+asked for `UEFI`/`Once`. `BootSourceOverrideTarget` is the only field that
+stuck as requested (`"Pxe"`).
+
+`system.1.after-correct-set.json` is synthetic, not a real capture - a copy
+of `system.1.json` with `Boot.BootSourceOverrideEnabled/Mode/Target` set to
+what a well-behaved BMC would show after actually honoring the request. Used
+by the happy-path test to confirm the verification added in response to this
+bug doesn't produce false negatives against a BMC that works correctly.
+
+See `boot_device_test.go`'s `TestSystemBootDeviceSet_DetectsSupermicroSilentModeDowngrade`
+and `TestSystemBootDeviceSet_HappyPath`.

--- a/internal/redfishwrapper/fixtures/supermicro/patch-success.json
+++ b/internal/redfishwrapper/fixtures/supermicro/patch-success.json
@@ -1,0 +1,1 @@
+{"Success":{"code":"Base.1.10.3.Success","message":"Successfully Completed Request."}}

--- a/internal/redfishwrapper/fixtures/supermicro/serviceroot.json
+++ b/internal/redfishwrapper/fixtures/supermicro/serviceroot.json
@@ -1,0 +1,87 @@
+{
+    "@odata.type": "#ServiceRoot.v1_19_0.ServiceRoot",
+    "@odata.id": "/redfish/v1",
+    "Id": "ServiceRoot",
+    "Name": "Root Service",
+    "RedfishVersion": "1.22.2",
+    "UUID": "00000000-0000-0000-0000-905A088166A9",
+    "Vendor": "Supermicro",
+    "Systems": {
+        "@odata.id": "/redfish/v1/Systems"
+    },
+    "Fabrics": {
+        "@odata.id": "/redfish/v1/Fabrics"
+    },
+    "Chassis": {
+        "@odata.id": "/redfish/v1/Chassis"
+    },
+    "Managers": {
+        "@odata.id": "/redfish/v1/Managers"
+    },
+    "Tasks": {
+        "@odata.id": "/redfish/v1/TaskService"
+    },
+    "SessionService": {
+        "@odata.id": "/redfish/v1/SessionService"
+    },
+    "LicenseService": {
+        "@odata.id": "/redfish/v1/LicenseService"
+    },
+    "AccountService": {
+        "@odata.id": "/redfish/v1/AccountService"
+    },
+    "EventService": {
+        "@odata.id": "/redfish/v1/EventService"
+    },
+    "UpdateService": {
+        "@odata.id": "/redfish/v1/UpdateService"
+    },
+    "CertificateService": {
+        "@odata.id": "/redfish/v1/CertificateService"
+    },
+    "Registries": {
+        "@odata.id": "/redfish/v1/Registries"
+    },
+    "JsonSchemas": {
+        "@odata.id": "/redfish/v1/JsonSchemas"
+    },
+    "ComponentIntegrity": {
+        "@odata.id": "/redfish/v1/ComponentIntegrity"
+    },
+    "TelemetryService": {
+        "@odata.id": "/redfish/v1/TelemetryService"
+    },
+    "Product": null,
+    "ServiceIdentification": "E518845X6600399",
+    "Links": {
+        "Sessions": {
+            "@odata.id": "/redfish/v1/SessionService/Sessions"
+        }
+    },
+    "Oem": {
+        "Supermicro": {
+            "DumpService": {
+                "@odata.id": "/redfish/v1/Oem/Supermicro/DumpService"
+            }
+        }
+    },
+    "ProtocolFeaturesSupported": {
+        "FilterQuery": true,
+        "SelectQuery": true,
+        "ExcerptQuery": false,
+        "OnlyMemberQuery": false,
+        "DeepOperations": {
+            "DeepPATCH": false,
+            "DeepPOST": false,
+            "MaxLevels": 1
+        },
+        "ExpandQuery": {
+            "Links": true,
+            "NoLinks": true,
+            "ExpandAll": true,
+            "Levels": true,
+            "MaxLevels": 2
+        }
+    },
+    "@odata.etag": "\"8a205e72f3c0ffaf49fb7f1b86b6ed63\""
+}

--- a/internal/redfishwrapper/fixtures/supermicro/system.1.after-correct-set.json
+++ b/internal/redfishwrapper/fixtures/supermicro/system.1.after-correct-set.json
@@ -1,0 +1,203 @@
+{
+    "@odata.type": "#ComputerSystem.v1_25_0.ComputerSystem",
+    "@odata.id": "/redfish/v1/Systems/1",
+    "Id": "1",
+    "Name": "System",
+    "Description": "Description of server",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "SerialNumber": "E518845X6600399",
+    "PartNumber": "AS -1015CS-TNR-EU",
+    "AssetTag": null,
+    "IndicatorLED": "Off",
+    "LocationIndicatorActive": false,
+    "SystemType": "Physical",
+    "BiosVersion": "BIOS Date: 01/06/2026 Ver 3.8",
+    "Manufacturer": "Supermicro",
+    "Model": "AS -1015CS-TNR-EU",
+    "SKU": "091715D9",
+    "UUID": "FFD3B400-00DE-11F1-8000-905A088166A9",
+    "ProcessorSummary": {
+        "Count": 1,
+        "Model": "AMD Zen processor family",
+        "Status": {
+            "State": "Enabled",
+            "Health": "OK",
+            "HealthRollup": "OK"
+        },
+        "Metrics": {
+            "@odata.id": "/redfish/v1/Systems/1/ProcessorSummary/ProcessorMetrics"
+        }
+    },
+    "MemorySummary": {
+        "TotalSystemMemoryGiB": 64,
+        "MemoryMirroring": "System",
+        "Status": {
+            "State": "Enabled",
+            "Health": "OK",
+            "HealthRollup": "OK"
+        },
+        "Metrics": {
+            "@odata.id": "/redfish/v1/Systems/1/MemorySummary/MemoryMetrics"
+        }
+    },
+    "PowerState": "On",
+    "PowerOnDelaySeconds": 5,
+    "PowerOnDelaySeconds@Redfish.AllowableNumbers": [
+        "5:254:1"
+    ],
+    "PowerOffDelaySeconds": 5,
+    "PowerOffDelaySeconds@Redfish.AllowableNumbers": [
+        "5:254:1"
+    ],
+    "PowerCycleDelaySeconds": 5,
+    "PowerCycleDelaySeconds@Redfish.AllowableNumbers": [
+        "5:254:1"
+    ],
+    "Boot": {
+        "AutomaticRetryConfig": "Disabled",
+        "BootSourceOverrideEnabled": "Once",
+        "BootSourceOverrideMode": "UEFI",
+        "BootSourceOverrideTarget": "Pxe",
+        "BootSourceOverrideTarget@Redfish.AllowableValues": [
+            "None",
+            "Pxe",
+            "Floppy",
+            "Cd",
+            "Usb",
+            "Hdd",
+            "BiosSetup",
+            "Floppy",
+            "UsbCd",
+            "Diags",
+            "UefiBootNext"
+        ],
+        "Certificates": {
+            "@odata.id": "/redfish/v1/Systems/1/Boot/Certificates"
+        },
+        "BootOptions": {
+            "@odata.id": "/redfish/v1/Systems/1/BootOptions"
+        },
+        "BootNext": null,
+        "BootOrder": [
+            "Boot0008",
+            "Boot0002",
+            "Boot0003",
+            "Boot0004",
+            "Boot0005",
+            "Boot0006",
+            "Boot0007",
+            "Boot0001"
+        ]
+    },
+    "GraphicalConsole": {
+        "ServiceEnabled": true,
+        "Port": 5900,
+        "MaxConcurrentSessions": 4,
+        "ConnectTypesSupported": [
+            "KVMIP"
+        ]
+    },
+    "SerialConsole": {
+        "MaxConcurrentSessions": 1,
+        "SSH": {
+            "ServiceEnabled": true,
+            "Port": 22,
+            "SharedWithManagerCLI": true,
+            "ConsoleEntryCommand": "cd system1/sol1; start",
+            "HotKeySequenceDisplay": "press <Enter>, <Esc>, and then <T> to terminate session"
+        },
+        "IPMI": {
+            "HotKeySequenceDisplay": "Press ~.  - terminate connection",
+            "ServiceEnabled": true,
+            "Port": 623
+        }
+    },
+    "VirtualMediaConfig": {
+        "ServiceEnabled": true,
+        "Port": 623
+    },
+    "BootProgress": {
+        "OemLastState": null,
+        "LastState": "SystemHardwareInitializationComplete",
+        "LastStateTime": "2026-08-06T09:53:38Z"
+    },
+    "IPMIHostInterface": {
+        "ServiceEnabled": true
+    },
+    "Processors": {
+        "@odata.id": "/redfish/v1/Systems/1/Processors"
+    },
+    "Memory": {
+        "@odata.id": "/redfish/v1/Systems/1/Memory"
+    },
+    "EthernetInterfaces": {
+        "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces"
+    },
+    "NetworkInterfaces": {
+        "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces"
+    },
+    "Storage": {
+        "@odata.id": "/redfish/v1/Systems/1/Storage"
+    },
+    "LogServices": {
+        "@odata.id": "/redfish/v1/Systems/1/LogServices"
+    },
+    "SecureBoot": {
+        "@odata.id": "/redfish/v1/Systems/1/SecureBoot"
+    },
+    "Bios": {
+        "@odata.id": "/redfish/v1/Systems/1/Bios"
+    },
+    "VirtualMedia": {
+        "@odata.id": "/redfish/v1/Managers/1/VirtualMedia"
+    },
+    "Links": {
+        "Chassis": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/1"
+            }
+        ],
+        "ManagedBy": [
+            {
+                "@odata.id": "/redfish/v1/Managers/1"
+            }
+        ],
+        "PoweredBy": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/1/PowerSubsystem/PowerSupplies/1"
+            },
+            {
+                "@odata.id": "/redfish/v1/Chassis/1/PowerSubsystem/PowerSupplies/2"
+            }
+        ]
+    },
+    "Actions": {
+        "Oem": {},
+        "#ComputerSystem.Reset": {
+            "target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+            "@Redfish.ActionInfo": "/redfish/v1/Systems/1/ResetActionInfo",
+            "ResetType@Redfish.AllowableValues": [
+                "On",
+                "ForceOff",
+                "GracefulShutdown",
+                "GracefulRestart",
+                "ForceRestart",
+                "Nmi",
+                "ForceOn",
+                "PowerCycle"
+            ]
+        }
+    },
+    "Oem": {
+        "Supermicro": {
+            "FixedBootOrder": {
+                "@odata.id": "/redfish/v1/Systems/1/Oem/Supermicro/FixedBootOrder"
+            },
+            "@odata.type": "#SmcSystemExtensions.v1_0_0.System"
+        }
+    },
+    "@odata.etag": "\"f38af8c401c8b53eba3df547b6bfac59\""
+}

--- a/internal/redfishwrapper/fixtures/supermicro/system.1.json
+++ b/internal/redfishwrapper/fixtures/supermicro/system.1.json
@@ -1,0 +1,203 @@
+{
+    "@odata.type": "#ComputerSystem.v1_25_0.ComputerSystem",
+    "@odata.id": "/redfish/v1/Systems/1",
+    "Id": "1",
+    "Name": "System",
+    "Description": "Description of server",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "SerialNumber": "E518845X6600399",
+    "PartNumber": "AS -1015CS-TNR-EU",
+    "AssetTag": null,
+    "IndicatorLED": "Off",
+    "LocationIndicatorActive": false,
+    "SystemType": "Physical",
+    "BiosVersion": "BIOS Date: 01/06/2026 Ver 3.8",
+    "Manufacturer": "Supermicro",
+    "Model": "AS -1015CS-TNR-EU",
+    "SKU": "091715D9",
+    "UUID": "FFD3B400-00DE-11F1-8000-905A088166A9",
+    "ProcessorSummary": {
+        "Count": 1,
+        "Model": "AMD Zen processor family",
+        "Status": {
+            "State": "Enabled",
+            "Health": "OK",
+            "HealthRollup": "OK"
+        },
+        "Metrics": {
+            "@odata.id": "/redfish/v1/Systems/1/ProcessorSummary/ProcessorMetrics"
+        }
+    },
+    "MemorySummary": {
+        "TotalSystemMemoryGiB": 64,
+        "MemoryMirroring": "System",
+        "Status": {
+            "State": "Enabled",
+            "Health": "OK",
+            "HealthRollup": "OK"
+        },
+        "Metrics": {
+            "@odata.id": "/redfish/v1/Systems/1/MemorySummary/MemoryMetrics"
+        }
+    },
+    "PowerState": "On",
+    "PowerOnDelaySeconds": 5,
+    "PowerOnDelaySeconds@Redfish.AllowableNumbers": [
+        "5:254:1"
+    ],
+    "PowerOffDelaySeconds": 5,
+    "PowerOffDelaySeconds@Redfish.AllowableNumbers": [
+        "5:254:1"
+    ],
+    "PowerCycleDelaySeconds": 5,
+    "PowerCycleDelaySeconds@Redfish.AllowableNumbers": [
+        "5:254:1"
+    ],
+    "Boot": {
+        "AutomaticRetryConfig": "Disabled",
+        "BootSourceOverrideEnabled": "Disabled",
+        "BootSourceOverrideMode": "Legacy",
+        "BootSourceOverrideTarget": "Pxe",
+        "BootSourceOverrideTarget@Redfish.AllowableValues": [
+            "None",
+            "Pxe",
+            "Floppy",
+            "Cd",
+            "Usb",
+            "Hdd",
+            "BiosSetup",
+            "Floppy",
+            "UsbCd",
+            "Diags",
+            "UefiBootNext"
+        ],
+        "Certificates": {
+            "@odata.id": "/redfish/v1/Systems/1/Boot/Certificates"
+        },
+        "BootOptions": {
+            "@odata.id": "/redfish/v1/Systems/1/BootOptions"
+        },
+        "BootNext": null,
+        "BootOrder": [
+            "Boot0008",
+            "Boot0002",
+            "Boot0003",
+            "Boot0004",
+            "Boot0005",
+            "Boot0006",
+            "Boot0007",
+            "Boot0001"
+        ]
+    },
+    "GraphicalConsole": {
+        "ServiceEnabled": true,
+        "Port": 5900,
+        "MaxConcurrentSessions": 4,
+        "ConnectTypesSupported": [
+            "KVMIP"
+        ]
+    },
+    "SerialConsole": {
+        "MaxConcurrentSessions": 1,
+        "SSH": {
+            "ServiceEnabled": true,
+            "Port": 22,
+            "SharedWithManagerCLI": true,
+            "ConsoleEntryCommand": "cd system1/sol1; start",
+            "HotKeySequenceDisplay": "press <Enter>, <Esc>, and then <T> to terminate session"
+        },
+        "IPMI": {
+            "HotKeySequenceDisplay": "Press ~.  - terminate connection",
+            "ServiceEnabled": true,
+            "Port": 623
+        }
+    },
+    "VirtualMediaConfig": {
+        "ServiceEnabled": true,
+        "Port": 623
+    },
+    "BootProgress": {
+        "OemLastState": null,
+        "LastState": "SystemHardwareInitializationComplete",
+        "LastStateTime": "2026-08-06T09:53:38Z"
+    },
+    "IPMIHostInterface": {
+        "ServiceEnabled": true
+    },
+    "Processors": {
+        "@odata.id": "/redfish/v1/Systems/1/Processors"
+    },
+    "Memory": {
+        "@odata.id": "/redfish/v1/Systems/1/Memory"
+    },
+    "EthernetInterfaces": {
+        "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces"
+    },
+    "NetworkInterfaces": {
+        "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces"
+    },
+    "Storage": {
+        "@odata.id": "/redfish/v1/Systems/1/Storage"
+    },
+    "LogServices": {
+        "@odata.id": "/redfish/v1/Systems/1/LogServices"
+    },
+    "SecureBoot": {
+        "@odata.id": "/redfish/v1/Systems/1/SecureBoot"
+    },
+    "Bios": {
+        "@odata.id": "/redfish/v1/Systems/1/Bios"
+    },
+    "VirtualMedia": {
+        "@odata.id": "/redfish/v1/Managers/1/VirtualMedia"
+    },
+    "Links": {
+        "Chassis": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/1"
+            }
+        ],
+        "ManagedBy": [
+            {
+                "@odata.id": "/redfish/v1/Managers/1"
+            }
+        ],
+        "PoweredBy": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/1/PowerSubsystem/PowerSupplies/1"
+            },
+            {
+                "@odata.id": "/redfish/v1/Chassis/1/PowerSubsystem/PowerSupplies/2"
+            }
+        ]
+    },
+    "Actions": {
+        "Oem": {},
+        "#ComputerSystem.Reset": {
+            "target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+            "@Redfish.ActionInfo": "/redfish/v1/Systems/1/ResetActionInfo",
+            "ResetType@Redfish.AllowableValues": [
+                "On",
+                "ForceOff",
+                "GracefulShutdown",
+                "GracefulRestart",
+                "ForceRestart",
+                "Nmi",
+                "ForceOn",
+                "PowerCycle"
+            ]
+        }
+    },
+    "Oem": {
+        "Supermicro": {
+            "FixedBootOrder": {
+                "@odata.id": "/redfish/v1/Systems/1/Oem/Supermicro/FixedBootOrder"
+            },
+            "@odata.type": "#SmcSystemExtensions.v1_0_0.System"
+        }
+    },
+    "@odata.etag": "\"f38af8c401c8b53eba3df547b6bfac59\""
+}

--- a/internal/redfishwrapper/fixtures/supermicro/systems.json
+++ b/internal/redfishwrapper/fixtures/supermicro/systems.json
@@ -1,0 +1,13 @@
+{
+    "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+    "@odata.id": "/redfish/v1/Systems",
+    "Name": "Computer System Collection",
+    "Description": "Computer System Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/1"
+        }
+    ],
+    "@odata.etag": "\"e310554bb25b657853dd0b5f36f07991\""
+}


### PR DESCRIPTION
## What

`SystemBootDeviceSet` returned `ok=true` as soon as the `PATCH` got a
`200 OK`, without checking whether the BMC actually stored what was
requested.

## Why

On a real Supermicro `AS-1015CS-TNR-EU` (AMI-based Redfish,
`RedfishVersion: 1.22.2`), a `PATCH` requesting a one-time UEFI PXE
override (`BootSourceOverrideTarget=Pxe`,
`BootSourceOverrideEnabled=Once`, `BootSourceOverrideMode=UEFI`) got a
`200 OK`, but a subsequent `GET` showed `BootSourceOverrideMode`
silently reverted to `"Legacy"` and `Enabled` to `"Disabled"` - only
`Target` stuck. This system also has CSM/Legacy boot disabled in its
BIOS, so the override could never actually be honored, but callers had
no way to detect this short of manually re-checking after the call
returned.

We hit this in production via Tinkerbell's rufio controller, which
uses `SystemBootDeviceSet` to set a one-time PXE boot override before
provisioning bare-metal hosts - the box never actually rebooted into
PXE despite bmclib reporting success.

## What changed

`SystemBootDeviceSet` now re-fetches the system after writing and
compares against what was actually sent - not necessarily the full
request, since the existing minimal-fields fallback (for Redfish
implementations that reject the full field set, e.g. HP DL160 Gen10)
deliberately omits `Mode`, so verification only checks fields that
were actually part of whichever request succeeded. Returns `ok=false`
with a descriptive error on mismatch instead of a false `ok=true`.

Fixtures in `internal/redfishwrapper/fixtures/supermicro/` are real
captures from the affected hardware (see that directory's `README.md`)
plus one synthetic fixture for the added happy-path regression test,
confirming a BMC that behaves correctly still gets `ok=true`.

## Testing

- `go test ./...` passes across the whole repo.
- New test `TestSystemBootDeviceSet_DetectsSupermicroSilentModeDowngrade`
  reproduces the real bug via fixtures and confirms it's now caught.
- New test `TestSystemBootDeviceSet_HappyPath` confirms no regression
  for BMCs that honor the request correctly.