### PR TITLE
feat: add BootDeviceSet to the Dell provider

### DIFF
--- a/providers/dell/boot.go
+++ b/providers/dell/boot.go
@@ -1,0 +1,34 @@
+package dell
+
+import (
+	"context"
+
+	"github.com/bmc-toolbox/bmclib/v2/bmc"
+)
+
+// BootDeviceSet sets the next boot device by writing the ComputerSystem Boot
+// override.
+//
+// bootDevice is a bmclib boot-device name (e.g. "pxe", "disk", "cdrom",
+// "bios"). setPersistent selects BootSourceOverrideEnabled "Continuous" when
+// true and "Once" otherwise; efiBoot selects BootSourceOverrideMode "UEFI"
+// when true and "Legacy" otherwise. Implements bmc.BootDeviceSetter.
+//
+// On iDRAC10, Boot is read-only on the main ComputerSystem resource and must
+// be set via its @Redfish.Settings resource instead; on iDRAC9 and earlier,
+// Boot is writable directly and the Settings resource only advertises a
+// subset of Boot properties (observed: BootSourceOverrideMode, not Target or
+// Enabled). As of gofish v0.22.0, the underlying SetBoot call tries the main
+// resource first and falls back to Settings on rejection, which handles both
+// generations without a version check here.
+func (c *Conn) BootDeviceSet(ctx context.Context, bootDevice string, setPersistent, efiBoot bool) (ok bool, err error) {
+	return c.redfishwrapper.SystemBootDeviceSet(ctx, bootDevice, setPersistent, efiBoot)
+}
+
+// BootDeviceOverrideGet returns the current boot override (target,
+// persistence, UEFI/legacy mode) read from the ComputerSystem Boot object.
+//
+// Implements bmc.BootDeviceOverrideGetter.
+func (c *Conn) BootDeviceOverrideGet(ctx context.Context) (override bmc.BootDeviceOverride, err error) {
+	return c.redfishwrapper.GetBootDeviceOverride(ctx)
+}

--- a/providers/dell/boot_test.go
+++ b/providers/dell/boot_test.go
@@ -1,0 +1,95 @@
+package dell
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBootDeviceSet_DirectWrite verifies BootDeviceSet against a fixture with
+// no @Redfish.Settings (iDRAC 7.x-9.x style): the PATCH must go directly to
+// the main ComputerSystem resource and succeed in a single request.
+func TestBootDeviceSet_DirectWrite(t *testing.T) {
+	var patched bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/", endpointFunc("/serviceroot.json"))
+	mux.HandleFunc("/redfish/v1/Systems", endpointFunc("/systems.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			patched = true
+			body, _ := io.ReadAll(r.Body)
+			assert.Contains(t, string(body), "Pxe")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		endpointFunc("/systems_embedded.1.json")(w, r)
+	})
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := New(parsedURL.Hostname(), "", "", logr.Discard(), WithPort(parsedURL.Port()), WithUseBasicAuth(true))
+	require.NoError(t, client.Open(context.Background()))
+	defer client.Close(context.Background())
+
+	ok, err := client.BootDeviceSet(context.Background(), "pxe", false, true)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.True(t, patched, "expected a PATCH to the main ComputerSystem resource")
+}
+
+// TestBootDeviceSet_SettingsFallback verifies BootDeviceSet against a fixture
+// advertising @Redfish.Settings where the main resource rejects Boot writes
+// (iDRAC10 style): the PATCH to the main resource must fail, and BootDeviceSet
+// must still succeed by falling back to the Settings resource.
+func TestBootDeviceSet_SettingsFallback(t *testing.T) {
+	var settingsPatched bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/", endpointFunc("/serviceroot.json"))
+	mux.HandleFunc("/redfish/v1/Systems", endpointFunc("/systems.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"code":"Base.1.0.GeneralError","message":"Boot is a read-only property"}}`))
+			return
+		}
+		endpointFunc("/systems_embedded_idrac10.1.json")(w, r)
+	})
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/Settings", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			settingsPatched = true
+			body, _ := io.ReadAll(r.Body)
+			assert.Contains(t, string(body), "Pxe")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		endpointFunc("/systems_embedded_idrac10.1.json")(w, r)
+	})
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := New(parsedURL.Hostname(), "", "", logr.Discard(), WithPort(parsedURL.Port()), WithUseBasicAuth(true))
+	require.NoError(t, client.Open(context.Background()))
+	defer client.Close(context.Background())
+
+	ok, err := client.BootDeviceSet(context.Background(), "pxe", false, true)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.True(t, settingsPatched, "expected a fallback PATCH to the Settings resource")
+}

