### PR TITLE
feat: add per-database UEFI Secure Boot key reset and certificate import

### DIFF
--- a/bmc/secure_boot.go
+++ b/bmc/secure_boot.go
@@ -10,6 +10,36 @@ import (
 	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
 )
 
+// ResetSecureBootKeysType identifies the type of Secure Boot key reset to perform.
+type ResetSecureBootKeysType string
+
+// ResetSecureBootKeysType constants enumerate the supported reset types for the whole Secure Boot subsystem.
+const (
+	ResetSecureBootKeysTypeResetAllKeysToDefault ResetSecureBootKeysType = "ResetAllKeysToDefault"
+	ResetSecureBootKeysTypeDeleteAllKeys         ResetSecureBootKeysType = "DeleteAllKeys"
+	ResetSecureBootKeysTypeDeletePK              ResetSecureBootKeysType = "DeletePK"
+)
+
+// ResetSecureBootDatabaseKeysType identifies the type of per-database Secure Boot key reset to perform.
+type ResetSecureBootDatabaseKeysType string
+
+// ResetSecureBootDatabaseKeysType constants enumerate the supported reset types for a single Secure Boot database.
+const (
+	ResetSecureBootDatabaseKeysTypeResetAllKeysToDefault ResetSecureBootDatabaseKeysType = "ResetAllKeysToDefault"
+	ResetSecureBootDatabaseKeysTypeDeleteAllKeys         ResetSecureBootDatabaseKeysType = "DeleteAllKeys"
+)
+
+// SecureBootDatabase identifies a UEFI Secure Boot key database.
+type SecureBootDatabase string
+
+// SecureBootDatabase constants enumerate the supported Secure Boot key databases.
+const (
+	SecureBootDatabaseDB  SecureBootDatabase = "db"
+	SecureBootDatabaseKEK SecureBootDatabase = "KEK"
+	SecureBootDatabasePK  SecureBootDatabase = "PK"
+	SecureBootDatabaseDBX SecureBootDatabase = "dbx"
+)
+
 // SecureBootStateGetter provides retrieval of whether UEFI Secure Boot is enabled.
 type SecureBootStateGetter interface {
 	GetSecureBoot(ctx context.Context) (enabled bool, err error)
@@ -32,12 +62,36 @@ type secureBootSetterProvider struct {
 
 // SecureBootKeysResetter provides resetting the UEFI Secure Boot key databases.
 type SecureBootKeysResetter interface {
-	ResetSecureBootKeys(ctx context.Context, resetType string) (err error)
+	ResetSecureBootKeys(ctx context.Context, resetType ResetSecureBootKeysType) (err error)
 }
 
 type secureBootKeysResetterProvider struct {
 	name string
 	SecureBootKeysResetter
+}
+
+// SecureBootDatabaseKeysResetter provides resetting a single UEFI Secure Boot key
+// database (e.g. "db", "KEK"), leaving every other database - including PK -
+// untouched.
+type SecureBootDatabaseKeysResetter interface {
+	ResetSecureBootDatabaseKeys(ctx context.Context, database SecureBootDatabase, resetType ResetSecureBootDatabaseKeysType) (err error)
+}
+
+type secureBootDatabaseKeysResetterProvider struct {
+	name string
+	SecureBootDatabaseKeysResetter
+}
+
+// SecureBootCertificateImporter provides enrolling a certificate into a single
+// UEFI Secure Boot key database (e.g. "db", "KEK") without disturbing any
+// certificate already present.
+type SecureBootCertificateImporter interface {
+	ImportSecureBootCertificate(ctx context.Context, database SecureBootDatabase, certificatePEM string) (err error)
+}
+
+type secureBootCertificateImporterProvider struct {
+	name string
+	SecureBootCertificateImporter
 }
 
 func secureBootState(ctx context.Context, generic []secureBootStateGetterProvider) (enabled bool, metadata Metadata, err error) {
@@ -92,7 +146,7 @@ Loop:
 	return metadata, multierror.Append(err, errors.New("failure to set secure boot state"))
 }
 
-func resetSecureBootKeys(ctx context.Context, generic []secureBootKeysResetterProvider, resetType string) (metadata Metadata, err error) {
+func resetSecureBootKeys(ctx context.Context, generic []secureBootKeysResetterProvider, resetType ResetSecureBootKeysType) (metadata Metadata, err error) {
 	metadata = newMetadata()
 Loop:
 	for _, elem := range generic {
@@ -116,6 +170,58 @@ Loop:
 	}
 
 	return metadata, multierror.Append(err, errors.New("failure to reset secure boot keys"))
+}
+
+func resetSecureBootDatabaseKeys(ctx context.Context, generic []secureBootDatabaseKeysResetterProvider, database SecureBootDatabase, resetType ResetSecureBootDatabaseKeysType) (metadata Metadata, err error) {
+	metadata = newMetadata()
+Loop:
+	for _, elem := range generic {
+		if elem.SecureBootDatabaseKeysResetter == nil {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			err = multierror.Append(err, ctx.Err())
+			break Loop
+		default:
+			metadata.ProvidersAttempted = append(metadata.ProvidersAttempted, elem.name)
+			vErr := elem.ResetSecureBootDatabaseKeys(ctx, database, resetType)
+			if vErr != nil {
+				err = multierror.Append(err, errors.WithMessagef(vErr, "provider: %v", elem.name))
+				continue
+			}
+			metadata.SuccessfulProvider = elem.name
+			return metadata, nil
+		}
+	}
+
+	return metadata, multierror.Append(err, errors.New("failure to reset secure boot database keys"))
+}
+
+func importSecureBootCertificate(ctx context.Context, generic []secureBootCertificateImporterProvider, database SecureBootDatabase, certificatePEM string) (metadata Metadata, err error) {
+	metadata = newMetadata()
+Loop:
+	for _, elem := range generic {
+		if elem.SecureBootCertificateImporter == nil {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			err = multierror.Append(err, ctx.Err())
+			break Loop
+		default:
+			metadata.ProvidersAttempted = append(metadata.ProvidersAttempted, elem.name)
+			vErr := elem.ImportSecureBootCertificate(ctx, database, certificatePEM)
+			if vErr != nil {
+				err = multierror.Append(err, errors.WithMessagef(vErr, "provider: %v", elem.name))
+				continue
+			}
+			metadata.SuccessfulProvider = elem.name
+			return metadata, nil
+		}
+	}
+
+	return metadata, multierror.Append(err, errors.New("failure to import secure boot certificate"))
 }
 
 // GetSecureBootStateFromInterfaces returns whether UEFI Secure Boot is enabled using
@@ -182,7 +288,7 @@ func SetSecureBootFromInterfaces(ctx context.Context, generic []interface{}, ena
 
 // ResetSecureBootKeysFromInterfaces resets the UEFI Secure Boot key databases using
 // the first successful SecureBootKeysResetter implementation found in generic.
-func ResetSecureBootKeysFromInterfaces(ctx context.Context, generic []interface{}, resetType string) (metadata Metadata, err error) {
+func ResetSecureBootKeysFromInterfaces(ctx context.Context, generic []interface{}, resetType ResetSecureBootKeysType) (metadata Metadata, err error) {
 	implementations := make([]secureBootKeysResetterProvider, 0)
 	for _, elem := range generic {
 		if elem == nil {
@@ -209,4 +315,68 @@ func ResetSecureBootKeysFromInterfaces(ctx context.Context, generic []interface{
 	}
 
 	return resetSecureBootKeys(ctx, implementations, resetType)
+}
+
+// ResetSecureBootDatabaseKeysFromInterfaces resets a single UEFI Secure Boot key
+// database using the first successful SecureBootDatabaseKeysResetter
+// implementation found in generic.
+func ResetSecureBootDatabaseKeysFromInterfaces(ctx context.Context, generic []interface{}, database SecureBootDatabase, resetType ResetSecureBootDatabaseKeysType) (metadata Metadata, err error) {
+	implementations := make([]secureBootDatabaseKeysResetterProvider, 0)
+	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
+		temp := secureBootDatabaseKeysResetterProvider{name: getProviderName(elem)}
+		switch p := elem.(type) {
+		case SecureBootDatabaseKeysResetter:
+			temp.SecureBootDatabaseKeysResetter = p
+			implementations = append(implementations, temp)
+		default:
+			e := fmt.Sprintf("not a SecureBootDatabaseKeysResetter implementation: %T", p)
+			err = multierror.Append(err, errors.New(e))
+		}
+	}
+	if len(implementations) == 0 {
+		return metadata, multierror.Append(
+			err,
+			errors.Wrap(
+				bmclibErrs.ErrProviderImplementation,
+				("no SecureBootDatabaseKeysResetter implementations found"),
+			),
+		)
+	}
+
+	return resetSecureBootDatabaseKeys(ctx, implementations, database, resetType)
+}
+
+// ImportSecureBootCertificateFromInterfaces enrolls a certificate into a single
+// UEFI Secure Boot key database using the first successful
+// SecureBootCertificateImporter implementation found in generic.
+func ImportSecureBootCertificateFromInterfaces(ctx context.Context, generic []interface{}, database SecureBootDatabase, certificatePEM string) (metadata Metadata, err error) {
+	implementations := make([]secureBootCertificateImporterProvider, 0)
+	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
+		temp := secureBootCertificateImporterProvider{name: getProviderName(elem)}
+		switch p := elem.(type) {
+		case SecureBootCertificateImporter:
+			temp.SecureBootCertificateImporter = p
+			implementations = append(implementations, temp)
+		default:
+			e := fmt.Sprintf("not a SecureBootCertificateImporter implementation: %T", p)
+			err = multierror.Append(err, errors.New(e))
+		}
+	}
+	if len(implementations) == 0 {
+		return metadata, multierror.Append(
+			err,
+			errors.Wrap(
+				bmclibErrs.ErrProviderImplementation,
+				("no SecureBootCertificateImporter implementations found"),
+			),
+		)
+	}
+
+	return importSecureBootCertificate(ctx, implementations, database, certificatePEM)
 }

--- a/bmc/secure_boot_test.go
+++ b/bmc/secure_boot_test.go
@@ -37,11 +37,35 @@ type mockSecureBootKeysResetter struct {
 	err error
 }
 
-func (m *mockSecureBootKeysResetter) ResetSecureBootKeys(ctx context.Context, _ string) error {
+func (m *mockSecureBootKeysResetter) ResetSecureBootKeys(ctx context.Context, _ ResetSecureBootKeysType) error {
 	return m.err
 }
 
 func (m *mockSecureBootKeysResetter) Name() string {
+	return "mock"
+}
+
+type mockSecureBootDatabaseKeysResetter struct {
+	err error
+}
+
+func (m *mockSecureBootDatabaseKeysResetter) ResetSecureBootDatabaseKeys(ctx context.Context, _ SecureBootDatabase, _ ResetSecureBootDatabaseKeysType) error {
+	return m.err
+}
+
+func (m *mockSecureBootDatabaseKeysResetter) Name() string {
+	return "mock"
+}
+
+type mockSecureBootCertificateImporter struct {
+	err error
+}
+
+func (m *mockSecureBootCertificateImporter) ImportSecureBootCertificate(ctx context.Context, _ SecureBootDatabase, _ string) error {
+	return m.err
+}
+
+func (m *mockSecureBootCertificateImporter) Name() string {
 	return "mock"
 }
 
@@ -158,7 +182,87 @@ func TestResetSecureBootKeysFromInterfaces(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := ResetSecureBootKeysFromInterfaces(context.Background(), tt.generic, "ResetAllKeysToDefault")
+			_, err := ResetSecureBootKeysFromInterfaces(context.Background(), tt.generic, ResetSecureBootKeysTypeResetAllKeysToDefault)
+
+			if tt.errMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestResetSecureBootDatabaseKeysFromInterfaces(t *testing.T) {
+	testCases := []struct {
+		name    string
+		generic []interface{}
+		errMsg  string
+	}{
+		{
+			name:    "success",
+			generic: []interface{}{&mockSecureBootDatabaseKeysResetter{}},
+		},
+		{
+			name:    "not an implementation",
+			generic: []interface{}{&mockSecureBootStateGetter{}},
+			errMsg:  "no SecureBootDatabaseKeysResetter implementations found",
+		},
+		{
+			name:    "no implementations",
+			generic: []interface{}{},
+			errMsg:  "no SecureBootDatabaseKeysResetter implementations found",
+		},
+		{
+			name:    "error from resetter",
+			generic: []interface{}{&mockSecureBootDatabaseKeysResetter{err: errors.New("foobar")}},
+			errMsg:  "foobar",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ResetSecureBootDatabaseKeysFromInterfaces(context.Background(), tt.generic, SecureBootDatabaseDB, ResetSecureBootDatabaseKeysTypeResetAllKeysToDefault)
+
+			if tt.errMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestImportSecureBootCertificateFromInterfaces(t *testing.T) {
+	testCases := []struct {
+		name    string
+		generic []interface{}
+		errMsg  string
+	}{
+		{
+			name:    "success",
+			generic: []interface{}{&mockSecureBootCertificateImporter{}},
+		},
+		{
+			name:    "not an implementation",
+			generic: []interface{}{&mockSecureBootStateGetter{}},
+			errMsg:  "no SecureBootCertificateImporter implementations found",
+		},
+		{
+			name:    "no implementations",
+			generic: []interface{}{},
+			errMsg:  "no SecureBootCertificateImporter implementations found",
+		},
+		{
+			name:    "error from importer",
+			generic: []interface{}{&mockSecureBootCertificateImporter{err: errors.New("foobar")}},
+			errMsg:  "foobar",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ImportSecureBootCertificateFromInterfaces(context.Background(), tt.generic, SecureBootDatabaseDB, "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----")
 
 			if tt.errMsg == "" {
 				assert.NoError(t, err)

--- a/client.go
+++ b/client.go
@@ -695,13 +695,38 @@ func (c *Client) SetSecureBoot(ctx context.Context, enable bool) (err error) {
 	return err
 }
 
-// ResetSecureBootKeys resets the UEFI Secure Boot key databases. resetType is one
-// of ResetAllKeysToDefault, DeleteAllKeys, or DeletePK.
-func (c *Client) ResetSecureBootKeys(ctx context.Context, resetType string) (err error) {
+// ResetSecureBootKeys resets the UEFI Secure Boot key databases.
+func (c *Client) ResetSecureBootKeys(ctx context.Context, resetType bmc.ResetSecureBootKeysType) (err error) {
 	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "ResetSecureBootKeys")
 	defer span.End()
 
 	metadata, err := bmc.ResetSecureBootKeysFromInterfaces(ctx, c.registry().GetDriverInterfaces(), resetType)
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// ResetSecureBootDatabaseKeys resets a single UEFI Secure Boot key database,
+// leaving every other database - including PK - untouched.
+func (c *Client) ResetSecureBootDatabaseKeys(ctx context.Context, database bmc.SecureBootDatabase, resetType bmc.ResetSecureBootDatabaseKeysType) (err error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "ResetSecureBootDatabaseKeys")
+	defer span.End()
+
+	metadata, err := bmc.ResetSecureBootDatabaseKeysFromInterfaces(ctx, c.registry().GetDriverInterfaces(), database, resetType)
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return err
+}
+
+// ImportSecureBootCertificate enrolls a PEM-encoded certificate into a single
+// UEFI Secure Boot key database without disturbing any certificate already present.
+func (c *Client) ImportSecureBootCertificate(ctx context.Context, database bmc.SecureBootDatabase, certificatePEM string) (err error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "ImportSecureBootCertificate")
+	defer span.End()
+
+	metadata, err := bmc.ImportSecureBootCertificateFromInterfaces(ctx, c.registry().GetDriverInterfaces(), database, certificatePEM)
 	c.setMetadata(metadata)
 	metadata.RegisterSpanAttributes(c.Auth.Host, span)
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -127,6 +127,10 @@ var (
 
 	// ErrBMCUpdating is returned when the BMC is going through an update and will not serve other queries.
 	ErrBMCUpdating = errors.New("a BMC firmware update is in progress")
+
+	// ErrSecureBootDatabaseNotFound is returned when the requested UEFI Secure Boot key database
+	// (db, KEK, PK, dbx, ...) is not present in the SecureBootDatabases collection reported by the BMC.
+	ErrSecureBootDatabaseNotFound = errors.New("secure boot key database not found")
 )
 
 // ErrUnsupportedHardware is returned when an operation is attempted on unsupported hardware.

--- a/examples/secure-boot/doc.go
+++ b/examples/secure-boot/doc.go
@@ -1,0 +1,29 @@
+/*
+Package main provides an example of using the bmclib Secure Boot interfaces
+to get/set UEFI Secure Boot state and manage Secure Boot key databases.
+
+This example demonstrates:
+  - Getting the current Secure Boot state
+  - Enabling/disabling Secure Boot
+  - Resetting all Secure Boot keys
+  - Resetting a specific Secure Boot database
+  - Importing a certificate into a Secure Boot database
+
+Usage:
+
+	$ go run ./examples/secure-boot/main.go -h
+	Usage of ./main:
+	  -host string
+	        BMC hostname to connect to
+	  -password string
+	        Password to login with
+	  -user string
+	        Username to login with
+	  -cert string
+	        Path to PEM-encoded certificate file (for import mode)
+	  -database string
+	        Database for database-specific operations: db, KEK, PK, dbx (default "db")
+	  -mode string
+	        Mode [get,set,reset,reset-db,import] (default "get")
+*/
+package main

--- a/examples/secure-boot/main.go
+++ b/examples/secure-boot/main.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	logrusr "github.com/bombsimon/logrusr/v2"
+	"github.com/sirupsen/logrus"
+
+	bmclib "github.com/bmc-toolbox/bmclib/v2"
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+	"github.com/bmc-toolbox/bmclib/v2/providers"
+)
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	// Command line option flag parsing
+	user := flag.String("user", "", "Username to login with")
+	pass := flag.String("password", "", "Password to login with")
+	host := flag.String("host", "", "BMC hostname to connect to")
+	mode := flag.String("mode", "get", "Mode [get,set,reset,reset-db,import]")
+	database := flag.String("database", "db", "Database for database-specific operations: db, KEK, PK, dbx")
+	certFile := flag.String("cert", "", "Path to PEM-encoded certificate file (for import mode)")
+
+	flag.Parse()
+
+	// Logger configuration
+	l := logrus.New()
+	l.Level = logrus.DebugLevel
+	logger := logrusr.New(l)
+
+	// Validate required parameters
+	if *host == "" || *user == "" || *pass == "" {
+		l.Fatal("required host/user/pass parameters not defined")
+	}
+
+	// bmclib client abstraction
+	clientOpts := []bmclib.Option{bmclib.WithLogger(logger)}
+	client := bmclib.NewClient(*host, *user, *pass, clientOpts...)
+
+	// Filter to providers that support Secure Boot operations
+	client.Registry.Drivers = client.Registry.Supports(
+		providers.FeatureGetSecureBoot,
+		providers.FeatureSetSecureBoot,
+		providers.FeatureResetSecureBootKeys,
+		providers.FeatureResetSecureBootDatabaseKeys,
+		providers.FeatureImportSecureBootCertificate,
+	)
+
+	err := client.Open(ctx)
+	if err != nil {
+		l.Fatal(err, "bmc login failed")
+	}
+
+	defer func() { _ = client.Close(ctx) }()
+
+	// Operating mode selection
+	switch strings.ToLower(*mode) {
+	case "get":
+		// Get current Secure Boot state
+		enabled, err := client.GetSecureBoot(ctx)
+		if err != nil {
+			l.Fatal(err)
+		}
+
+		fmt.Printf("Secure Boot enabled: %v\n", enabled)
+
+	case "set":
+		// Enable Secure Boot
+		// To disable, use 'false' instead
+		err := client.SetSecureBoot(ctx, true)
+		if err != nil {
+			l.Fatal(err)
+		}
+
+		fmt.Println("Secure Boot enabled successfully")
+
+	case "reset":
+		// Reset all Secure Boot keys to default
+		err := client.ResetSecureBootKeys(ctx, bmc.ResetSecureBootKeysTypeResetAllKeysToDefault)
+		if err != nil {
+			l.Fatal(err)
+		}
+
+		fmt.Println("Secure Boot keys reset to default successfully")
+
+	case "reset-db":
+		// Reset a specific Secure Boot database
+		// Valid databases: db, KEK, PK, dbx
+		dbType := stringToSecureBootDatabase(*database)
+		if dbType == "" {
+			l.Fatalf("invalid database: %s (must be db, KEK, PK, or dbx)", *database)
+		}
+
+		err := client.ResetSecureBootDatabaseKeys(ctx, dbType, bmc.ResetSecureBootDatabaseKeysTypeResetAllKeysToDefault)
+		if err != nil {
+			l.Fatal(err)
+		}
+
+		fmt.Printf("Secure Boot database '%s' reset to default successfully\n", *database)
+
+	case "import":
+		// Import a certificate into a Secure Boot database
+		if *certFile == "" {
+			l.Fatal("certificate file required for import mode")
+		}
+
+		certData, err := os.ReadFile(*certFile)
+		if err != nil {
+			l.Fatal(err)
+		}
+
+		dbType := stringToSecureBootDatabase(*database)
+		if dbType == "" {
+			l.Fatalf("invalid database: %s (must be db or KEK)", *database)
+		}
+
+		err = client.ImportSecureBootCertificate(ctx, dbType, string(certData))
+		if err != nil {
+			l.Fatal(err)
+		}
+
+		fmt.Printf("Certificate imported to database '%s' successfully\n", *database)
+
+	default:
+		l.Fatalf("unknown mode: %s", *mode)
+	}
+}
+
+// stringToSecureBootDatabase converts a string to a SecureBootDatabase constant
+func stringToSecureBootDatabase(s string) bmc.SecureBootDatabase {
+	switch strings.ToLower(s) {
+	case "db":
+		return bmc.SecureBootDatabaseDB
+	case "kek":
+		return bmc.SecureBootDatabaseKEK
+	case "pk":
+		return bmc.SecureBootDatabasePK
+	case "dbx":
+		return bmc.SecureBootDatabaseDBX
+	default:
+		return ""
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
 	github.com/sirupsen/logrus v1.9.3
-	github.com/stmcginnis/gofish v0.22.0
+	github.com/stmcginnis/gofish v0.24.1-0.20260826144359-aa6a0d77e479
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.29.0
 	go.opentelemetry.io/otel/trace v1.29.0

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/stmcginnis/gofish v0.22.0 h1:OahXohfrIzAXOsWuKDQ7lm/QvdZBg1P2OzFYmbKAd/0=
-github.com/stmcginnis/gofish v0.22.0/go.mod h1:PzF5i8ecRG9A2ol8XT64npKUunyraJ+7t0kYMpQAtqU=
+github.com/stmcginnis/gofish v0.24.1-0.20260826144359-aa6a0d77e479 h1:FuKSjxinf+dN6TrYWzB6YsIJZdCQGU5KwFhmhHGfDSM=
+github.com/stmcginnis/gofish v0.24.1-0.20260826144359-aa6a0d77e479/go.mod h1:PzF5i8ecRG9A2ol8XT64npKUunyraJ+7t0kYMpQAtqU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/internal/redfishwrapper/fixtures/dell/secureboot.json
+++ b/internal/redfishwrapper/fixtures/dell/secureboot.json
@@ -7,6 +7,9 @@
     "SecureBootEnable": true,
     "SecureBootCurrentBoot": "Disabled",
     "SecureBootMode": "SetupMode",
+    "SecureBootDatabases": {
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot/SecureBootDatabases"
+    },
     "Actions": {
         "#SecureBoot.ResetKeys": {
             "target": "/redfish/v1/Systems/System.Embedded.1/SecureBoot/Actions/SecureBoot.ResetKeys",

--- a/internal/redfishwrapper/fixtures/dell/securebootdatabase.db.json
+++ b/internal/redfishwrapper/fixtures/dell/securebootdatabase.db.json
@@ -1,0 +1,16 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#SecureBootDatabase.SecureBootDatabase",
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot/SecureBootDatabases/db",
+    "@odata.type": "#SecureBootDatabase.v1_0_3.SecureBootDatabase",
+    "Id": "db",
+    "DatabaseId": "db",
+    "Name": "UEFI db",
+    "Certificates": {
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot/SecureBootDatabases/db/Certificates"
+    },
+    "Actions": {
+        "#SecureBootDatabase.ResetKeys": {
+            "target": "/redfish/v1/Systems/System.Embedded.1/SecureBoot/SecureBootDatabases/db/Actions/SecureBootDatabase.ResetKeys"
+        }
+    }
+}

--- a/internal/redfishwrapper/fixtures/dell/securebootdatabase_collection.json
+++ b/internal/redfishwrapper/fixtures/dell/securebootdatabase_collection.json
@@ -1,0 +1,12 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#SecureBootDatabaseCollection.SecureBootDatabaseCollection",
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot/SecureBootDatabases",
+    "@odata.type": "#SecureBootDatabaseCollection.SecureBootDatabaseCollection",
+    "Name": "UEFI Secure Boot Database Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot/SecureBootDatabases/db"
+        }
+    ]
+}

--- a/internal/redfishwrapper/secure_boot.go
+++ b/internal/redfishwrapper/secure_boot.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stmcginnis/gofish/schemas"
 
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
 	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
 )
 
@@ -22,6 +23,9 @@ func (c *Client) GetSecureBoot(ctx context.Context) (enabled bool, err error) {
 	secureBoot, err := sys.SecureBoot()
 	if err != nil {
 		return false, err
+	}
+	if secureBoot == nil {
+		return false, bmclibErrs.ErrRedfishVersionIncompatible
 	}
 
 	return secureBoot.SecureBootEnable, nil
@@ -43,15 +47,17 @@ func (c *Client) SetSecureBoot(ctx context.Context, enable bool) (err error) {
 	if err != nil {
 		return err
 	}
+	if secureBoot == nil {
+		return bmclibErrs.ErrRedfishVersionIncompatible
+	}
 
 	secureBoot.SecureBootEnable = enable
 
 	return secureBoot.Update()
 }
 
-// ResetSecureBootKeys resets the UEFI Secure Boot key databases. resetType is one
-// of ResetAllKeysToDefault, DeleteAllKeys, or DeletePK.
-func (c *Client) ResetSecureBootKeys(ctx context.Context, resetType string) (err error) {
+// ResetSecureBootKeys resets the UEFI Secure Boot key databases.
+func (c *Client) ResetSecureBootKeys(ctx context.Context, resetType bmc.ResetSecureBootKeysType) (err error) {
 	sys, err := c.System()
 	if err != nil {
 		return err
@@ -65,8 +71,73 @@ func (c *Client) ResetSecureBootKeys(ctx context.Context, resetType string) (err
 	if err != nil {
 		return err
 	}
+	if secureBoot == nil {
+		return bmclibErrs.ErrRedfishVersionIncompatible
+	}
 
 	_, err = secureBoot.ResetKeys(schemas.ResetKeysType(resetType))
+
+	return err
+}
+
+// secureBootDatabase returns the single UEFI Secure Boot key database matching
+// database from the SecureBootDatabases collection reported by the BMC.
+func (c *Client) secureBootDatabase(database bmc.SecureBootDatabase) (*schemas.SecureBootDatabase, error) {
+	sys, err := c.System()
+	if err != nil {
+		return nil, err
+	}
+
+	if !c.compatibleOdataID(sys.ODataID, knownSystemsOdataIDs) {
+		return nil, bmclibErrs.ErrRedfishSystemOdataID
+	}
+
+	secureBoot, err := sys.SecureBoot()
+	if err != nil {
+		return nil, err
+	}
+	if secureBoot == nil {
+		return nil, bmclibErrs.ErrRedfishVersionIncompatible
+	}
+
+	databases, err := secureBoot.SecureBootDatabases()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, db := range databases {
+		if db.DatabaseID == string(database) {
+			return db, nil
+		}
+	}
+
+	return nil, bmclibErrs.ErrSecureBootDatabaseNotFound
+}
+
+// ResetSecureBootDatabaseKeys resets a single UEFI Secure Boot key database
+// rather than the whole SecureBoot subsystem, leaving every other database -
+// including PK - untouched. DeletePK is not a valid per-database reset type.
+func (c *Client) ResetSecureBootDatabaseKeys(ctx context.Context, database bmc.SecureBootDatabase, resetType bmc.ResetSecureBootDatabaseKeysType) (err error) {
+	db, err := c.secureBootDatabase(database)
+	if err != nil {
+		return err
+	}
+
+	_, err = db.ResetKeys(schemas.SecureBootDatabaseResetKeysType(resetType))
+
+	return err
+}
+
+// ImportSecureBootCertificate enrolls a PEM-encoded certificate into a single
+// UEFI Secure Boot key database without disturbing any certificate already
+// present - it is additive, unlike ResetSecureBootDatabaseKeys.
+func (c *Client) ImportSecureBootCertificate(ctx context.Context, database bmc.SecureBootDatabase, certificatePEM string) (err error) {
+	db, err := c.secureBootDatabase(database)
+	if err != nil {
+		return err
+	}
+
+	_, err = db.AddCertificate(certificatePEM, schemas.PEMCertificateType, "")
 
 	return err
 }

--- a/internal/redfishwrapper/secure_boot_test.go
+++ b/internal/redfishwrapper/secure_boot_test.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
 )
 
 func newDellSecureBootClient(t *testing.T, mux *http.ServeMux) *Client {
@@ -80,7 +83,62 @@ func TestResetSecureBootKeys(t *testing.T) {
 	})
 	client := newDellSecureBootClient(t, mux)
 
-	err := client.ResetSecureBootKeys(context.Background(), "ResetAllKeysToDefault")
+	err := client.ResetSecureBootKeys(context.Background(), bmc.ResetSecureBootKeysTypeResetAllKeysToDefault)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, resetAttempts, "expected ResetSecureBootKeys to POST to the ResetKeys action once")
+}
+
+func TestResetSecureBootDatabaseKeys(t *testing.T) {
+	var resetAttempts int
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/SecureBoot", endpointFunc(t, "dell/secureboot.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/SecureBoot/SecureBootDatabases", endpointFunc(t, "dell/securebootdatabase_collection.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/SecureBoot/SecureBootDatabases/db", endpointFunc(t, "dell/securebootdatabase.db.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/SecureBoot/SecureBootDatabases/db/Actions/SecureBootDatabase.ResetKeys", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		resetAttempts++
+		w.WriteHeader(http.StatusNoContent)
+	})
+	client := newDellSecureBootClient(t, mux)
+
+	err := client.ResetSecureBootDatabaseKeys(context.Background(), bmc.SecureBootDatabaseDB, bmc.ResetSecureBootDatabaseKeysTypeResetAllKeysToDefault)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, resetAttempts, "expected ResetSecureBootDatabaseKeys to POST to the database's ResetKeys action once")
+}
+
+func TestResetSecureBootDatabaseKeysNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/SecureBoot", endpointFunc(t, "dell/secureboot.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/SecureBoot/SecureBootDatabases", endpointFunc(t, "dell/securebootdatabase_collection.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/SecureBoot/SecureBootDatabases/db", endpointFunc(t, "dell/securebootdatabase.db.json"))
+	client := newDellSecureBootClient(t, mux)
+
+	err := client.ResetSecureBootDatabaseKeys(context.Background(), bmc.SecureBootDatabaseKEK, bmc.ResetSecureBootDatabaseKeysTypeResetAllKeysToDefault)
+	assert.ErrorIs(t, err, bmclibErrs.ErrSecureBootDatabaseNotFound)
+}
+
+func TestImportSecureBootCertificate(t *testing.T) {
+	var importAttempts int
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/SecureBoot", endpointFunc(t, "dell/secureboot.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/SecureBoot/SecureBootDatabases", endpointFunc(t, "dell/securebootdatabase_collection.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/SecureBoot/SecureBootDatabases/db", endpointFunc(t, "dell/securebootdatabase.db.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/SecureBoot/SecureBootDatabases/db/Certificates", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		importAttempts++
+		w.WriteHeader(http.StatusNoContent)
+	})
+	client := newDellSecureBootClient(t, mux)
+
+	err := client.ImportSecureBootCertificate(context.Background(), bmc.SecureBootDatabaseDB, "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, importAttempts, "expected ImportSecureBootCertificate to POST to the database's Certificates collection once")
 }

--- a/providers/dell/idrac.go
+++ b/providers/dell/idrac.go
@@ -51,6 +51,8 @@ var (
 		providers.FeatureGetSecureBoot,
 		providers.FeatureSetSecureBoot,
 		providers.FeatureResetSecureBootKeys,
+		providers.FeatureResetSecureBootDatabaseKeys,
+		providers.FeatureImportSecureBootCertificate,
 	}
 
 	errManufacturerUnknown = errors.New("error identifying device manufacturer")
@@ -265,8 +267,18 @@ func (c *Conn) SetSecureBoot(ctx context.Context, enable bool) (err error) {
 }
 
 // ResetSecureBootKeys resets the UEFI Secure Boot key databases
-func (c *Conn) ResetSecureBootKeys(ctx context.Context, resetType string) (err error) {
+func (c *Conn) ResetSecureBootKeys(ctx context.Context, resetType bmc.ResetSecureBootKeysType) (err error) {
 	return c.redfishwrapper.ResetSecureBootKeys(ctx, resetType)
+}
+
+// ResetSecureBootDatabaseKeys resets a single UEFI Secure Boot key database
+func (c *Conn) ResetSecureBootDatabaseKeys(ctx context.Context, database bmc.SecureBootDatabase, resetType bmc.ResetSecureBootDatabaseKeysType) (err error) {
+	return c.redfishwrapper.ResetSecureBootDatabaseKeys(ctx, database, resetType)
+}
+
+// ImportSecureBootCertificate enrolls a certificate into a single UEFI Secure Boot key database
+func (c *Conn) ImportSecureBootCertificate(ctx context.Context, database bmc.SecureBootDatabase, certificatePEM string) (err error) {
+	return c.redfishwrapper.ImportSecureBootCertificate(ctx, database, certificatePEM)
 }
 
 // SendNMI tells the BMC to issue an NMI to the device

--- a/providers/lenovo/lenovo.go
+++ b/providers/lenovo/lenovo.go
@@ -80,6 +80,8 @@ var Features = registrar.Features{
 	providers.FeatureGetSecureBoot,
 	providers.FeatureSetSecureBoot,
 	providers.FeatureResetSecureBootKeys,
+	providers.FeatureResetSecureBootDatabaseKeys,
+	providers.FeatureImportSecureBootCertificate,
 	// inventory-storage
 	providers.FeatureInventoryRead,
 	// firmware-tasks

--- a/providers/lenovo/power_boot_bios_test.go
+++ b/providers/lenovo/power_boot_bios_test.go
@@ -3,6 +3,8 @@ package lenovo
 import (
 	"context"
 	"testing"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
 )
 
 // Requirement: Power state read.
@@ -229,7 +231,7 @@ func TestResetSecureBootKeys(t *testing.T) {
 	ts := newTestServer(t, testServerOpts{})
 	c := ts.openedClient(t)
 
-	if err := c.ResetSecureBootKeys(context.Background(), "ResetAllKeysToDefault"); err != nil {
+	if err := c.ResetSecureBootKeys(context.Background(), bmc.ResetSecureBootKeysTypeResetAllKeysToDefault); err != nil {
 		t.Fatalf("ResetSecureBootKeys: %v", err)
 	}
 	if !ts.didResetSecureBootKeys() {

--- a/providers/lenovo/secure_boot.go
+++ b/providers/lenovo/secure_boot.go
@@ -2,6 +2,8 @@ package lenovo
 
 import (
 	"context"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
 )
 
 // GetSecureBoot returns whether UEFI Secure Boot is currently enabled.
@@ -21,6 +23,20 @@ func (c *Conn) SetSecureBoot(ctx context.Context, enable bool) (err error) {
 // ResetSecureBootKeys resets the UEFI Secure Boot key databases.
 //
 // Implements bmc.SecureBootKeysResetter.
-func (c *Conn) ResetSecureBootKeys(ctx context.Context, resetType string) (err error) {
+func (c *Conn) ResetSecureBootKeys(ctx context.Context, resetType bmc.ResetSecureBootKeysType) (err error) {
 	return c.redfishwrapper.ResetSecureBootKeys(ctx, resetType)
+}
+
+// ResetSecureBootDatabaseKeys resets a single UEFI Secure Boot key database.
+//
+// Implements bmc.SecureBootDatabaseKeysResetter.
+func (c *Conn) ResetSecureBootDatabaseKeys(ctx context.Context, database bmc.SecureBootDatabase, resetType bmc.ResetSecureBootDatabaseKeysType) (err error) {
+	return c.redfishwrapper.ResetSecureBootDatabaseKeys(ctx, database, resetType)
+}
+
+// ImportSecureBootCertificate enrolls a certificate into a single UEFI Secure Boot key database.
+//
+// Implements bmc.SecureBootCertificateImporter.
+func (c *Conn) ImportSecureBootCertificate(ctx context.Context, database bmc.SecureBootDatabase, certificatePEM string) (err error) {
+	return c.redfishwrapper.ImportSecureBootCertificate(ctx, database, certificatePEM)
 }

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -88,4 +88,10 @@ const (
 
 	// FeatureResetSecureBootKeys means an implementation that can reset the UEFI Secure Boot key databases
 	FeatureResetSecureBootKeys registrar.Feature = "resetsecurebootkeys"
+
+	// FeatureResetSecureBootDatabaseKeys means an implementation that can reset a single UEFI Secure Boot key database
+	FeatureResetSecureBootDatabaseKeys registrar.Feature = "resetsecurebootdatabasekeys"
+
+	// FeatureImportSecureBootCertificate means an implementation that can enroll a certificate into a single UEFI Secure Boot key database
+	FeatureImportSecureBootCertificate registrar.Feature = "importsecurebootcertificate"
 )

--- a/providers/redfish/redfish.go
+++ b/providers/redfish/redfish.go
@@ -43,6 +43,8 @@ var Features = registrar.Features{
 	providers.FeatureGetSecureBoot,
 	providers.FeatureSetSecureBoot,
 	providers.FeatureResetSecureBootKeys,
+	providers.FeatureResetSecureBootDatabaseKeys,
+	providers.FeatureImportSecureBootCertificate,
 }
 
 // compile-time assertions that the provider implements the BIOS configuration interfaces.
@@ -267,8 +269,18 @@ func (c *Conn) SetSecureBoot(ctx context.Context, enable bool) (err error) {
 }
 
 // ResetSecureBootKeys resets the UEFI Secure Boot key databases
-func (c *Conn) ResetSecureBootKeys(ctx context.Context, resetType string) (err error) {
+func (c *Conn) ResetSecureBootKeys(ctx context.Context, resetType bmc.ResetSecureBootKeysType) (err error) {
 	return c.redfishwrapper.ResetSecureBootKeys(ctx, resetType)
+}
+
+// ResetSecureBootDatabaseKeys resets a single UEFI Secure Boot key database
+func (c *Conn) ResetSecureBootDatabaseKeys(ctx context.Context, database bmc.SecureBootDatabase, resetType bmc.ResetSecureBootDatabaseKeysType) (err error) {
+	return c.redfishwrapper.ResetSecureBootDatabaseKeys(ctx, database, resetType)
+}
+
+// ImportSecureBootCertificate enrolls a certificate into a single UEFI Secure Boot key database
+func (c *Conn) ImportSecureBootCertificate(ctx context.Context, database bmc.SecureBootDatabase, certificatePEM string) (err error) {
+	return c.redfishwrapper.ImportSecureBootCertificate(ctx, database, certificatePEM)
 }
 
 // SendNMI tells the BMC to issue an NMI to the device

--- a/providers/supermicro/supermicro.go
+++ b/providers/supermicro/supermicro.go
@@ -63,6 +63,8 @@ var Features = registrar.Features{
 	providers.FeatureGetSecureBoot,
 	providers.FeatureSetSecureBoot,
 	providers.FeatureResetSecureBootKeys,
+	providers.FeatureResetSecureBootDatabaseKeys,
+	providers.FeatureImportSecureBootCertificate,
 }
 
 // supports
@@ -707,12 +709,30 @@ func (c *Client) SetSecureBoot(ctx context.Context, enable bool) (err error) {
 }
 
 // ResetSecureBootKeys resets the UEFI Secure Boot key databases
-func (c *Client) ResetSecureBootKeys(ctx context.Context, resetType string) (err error) {
+func (c *Client) ResetSecureBootKeys(ctx context.Context, resetType bmc.ResetSecureBootKeysType) (err error) {
 	if c.serviceClient == nil || c.serviceClient.redfish == nil {
 		return errors.Wrap(bmclibErrs.ErrLoginFailed, "client not initialized")
 	}
 
 	return c.serviceClient.redfish.ResetSecureBootKeys(ctx, resetType)
+}
+
+// ResetSecureBootDatabaseKeys resets a single UEFI Secure Boot key database
+func (c *Client) ResetSecureBootDatabaseKeys(ctx context.Context, database bmc.SecureBootDatabase, resetType bmc.ResetSecureBootDatabaseKeysType) (err error) {
+	if c.serviceClient == nil || c.serviceClient.redfish == nil {
+		return errors.Wrap(bmclibErrs.ErrLoginFailed, "client not initialized")
+	}
+
+	return c.serviceClient.redfish.ResetSecureBootDatabaseKeys(ctx, database, resetType)
+}
+
+// ImportSecureBootCertificate enrolls a certificate into a single UEFI Secure Boot key database
+func (c *Client) ImportSecureBootCertificate(ctx context.Context, database bmc.SecureBootDatabase, certificatePEM string) (err error) {
+	if c.serviceClient == nil || c.serviceClient.redfish == nil {
+		return errors.Wrap(bmclibErrs.ErrLoginFailed, "client not initialized")
+	}
+
+	return c.serviceClient.redfish.ImportSecureBootCertificate(ctx, database, certificatePEM)
 }
 
 // SendNMI tells the BMC to issue an NMI to the device


### PR DESCRIPTION
## What does this PR implement/change/remove?

Extends the SecureBoot support added in #457 with per-database operations, newly possible now that gofish's `SecureBootDatabase` gained `AddCertificate`/`AddSignature` (stmcginnis/gofish#561). Unlike the whole-subsystem `ResetSecureBootKeys`, these target a single database (e.g. `db`, `KEK`) without touching `PK` - the mechanism a caller needs to enroll a custom certificate into `db`/`KEK` while leaving an already-provisioned `PK` (and whatever Setup Mode state it implies) alone.

Adds the same three-layer bmclib capability as #457, wired into the same four providers:
- `internal/redfishwrapper`: `ResetSecureBootDatabaseKeys`/`ImportSecureBootCertificate`, finding the target database by `DatabaseID` in the `SecureBootDatabases` collection.
- `bmc`: `SecureBootDatabaseKeysResetter`/`SecureBootCertificateImporter` interfaces with the usual `FromInterfaces` dispatch.
- `Client.ResetSecureBootDatabaseKeys`/`ImportSecureBootCertificate` passthroughs.

Wired into every provider that embeds `redfishwrapper.Client` - `redfish` (generic), `dell`, `supermicro`, and `lenovo` - plus new `Feature*` constants (`FeatureResetSecureBootDatabaseKeys`, `FeatureImportSecureBootCertificate`) on each, matching how `GetSecureBoot`/`SetSecureBoot`/`ResetSecureBootKeys` are already exposed at each provider layer.

Bumps gofish to a pseudo-version pinned to the `AddCertificate`/`AddSignature` commit (`stmcginnis/gofish@aa6a0d7`), ahead of the next tagged release - happy to hold this until a real gofish tag exists if you'd prefer.

### Checklist
- [x] Tests added
- [x] Similar commits squashed

### The HW vendor this change applies to (if applicable)
Any BMC reached via the generic Redfish, Dell, Supermicro, or Lenovo XCC provider - currently verified end-to-end against real Dell hardware (iDRAC); Supermicro/Lenovo firmware doesn't yet expose `SecureBootDatabases` in our testing, so they'll pick this up automatically once their firmware does.

### The HW model number, product name this change applies to (if applicable)
N/A - generic Redfish `SecureBootDatabase`/`Certificates` resources, not vendor-specific.

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)
Requires the Redfish `SecureBoot.v1_1_x` `SecureBootDatabases` resource collection with a working `Certificates` POST - confirmed present on Dell iDRAC (`SecureBoot.v1_1_2`). Not yet present on the Supermicro/Lenovo firmware we tested against.

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)
gofish `>= aa6a0d7` (`stmcginnis/gofish#561`, `SecureBootDatabase.AddCertificate`/`AddSignature`) - not in a tagged release yet.

## Description for changelog/release notes

```
Add ResetSecureBootDatabaseKeys/ImportSecureBootCertificate support for the redfish, dell, supermicro, and lenovo providers.
```