### PR TITLE
chore(deps): upgrade bougou/go-ipmi to v0.9.1

### DIFF
--- a/examples/screenshot/main.go
+++ b/examples/screenshot/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/x509"
 	"flag"
-	"fmt"
 	"os"
 	"time"
 
@@ -72,7 +71,7 @@ func main() {
 		return
 	}
 
-	filename := fmt.Sprintf("screenshot." + fileType)
+	filename := "screenshot." + fileType
 	fh, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE, 0o600)
 	if err != nil {
 		l.WithError(err).Error()

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module github.com/bmc-toolbox/bmclib/v2
 
-go 1.23.0
+go 1.24.0
 
 require (
 	dario.cat/mergo v1.0.1
 	github.com/Jeffail/gabs/v2 v2.7.0
 	github.com/bmc-toolbox/common v0.0.1
 	github.com/bombsimon/logrusr/v2 v2.0.1
-	github.com/bougou/go-ipmi v0.8.3
+	github.com/bougou/go-ipmi v0.9.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zerologr v1.2.3
@@ -32,6 +32,7 @@ require (
 	github.com/VictorLowther/soap v0.0.0-20150314151524-8e36fca84b22 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.15.0 // indirect
+	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/kr/pretty v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/bmc-toolbox/common v0.0.1 h1:9Phffpmv1S0Qcfu/BD5j2rWoYMQ/tkA1sZs/9tmo
 github.com/bmc-toolbox/common v0.0.1/go.mod h1:Cdnkm+edb6C0pVkyCrwh3JTXAe0iUF9diDG/DztPI9I=
 github.com/bombsimon/logrusr/v2 v2.0.1 h1:1VgxVNQMCvjirZIYaT9JYn6sAVGVEcNtRE0y4mvaOAM=
 github.com/bombsimon/logrusr/v2 v2.0.1/go.mod h1:ByVAX+vHdLGAfdroiMg6q0zgq2FODY2lc5YJvzmOJio=
-github.com/bougou/go-ipmi v0.8.3 h1:jegrU+5lx5Moe/MiggLFIHCwDoVPd/BZuIOKYZS3BUY=
-github.com/bougou/go-ipmi v0.8.3/go.mod h1:HWli0nfKgnBtD/3ViiDaqp6wHZogZrg5A5ctMMDUYS0=
+github.com/bougou/go-ipmi v0.9.1 h1:dI/ihmEnJ/tIKjCsx85Rm8XPh2yiJll8CVFlYlFgY5c=
+github.com/bougou/go-ipmi v0.9.1/go.mod h1:09+IrJAgPdIwDEl2eBPQ/61e5Pl1m0WoBczP2oUwTN8=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -26,6 +26,8 @@ github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zerologr v1.2.3 h1:up5N9vcH9Xck3jJkXzgyOxozT14R47IyDODz8LM1KSs=
 github.com/go-logr/zerologr v1.2.3/go.mod h1:BxwGo7y5zgSHYR1BjbnHPyF/5ZjVKfKxAZANVu6E8Ho=
+github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
+github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -99,6 +101,7 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210608053332-aa57babbf139/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=

--- a/internal/goipmi/goipmi.go
+++ b/internal/goipmi/goipmi.go
@@ -10,7 +10,10 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 
-	"github.com/bougou/go-ipmi"
+	"github.com/bougou/go-ipmi/pkg/client"
+	"github.com/bougou/go-ipmi/pkg/command/chassis"
+	"github.com/bougou/go-ipmi/pkg/command/transport"
+	"github.com/bougou/go-ipmi/pkg/types"
 )
 
 // Ipmi holds the data for an ipmi connection
@@ -19,7 +22,7 @@ type Ipmi struct {
 	Password    string
 	Host        string
 	Port        int
-	client      *ipmi.Client
+	client      *client.Client
 	cipherSuite int
 	log         logr.Logger
 }
@@ -46,7 +49,7 @@ func WithLogger(log logr.Logger) Option {
 
 // New returns a new ipmi instance
 func New(username, password, host string, port int, opts ...Option) (c *Ipmi, err error) {
-	cl, err := ipmi.NewClient(host, port, username, password)
+	cl, err := client.NewClient(host, port, username, password)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +65,7 @@ func New(username, password, host string, port int, opts ...Option) (c *Ipmi, er
 	for _, opt := range opts {
 		opt(c)
 	}
-	c.client.WithInterface(ipmi.InterfaceLanplus)
+	c.client.WithInterface(client.InterfaceLanplus)
 	c.client.WithCipherSuiteID(toCipherSuiteID(c.cipherSuite))
 
 	return c, nil
@@ -72,7 +75,7 @@ func New(username, password, host string, port int, opts ...Option) (c *Ipmi, er
 // to run isolated operations (such as compatibility checks) without touching the
 // session state of the original connection.
 func (i *Ipmi) Clone() (*Ipmi, error) {
-	cl, err := ipmi.NewClient(i.Host, i.Port, i.Username, i.Password)
+	cl, err := client.NewClient(i.Host, i.Port, i.Username, i.Password)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +88,7 @@ func (i *Ipmi) Clone() (*Ipmi, error) {
 		cipherSuite: i.cipherSuite,
 		client:      cl,
 	}
-	c.client.WithInterface(ipmi.InterfaceLanplus)
+	c.client.WithInterface(client.InterfaceLanplus)
 	c.client.WithCipherSuiteID(toCipherSuiteID(c.cipherSuite))
 
 	return c, nil
@@ -113,11 +116,11 @@ func parseSystemEventLog(raw string) (entries [][]string) {
 	return entries
 }
 
-func toCipherSuiteID(c int) ipmi.CipherSuiteID {
+func toCipherSuiteID(c int) types.CipherSuiteID {
 	if c >= 0 && c <= 19 {
-		return ipmi.CipherSuiteID(c)
+		return types.CipherSuiteID(c)
 	}
-	return ipmi.CipherSuiteID3
+	return types.CipherSuiteID3
 }
 
 // Open establishes an IPMI LAN+ session to the BMC.
@@ -132,7 +135,7 @@ func (i *Ipmi) Close(ctx context.Context) error {
 
 // PowerCycle reboots the machine via bmc
 func (i *Ipmi) PowerCycle(ctx context.Context) (status bool, err error) {
-	_, err = i.client.ChassisControl(ctx, ipmi.ChassisControlPowerCycle)
+	_, err = i.client.ChassisControl(ctx, chassis.ChassisControlPowerCycle)
 	if err != nil {
 		return false, fmt.Errorf("chassis control failed: %v", err)
 	}
@@ -152,10 +155,10 @@ func (i *Ipmi) ForceRestart(ctx context.Context) (status bool, err error) {
 
 	if chassisStatus.PowerIsOn {
 		// System is on, do a power cycle
-		_, err = i.client.ChassisControl(ctx, ipmi.ChassisControlPowerCycle)
+		_, err = i.client.ChassisControl(ctx, chassis.ChassisControlPowerCycle)
 	} else {
 		// System is off, just power on
-		_, err = i.client.ChassisControl(ctx, ipmi.ChassisControlPowerUp)
+		_, err = i.client.ChassisControl(ctx, chassis.ChassisControlPowerUp)
 	}
 
 	if err != nil {
@@ -166,7 +169,7 @@ func (i *Ipmi) ForceRestart(ctx context.Context) (status bool, err error) {
 
 // PowerReset reboots the machine via bmc
 func (i *Ipmi) PowerReset(ctx context.Context) (status bool, err error) {
-	_, err = i.client.ChassisControl(ctx, ipmi.ChassisControlHardReset)
+	_, err = i.client.ChassisControl(ctx, chassis.ChassisControlHardReset)
 	if err != nil {
 		return false, fmt.Errorf("chassis control failed: %v", err)
 	}
@@ -209,7 +212,7 @@ func (i *Ipmi) PowerOn(ctx context.Context) (status bool, err error) {
 		return true, nil
 	}
 
-	_, err = i.client.ChassisControl(ctx, ipmi.ChassisControlPowerUp)
+	_, err = i.client.ChassisControl(ctx, chassis.ChassisControlPowerUp)
 	if err != nil {
 		return false, fmt.Errorf("chassis control failed: %v", err)
 	}
@@ -218,7 +221,7 @@ func (i *Ipmi) PowerOn(ctx context.Context) (status bool, err error) {
 
 // PowerOnForce power on the machine via bmc even when the machine is already on (Thanks HP!)
 func (i *Ipmi) PowerOnForce(ctx context.Context) (status bool, err error) {
-	_, err = i.client.ChassisControl(ctx, ipmi.ChassisControlPowerUp)
+	_, err = i.client.ChassisControl(ctx, chassis.ChassisControlPowerUp)
 	if err != nil {
 		return false, fmt.Errorf("chassis control failed: %v", err)
 	}
@@ -231,7 +234,7 @@ func (i *Ipmi) PowerOff(ctx context.Context) (status bool, err error) {
 		return true, nil
 	}
 
-	_, err = i.client.ChassisControl(ctx, ipmi.ChassisControlPowerDown)
+	_, err = i.client.ChassisControl(ctx, chassis.ChassisControlPowerDown)
 	if err != nil {
 		return false, fmt.Errorf("chassis control failed: %v", err)
 	}
@@ -248,7 +251,7 @@ func (i *Ipmi) PowerSoft(ctx context.Context) (status bool, err error) {
 		return true, nil
 	}
 
-	_, err = i.client.ChassisControl(ctx, ipmi.ChassisControlSoftShutdown)
+	_, err = i.client.ChassisControl(ctx, chassis.ChassisControlSoftShutdown)
 	if err != nil {
 		return false, fmt.Errorf("chassis control failed: %v", err)
 	}
@@ -257,7 +260,7 @@ func (i *Ipmi) PowerSoft(ctx context.Context) (status bool, err error) {
 
 // PxeOnceEfi makes the machine to boot via pxe once using EFI
 func (i *Ipmi) PxeOnceEfi(ctx context.Context) (status bool, err error) {
-	err = i.client.SetBootDevice(ctx, ipmi.BootDeviceSelectorForcePXE, ipmi.BIOSBootTypeEFI, false)
+	err = i.client.SetBootDevice(ctx, types.BootDeviceSelectorForcePXE, types.BIOSBootTypeEFI, false)
 	if err != nil {
 		return false, fmt.Errorf("set boot device failed: %v", err)
 	}
@@ -266,29 +269,29 @@ func (i *Ipmi) PxeOnceEfi(ctx context.Context) (status bool, err error) {
 
 // BootDeviceSet sets the next boot device with options
 func (i *Ipmi) BootDeviceSet(ctx context.Context, bootDevice string, setPersistent, efiBoot bool) (ok bool, err error) {
-	var device ipmi.BootDeviceSelector
+	var device types.BootDeviceSelector
 	switch strings.ToLower(bootDevice) {
 	case "pxe":
-		device = ipmi.BootDeviceSelectorForcePXE
+		device = types.BootDeviceSelectorForcePXE
 	case "disk", "hd":
-		device = ipmi.BootDeviceSelectorForceHardDrive
+		device = types.BootDeviceSelectorForceHardDrive
 	case "safe":
-		device = ipmi.BootDeviceSelectorForceHardDriveSafe
+		device = types.BootDeviceSelectorForceHardDriveSafe
 	case "diag":
-		device = ipmi.BootDeviceSelectorForceDiagnosticPartition
+		device = types.BootDeviceSelectorForceDiagnosticPartition
 	case "cdrom", "cd":
-		device = ipmi.BootDeviceSelectorForceCDROM
+		device = types.BootDeviceSelectorForceCDROM
 	case "bios", "setup":
-		device = ipmi.BootDeviceSelectorForceBIOSSetup
+		device = types.BootDeviceSelectorForceBIOSSetup
 	case "floppy":
-		device = ipmi.BootDeviceSelectorForceFloppy
+		device = types.BootDeviceSelectorForceFloppy
 	default:
-		device = ipmi.BootDeviceSelectorNoOverride
+		device = types.BootDeviceSelectorNoOverride
 	}
 
-	biosBootType := ipmi.BIOSBootTypeLegacy
+	biosBootType := types.BIOSBootTypeLegacy
 	if efiBoot {
-		biosBootType = ipmi.BIOSBootTypeEFI
+		biosBootType = types.BIOSBootTypeEFI
 	}
 
 	err = i.client.SetBootDevice(ctx, device, biosBootType, setPersistent)
@@ -300,7 +303,7 @@ func (i *Ipmi) BootDeviceSet(ctx context.Context, bootDevice string, setPersiste
 
 // PxeOnceMbr makes the machine to boot via pxe once using MBR
 func (i *Ipmi) PxeOnceMbr(ctx context.Context) (status bool, err error) {
-	err = i.client.SetBootDevice(ctx, ipmi.BootDeviceSelectorForcePXE, ipmi.BIOSBootTypeLegacy, false)
+	err = i.client.SetBootDevice(ctx, types.BootDeviceSelectorForcePXE, types.BIOSBootTypeLegacy, false)
 	if err != nil {
 		return false, fmt.Errorf("set boot device failed: %v", err)
 	}
@@ -410,7 +413,7 @@ func (i *Ipmi) GetSystemEventLogRaw(ctx context.Context) (eventlog string, err e
 		timestamp := entry.Standard.Timestamp.Format("01/02/2006 | 15:04:05")
 		sensorName := fmt.Sprintf("Sensor %d", entry.Standard.SensorNumber)
 		eventDir := "Asserted"
-		if entry.Standard.EventDir == ipmi.EventDirDeassertion {
+		if entry.Standard.EventDir == types.EventDirDeassertion {
 			eventDir = "Deasserted"
 		}
 		eventData := fmt.Sprintf("0x%02x 0x%02x 0x%02x",
@@ -428,13 +431,13 @@ func (i *Ipmi) GetSystemEventLogRaw(ctx context.Context) (eventlog string, err e
 
 // DeactivateSOL deactivates any active SOL payload, treating an already-deactivated payload as success.
 func (i *Ipmi) DeactivateSOL(ctx context.Context) (err error) {
-	_, err = i.client.DeactivatePayload(ctx, &ipmi.DeactivatePayloadRequest{
-		PayloadType:     ipmi.PayloadTypeSOL,
+	_, err = i.client.DeactivatePayload(ctx, &transport.DeactivatePayloadRequest{
+		PayloadType:     types.PayloadTypeSOL,
 		PayloadInstance: 0,
 	})
 	if err != nil {
 		// 0x80 means SOL was already deactivated; treat as success.
-		var respErr *ipmi.ResponseError
+		var respErr *types.ResponseError
 		if errors.As(err, &respErr) && respErr.CompletionCode() == 0x80 {
 			return nil
 		}
@@ -445,7 +448,7 @@ func (i *Ipmi) DeactivateSOL(ctx context.Context) (err error) {
 
 // SendPowerDiag tells the BMC to issue an NMI to the device
 func (i *Ipmi) SendPowerDiag(ctx context.Context) error {
-	_, err := i.client.ChassisControl(ctx, ipmi.ChassisControlDiagnosticInterrupt)
+	_, err := i.client.ChassisControl(ctx, chassis.ChassisControlDiagnosticInterrupt)
 	if err != nil {
 		return errors.Wrap(err, "failed sending power diag")
 	}


### PR DESCRIPTION
## What does this PR implement/change/remove?
upgrade bougou/go-ipmi to v0.9.1
go-ipmi v0.9.1 requires go >= 1.24, so bump the go directive from 1.23.0 to 1.24.0. 
### Checklist
- [x] Tests added
- [x] Similar commits squashed

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

## Description for changelog/release notes

```
upgrade bougou/go-ipmi to v0.9.1
```