--- a/providers/dell/fixtures/systems_embedded_idrac10.1.json
+++ b/providers/dell/fixtures/systems_embedded_idrac10.1.json
@@ -1,0 +1,533 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1",
+    "@odata.type": "#ComputerSystem.v1_12_0.ComputerSystem",
+    "Actions": {
+        "#ComputerSystem.Reset": {
+            "target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+            "ResetType@Redfish.AllowableValues": [
+                "On",
+                "ForceOff",
+                "ForceRestart",
+                "GracefulRestart",
+                "GracefulShutdown",
+                "PushPowerButton",
+                "Nmi",
+                "PowerCycle"
+            ]
+        }
+    },
+    "AssetTag": "",
+    "Bios": {
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"
+    },
+    "BiosVersion": "2.6.6",
+    "Boot": {
+        "BootOptions": {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootOptions"
+        },
+        "Certificates": {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Boot/Certificates"
+        },
+        "BootOrder": [
+            "HardDisk.List.1-1",
+            "NIC.Slot.3-1-1"
+        ],
+        "BootOrder@odata.count": 2,
+        "BootSourceOverrideEnabled": "Disabled",
+        "BootSourceOverrideMode": "Legacy",
+        "BootSourceOverrideTarget": "None",
+        "UefiTargetBootSourceOverride": null,
+        "BootSourceOverrideTarget@Redfish.AllowableValues": [
+            "None",
+            "Pxe",
+            "Floppy",
+            "Cd",
+            "Hdd",
+            "BiosSetup",
+            "Utilities",
+            "UefiTarget",
+            "SDCard",
+            "UefiHttp"
+        ]
+    },
+    "Description": "Computer System which represents a machine (physical or virtual) and the local resources such as memory, cpu and other devices that can be accessed from that machine.",
+    "EthernetInterfaces": {
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"
+    },
+    "HostName": "foobaz",
+    "HostWatchdogTimer": {
+        "FunctionEnabled": false,
+        "Status": {
+            "State": "Disabled"
+        },
+        "TimeoutAction": "None"
+    },
+    "HostingRoles": [],
+    "HostingRoles@odata.count": 0,
+    "Id": "System.Embedded.1",
+    "IndicatorLED": "Lit",
+    "Links": {
+        "Chassis": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1"
+            }
+        ],
+        "Chassis@odata.count": 1,
+        "CooledBy": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/0"
+            },
+            {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/1"
+            },
+            {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/2"
+            },
+            {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/3"
+            },
+            {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/4"
+            },
+            {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/5"
+            },
+            {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/6"
+            },
+            {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/7"
+            },
+            {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/8"
+            },
+            {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/9"
+            },
+            {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/10"
+            },
+            {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/11"
+            }
+        ],
+        "CooledBy@odata.count": 12,
+        "ManagedBy": [
+            {
+                "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"
+            }
+        ],
+        "ManagedBy@odata.count": 1,
+        "Oem": {
+            "Dell": {
+                "@odata.type": "#DellOem.v1_2_0.DellOemLinks",
+                "BootOrder": {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellBootSources"
+                },
+                "DellBootSources": {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellBootSources"
+                },
+                "DellSoftwareInstallationService": {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellSoftwareInstallationService"
+                },
+                "DellVideoCollection": {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellVideo"
+                },
+                "DellChassisCollection": {
+                    "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Oem/Dell/DellChassis"
+                },
+                "DellPresenceAndStatusSensorCollection": {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellPresenceAndStatusSensors"
+                },
+                "DellSensorCollection": {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellSensors"
+                },
+                "DellRollupStatusCollection": {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellRollupStatus"
+                },
+                "DellPSNumericSensorCollection": {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellPSNumericSensors"
+                },
+                "DellVideoNetworkCollection": {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellVideoNetwork"
+                },
+                "DellOSDeploymentService": {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService"
+                },
+                "DellMetricService": {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellMetricService"
+                },
+                "DellGPUSensorCollection": {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellGPUSensors"
+                },
+                "DellRaidService": {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellRaidService"
+                },
+                "DellNumericSensorCollection": {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellNumericSensors"
+                },
+                "DellBIOSService": {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellBIOSService"
+                },
+                "DellSlotCollection": {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellSlots"
+                }
+            }
+        },
+        "PoweredBy": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Power#/PowerSupplies/0"
+            },
+            {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Power#/PowerSupplies/1"
+            }
+        ],
+        "PoweredBy@odata.count": 2
+    },
+    "Manufacturer": "Dell Inc.",
+    "Memory": {
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Memory"
+    },
+    "MemorySummary": {
+        "MemoryMirroring": "System",
+        "Status": {
+            "Health": "OK",
+            "HealthRollup": "OK",
+            "State": "Enabled"
+        },
+        "TotalSystemMemoryGiB": 256
+    },
+    "Model": "PowerEdge R6715",
+    "Name": "System",
+    "NetworkInterfaces": {
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1/NetworkInterfaces"
+    },
+    "Oem": {
+        "Dell": {
+            "@odata.type": "#DellOem.v1_2_0.DellOemResources",
+            "DellSystem": {
+                "BIOSReleaseDate": "01/13/2022",
+                "BaseBoardChassisSlot": "NA",
+                "BatteryRollupStatus": "OK",
+                "BladeGeometry": "NotApplicable",
+                "CMCIP": null,
+                "CPURollupStatus": "OK",
+                "ChassisModel": "",
+                "ChassisName": "Main System Chassis",
+                "ChassisServiceTag": "FOOBAR",
+                "ChassisSystemHeightUnit": 1,
+                "CurrentRollupStatus": "OK",
+                "EstimatedExhaustTemperatureCelsius": 255,
+                "EstimatedSystemAirflowCFM": 255,
+                "ExpressServiceCode": "1234567819",
+                "FanRollupStatus": "OK",
+                "Id": "System.Embedded.1",
+                "IDSDMRollupStatus": null,
+                "IntrusionRollupStatus": "OK",
+                "IsOEMBranded": "False",
+                "LastSystemInventoryTime": "2023-04-28T04:00:49+00:00",
+                "LastUpdateTime": "2022-10-11T21:35:12+00:00",
+                "LicensingRollupStatus": "OK",
+                "ManagedSystemSize": "1 U",
+                "MaxCPUSockets": 1,
+                "MaxDIMMSlots": 16,
+                "MaxPCIeSlots": 5,
+                "MemoryOperationMode": "OptimizerMode",
+                "Name": "DellSystem",
+                "NodeID": "FOOBAR",
+                "PSRollupStatus": "OK",
+                "PlatformGUID": "33435a4f-c0c6-4780-5210-00304c4c4544",
+                "PopulatedDIMMSlots": 8,
+                "PopulatedPCIeSlots": 2,
+                "PowerCapEnabledState": "Disabled",
+                "SDCardRollupStatus": null,
+                "SELRollupStatus": "OK",
+                "ServerAllocationWatts": null,
+                "StorageRollupStatus": "OK",
+                "SysMemErrorMethodology": "Multi-bitECC",
+                "SysMemFailOverState": "NotInUse",
+                "SysMemLocation": "SystemBoardOrMotherboard",
+                "SysMemPrimaryStatus": "OK",
+                "SystemGeneration": "17G Monolithic",
+                "SystemID": 2300,
+                "SystemRevision": "I",
+                "TempRollupStatus": "OK",
+                "TempStatisticsRollupStatus": "OK",
+                "UUID": "4c4c4544-0030-5210-8047-c6c04f5a4333",
+                "VoltRollupStatus": "OK",
+                "smbiosGUID": "44454c4c-3000-1052-8047-c6c04f5a4333",
+                "@odata.context": "/redfish/v1/$metadata#DellSystem.DellSystem",
+                "@odata.type": "#DellSystem.v1_3_0.DellSystem",
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellSystem/System.Embedded.1"
+            }
+        }
+    },
+    "PCIeDevices": [
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/0-3"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/0-2"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/0-4"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/0-7"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/0-1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/0-20"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/0-8"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/70-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/65-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/69-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/192-2"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/192-1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/194-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/4-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/192-3"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/192-4"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/192-8"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/192-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/192-7"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/1-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/128-3"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/128-2"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/72-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/128-4"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/128-7"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/128-1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/128-8"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/64-3"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/64-2"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/64-4"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/64-7"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/64-1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/64-8"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/195-0"
+        }
+    ],
+    "PCIeDevices@odata.count": 34,
+    "PCIeFunctions": [
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/0-3/PCIeFunctions/0-3-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/0-2/PCIeFunctions/0-2-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/0-4/PCIeFunctions/0-4-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/0-7/PCIeFunctions/0-7-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/0-1/PCIeFunctions/0-1-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/0-20/PCIeFunctions/0-20-3"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/0-8/PCIeFunctions/0-8-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/0-20/PCIeFunctions/0-20-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/70-0/PCIeFunctions/70-0-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/65-0/PCIeFunctions/65-0-1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/65-0/PCIeFunctions/65-0-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/69-0/PCIeFunctions/69-0-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/192-2/PCIeFunctions/192-2-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/192-1/PCIeFunctions/192-1-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/194-0/PCIeFunctions/194-0-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/4-0/PCIeFunctions/4-0-3"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/192-3/PCIeFunctions/192-3-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/192-4/PCIeFunctions/192-4-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/192-8/PCIeFunctions/192-8-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/192-0/PCIeFunctions/192-0-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/192-7/PCIeFunctions/192-7-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/1-0/PCIeFunctions/1-0-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/128-3/PCIeFunctions/128-3-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/128-2/PCIeFunctions/128-2-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/72-0/PCIeFunctions/72-0-3"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/128-4/PCIeFunctions/128-4-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/128-7/PCIeFunctions/128-7-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/128-1/PCIeFunctions/128-1-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/128-8/PCIeFunctions/128-8-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/64-3/PCIeFunctions/64-3-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/64-2/PCIeFunctions/64-2-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/64-4/PCIeFunctions/64-4-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/64-7/PCIeFunctions/64-7-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/64-1/PCIeFunctions/64-1-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/64-8/PCIeFunctions/64-8-0"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/195-0/PCIeFunctions/195-0-0"
+        }
+    ],
+    "PCIeFunctions@odata.count": 36,
+    "PartNumber": "07PXPYA01",
+    "PowerState": "On",
+    "ProcessorSummary": {
+        "Count": 1,
+        "LogicalProcessorCount": 32,
+        "Model": "AMD EPYC 7502P 32-Core Processor",
+        "Status": {
+            "Health": "OK",
+            "HealthRollup": "OK",
+            "State": "Enabled"
+        }
+    },
+    "Processors": {
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"
+    },
+    "SKU": "FOOBAR",
+    "SecureBoot": {
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"
+    },
+    "SerialNumber": "FOOBAR123",
+    "SimpleStorage": {
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SimpleStorage"
+    },
+    "Status": {
+        "Health": "OK",
+        "HealthRollup": "OK",
+        "State": "Enabled"
+    },
+    "Storage": {
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage"
+    },
+    "SystemType": "Physical",
+    "TrustedModules": [
+        {
+            "FirmwareVersion": "1.3.2.8",
+            "InterfaceType": "TPM2_0",
+            "Status": {
+                "State": "Enabled"
+            }
+        }
+    ],
+    "TrustedModules@odata.count": 1,
+    "UUID": "4c4c4544-0030-5210-8047-c6c04f5a4333",
+    "@Redfish.Settings": {
+        "SettingsObject": {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Settings"
+        },
+        "SupportedApplyTimes": [
+            "OnReset"
+        ]
+    }
+}

--- a/providers/dell/idrac.go
+++ b/providers/dell/idrac.go
@@ -40,6 +40,7 @@ var (
 		providers.FeatureScreenshot,
 		providers.FeaturePowerState,
 		providers.FeaturePowerSet,
+		providers.FeatureBootDeviceSet,
 		providers.FeatureFirmwareInstallSteps,
 		providers.FeatureFirmwareUploadInitiateInstall,
 		providers.FeatureFirmwareTaskStatus,


### PR DESCRIPTION
## What does this PR implement/change/remove?

Dell provider has no `BootDeviceSet`, so it's never a candidate for boot-device actions in bmclib's dispatch — always falls through to IPMI. On iDRAC10, IPMI reports success but the one-time boot override doesn't actually apply. On iDRAC9 IPMI works fine, so this was silent and generation-specific.

Adds `BootDeviceSet`/`BootDeviceOverrideGet` to the Dell provider, same pattern as `lenovo` and generic `redfish` — delegates to `redfishwrapper.SystemBootDeviceSet`, which already tries the main resource first and falls back to `@Redfish.Settings` on rejection (iDRAC10's `Boot` is read-only there). iDRAC9 never hits the fallback.

Confirmed live on both generations:
```
iDRAC10 (R6715, 1.20.80.50):  PATCH /Systems/System.Embedded.1        -> 400 PropertyNotWritable
                               PATCH /Systems/System.Embedded.1/Settings -> 200 Success
iDRAC9  (R760xd2, 7.30.10.50): PATCH /Systems/System.Embedded.1        -> 200 Success
```

Also ran this through Tinkerbell/Rufio end to end on both units: `dell` handles the boot device set, PXE boot happens, IPMI never gets touched.

### Checklist
- [x] Tests added
- [x] Similar commits squashed

### The HW vendor this change applies to (if applicable)
Dell, iDRAC10 (17G) and iDRAC9 (16G).

### The HW model number, product name this change applies to (if applicable)
PowerEdge R6715 (iDRAC10), PowerEdge R760xd2 (iDRAC9).

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)
iDRAC10 1.20.80.50, iDRAC9 7.30.10.50.

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)
None — relies on the gofish `v0.22.0` already pinned in go.mod.

## Description for changelog/release notes

```
Add BootDeviceSet/BootDeviceOverrideGet to the Dell provider, so boot-device actions use Redfish instead of always falling back to IPMI.
```
