### PR TITLE
feat: add SetHTTPBootURI support

### DIFF
--- a/bmc/http_boot.go
+++ b/bmc/http_boot.go
@@ -1,0 +1,74 @@
+package bmc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+)
+
+// HTTPBootURISetter sets the URI UEFI HTTP Boot fetches its boot image from.
+type HTTPBootURISetter interface {
+	SetHTTPBootURI(ctx context.Context, uri string) (ok bool, err error)
+}
+
+// httpBootURIProviders is an internal struct to correlate an implementation/provider and its name
+type httpBootURIProviders struct {
+	name              string
+	httpBootURISetter HTTPBootURISetter
+}
+
+// setHTTPBootURI sets the HTTP Boot URI.
+func setHTTPBootURI(ctx context.Context, uri string, b []httpBootURIProviders) (ok bool, metadata Metadata, err error) {
+	var metadataLocal Metadata
+
+	for _, elem := range b {
+		if elem.httpBootURISetter == nil {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			err = multierror.Append(err, ctx.Err())
+
+			return false, metadata, err
+		default:
+			metadataLocal.ProvidersAttempted = append(metadataLocal.ProvidersAttempted, elem.name)
+			ok, setErr := elem.httpBootURISetter.SetHTTPBootURI(ctx, uri)
+			if setErr != nil {
+				err = multierror.Append(err, errors.WithMessagef(setErr, "provider: %v", elem.name))
+				continue
+			}
+			if !ok {
+				err = multierror.Append(err, fmt.Errorf("provider: %v, failed to set http boot uri", elem.name))
+				continue
+			}
+			metadataLocal.SuccessfulProvider = elem.name
+			return ok, metadataLocal, nil
+		}
+	}
+	return ok, metadataLocal, multierror.Append(err, errors.New("failed to set http boot uri"))
+}
+
+// SetHTTPBootURIFromInterfaces identifies implementations of the HTTPBootURISetter interface and passes the found implementations to the setHTTPBootURI() wrapper
+func SetHTTPBootURIFromInterfaces(ctx context.Context, uri string, generic []interface{}) (ok bool, metadata Metadata, err error) {
+	setters := make([]httpBootURIProviders, 0)
+	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
+		temp := httpBootURIProviders{name: getProviderName(elem)}
+		switch p := elem.(type) {
+		case HTTPBootURISetter:
+			temp.httpBootURISetter = p
+			setters = append(setters, temp)
+		default:
+			e := fmt.Sprintf("not a HTTPBootURISetter implementation: %T", p)
+			err = multierror.Append(err, errors.New(e))
+		}
+	}
+	if len(setters) == 0 {
+		return ok, metadata, multierror.Append(err, errors.New("no HTTPBootURISetter implementations found"))
+	}
+	return setHTTPBootURI(ctx, uri, setters)
+}

--- a/bmc/http_boot_test.go
+++ b/bmc/http_boot_test.go
@@ -1,0 +1,119 @@
+package bmc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-multierror"
+)
+
+type httpBootURITester struct {
+	MakeNotOK    bool
+	MakeErrorOut bool
+}
+
+func (r *httpBootURITester) SetHTTPBootURI(ctx context.Context, uri string) (ok bool, err error) {
+	if r.MakeErrorOut {
+		return ok, errors.New("setting http boot uri failed")
+	}
+	if r.MakeNotOK {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (r *httpBootURITester) Name() string {
+	return "test provider"
+}
+
+func TestSetHTTPBootURI(t *testing.T) {
+	testCases := map[string]struct {
+		uri          string
+		makeErrorOut bool
+		makeNotOk    bool
+		want         bool
+		err          error
+		ctxTimeout   time.Duration
+	}{
+		"success":               {uri: "http://example.com/boot.efi", want: true},
+		"not ok return":         {uri: "http://example.com/boot.efi", want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider, failed to set http boot uri"), errors.New("failed to set http boot uri")}}},
+		"error":                 {uri: "http://example.com/boot.efi", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider: setting http boot uri failed"), errors.New("failed to set http boot uri")}}},
+		"error context timeout": {uri: "http://example.com/boot.efi", want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded")}}, ctxTimeout: time.Nanosecond * 1},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			testImplementation := httpBootURITester{MakeErrorOut: tc.makeErrorOut, MakeNotOK: tc.makeNotOk}
+			expectedResult := tc.want
+			if tc.ctxTimeout == 0 {
+				tc.ctxTimeout = time.Second * 3
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
+			defer cancel()
+			result, _, err := setHTTPBootURI(ctx, tc.uri, []httpBootURIProviders{{"test provider", &testImplementation}})
+			if err != nil {
+				diff := cmp.Diff(err.Error(), tc.err.Error())
+				if diff != "" {
+					t.Fatal(diff)
+				}
+			} else {
+				diff := cmp.Diff(result, expectedResult)
+				if diff != "" {
+					t.Fatal(diff)
+				}
+			}
+		})
+	}
+}
+
+func TestSetHTTPBootURIFromInterfaces(t *testing.T) {
+	testCases := map[string]struct {
+		uri               string
+		err               error
+		badImplementation bool
+		want              bool
+		withName          bool
+	}{
+		"success":                  {uri: "http://example.com/boot.efi", want: true},
+		"success with metadata":    {uri: "http://example.com/boot.efi", want: true, withName: true},
+		"no implementations found": {uri: "http://example.com/boot.efi", want: false, badImplementation: true, err: &multierror.Error{Errors: []error{errors.New("not a HTTPBootURISetter implementation: *struct {}"), errors.New("no HTTPBootURISetter implementations found")}}},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var generic []interface{}
+			if tc.badImplementation {
+				badImplementation := struct{}{}
+				generic = []interface{}{&badImplementation}
+			} else {
+				testImplementation := httpBootURITester{}
+				generic = []interface{}{&testImplementation}
+			}
+			expectedResult := tc.want
+			result, metadata, err := SetHTTPBootURIFromInterfaces(context.Background(), tc.uri, generic)
+			if err != nil {
+				if tc.err != nil {
+					diff := cmp.Diff(err.Error(), tc.err.Error())
+					if diff != "" {
+						t.Fatal(diff)
+					}
+				} else {
+					t.Fatal(err)
+				}
+			} else {
+				diff := cmp.Diff(result, expectedResult)
+				if diff != "" {
+					t.Fatal(diff)
+				}
+			}
+			if tc.withName {
+				if diff := cmp.Diff(metadata.SuccessfulProvider, "test provider"); diff != "" {
+					t.Fatal(diff)
+				}
+			}
+		})
+	}
+}

--- a/client.go
+++ b/client.go
@@ -592,6 +592,18 @@ func (c *Client) SetVirtualMedia(ctx context.Context, kind, mediaURL string) (ok
 	return ok, err
 }
 
+// SetHTTPBootURI sets the URI UEFI HTTP Boot fetches its boot image from.
+func (c *Client) SetHTTPBootURI(ctx context.Context, uri string) (ok bool, err error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "SetHTTPBootURI")
+	defer span.End()
+
+	ok, metadata, err := bmc.SetHTTPBootURIFromInterfaces(ctx, uri, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return ok, err
+}
+
 // ResetBMC pass through to library function
 func (c *Client) ResetBMC(ctx context.Context, resetType string) (ok bool, err error) {
 	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "ResetBMC")

--- a/internal/redfishwrapper/http_boot.go
+++ b/internal/redfishwrapper/http_boot.go
@@ -1,0 +1,32 @@
+package redfishwrapper
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/stmcginnis/gofish/schemas"
+
+	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
+)
+
+// SetHTTPBootURI sets the URI UEFI HTTP Boot fetches its boot image from, via the standard
+// Redfish ComputerSystem.Boot.HttpBootUri property (Redfish schema v1.9.0+). It only sets that
+// one property, leaving BootSourceOverrideTarget/Enabled/Mode untouched — setting the URI does
+// not select UEFI HTTP Boot as the boot target; use SetBootDevice(..., "uefi_http", ...) for that.
+func (c *Client) SetHTTPBootURI(_ context.Context, uri string) (ok bool, err error) {
+	if err := c.SessionActive(); err != nil {
+		return false, errors.Wrap(bmclibErrs.ErrNotAuthenticated, err.Error())
+	}
+
+	system, err := c.System()
+	if err != nil {
+		return false, err
+	}
+
+	boot := schemas.Boot{HTTPBootURI: uri}
+	if err := system.SetBoot(&boot); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/internal/redfishwrapper/http_boot_test.go
+++ b/internal/redfishwrapper/http_boot_test.go
@@ -1,0 +1,67 @@
+package redfishwrapper
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newDellClientForBootTest is like newDellSecureBootClient but leaves the
+// System.Embedded.1 resource unregistered so the caller can install its own
+// GET/PATCH handler for it.
+func newDellClientForBootTest(t *testing.T, mux *http.ServeMux) *Client {
+	t.Helper()
+
+	mux.HandleFunc("/redfish/v1/", endpointFunc(t, "dell/serviceroot.json"))
+	mux.HandleFunc("/redfish/v1/Systems", endpointFunc(t, "dell/systems.json"))
+
+	server := httptest.NewTLSServer(mux)
+	t.Cleanup(server.Close)
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := NewClient(parsedURL.Hostname(), parsedURL.Port(), "", "", WithBasicAuthEnabled(true))
+
+	ctx := context.Background()
+	require.NoError(t, client.Open(ctx))
+	t.Cleanup(func() { _ = client.Close(ctx) })
+
+	return client
+}
+
+func TestSetHTTPBootURI(t *testing.T) {
+	var patchAttempts int
+	var patchBody map[string]any
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write(mustReadFile(t, "dell/system.embedded.1.json"))
+		case http.MethodPatch:
+			patchAttempts++
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&patchBody))
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+	client := newDellClientForBootTest(t, mux)
+
+	ok, err := client.SetHTTPBootURI(context.Background(), "http://boot.example.com/ipxe/boot.efi")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, 1, patchAttempts, "expected SetHTTPBootURI to PATCH the System resource once")
+
+	boot, ok := patchBody["Boot"].(map[string]any)
+	require.True(t, ok, "expected PATCH body to contain a Boot object")
+	assert.Equal(t, "http://boot.example.com/ipxe/boot.efi", boot["HttpBootUri"])
+	assert.Len(t, boot, 1, "expected only HttpBootUri to be sent, not other Boot fields such as BootSourceOverrideTarget")
+}

--- a/providers/dell/http_boot.go
+++ b/providers/dell/http_boot.go
@@ -1,0 +1,35 @@
+package dell
+
+import (
+	"context"
+	"fmt"
+)
+
+// httpBootDeviceIndex is the Dell "device" slot (HttpDevN in the BIOS attribute registry) this
+// file manages. Dell models HTTP Boot as up to 4 independently configurable per-NIC device
+// slots (HttpDev1..HttpDev4), each bound to a NIC FQDD via HttpDevNInterface - unlike
+// Supermicro/AMI Aptio's single global attribute. There is no field in bmc.NetworkBootConfig to
+// select a NIC, so this always targets slot 1, the primary boot device slot - confirmed live on
+// a PowerEdge R6715 (io18-kwdtpstorzur1-03, iDRAC firmware 1.5.3) where HttpDev1Interface is
+// already bound to the same NIC as PxeDev1Interface.
+const httpBootDeviceIndex = 1
+
+// SetHTTPBootURI sets the URI UEFI HTTP Boot fetches its boot image from.
+//
+// Unlike the Redfish-generic provider, which PATCHes the standard
+// ComputerSystem.Boot.HttpBootUri property, Dell's iDRAC does not populate that property at all
+// (confirmed live: absent from the Boot object entirely, not just empty, on iDRAC firmware
+// 1.5.3). Dell instead models the URI as a BIOS Setup attribute, HttpDevNUri, so this PATCHes
+// that attribute via SetBiosConfiguration instead. Independent of the HTTP Boot enable/disable
+// toggle: setting the URI does not enable the capability, and enabling the capability does not
+// require a URI, matching bmc.NetworkBootConfig's contract.
+func (c *Conn) SetHTTPBootURI(ctx context.Context, uri string) (ok bool, err error) {
+	attrs := map[string]string{
+		fmt.Sprintf("HttpDev%dUri", httpBootDeviceIndex): uri,
+	}
+	if err := c.redfishwrapper.SetBiosConfiguration(ctx, attrs); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/providers/dell/http_boot_test.go
+++ b/providers/dell/http_boot_test.go
@@ -1,0 +1,55 @@
+package dell
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetHTTPBootURI verifies SetHTTPBootURI PATCHes the HttpDev1Uri BIOS Setup attribute (device
+// slot 1, see httpBootDeviceIndex) rather than the generic Redfish ComputerSystem.Boot.HttpBootUri
+// property, which Dell's iDRAC doesn't populate at all.
+func TestSetHTTPBootURI(t *testing.T) {
+	var patched bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/", endpointFunc("/serviceroot.json"))
+	mux.HandleFunc("/redfish/v1/Systems", endpointFunc("/systems.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1", endpointFunc("/systems_embedded.1.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/Bios", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Bios","Attributes":{}}`))
+		case http.MethodPatch:
+			patched = true
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			assert.Contains(t, string(body), `"HttpDev1Uri":"http://example.com/ipxe.efi"`)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := New(parsedURL.Hostname(), "", "", logr.Discard(), WithPort(parsedURL.Port()), WithUseBasicAuth(true))
+	require.NoError(t, client.Open(context.Background()))
+	defer client.Close(context.Background())
+
+	ok, err := client.SetHTTPBootURI(context.Background(), "http://example.com/ipxe.efi")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.True(t, patched, "expected a PATCH to the Bios resource setting HttpDev1Uri")
+}

--- a/providers/dell/idrac.go
+++ b/providers/dell/idrac.go
@@ -41,6 +41,7 @@ var (
 		providers.FeaturePowerState,
 		providers.FeaturePowerSet,
 		providers.FeatureBootDeviceSet,
+		providers.FeatureSetHTTPBootURI,
 		providers.FeatureFirmwareInstallSteps,
 		providers.FeatureFirmwareUploadInitiateInstall,
 		providers.FeatureFirmwareTaskStatus,
@@ -110,6 +111,7 @@ func WithUseBasicAuth(useBasicAuth bool) Option {
 var (
 	_ bmc.BiosConfigurationGetter = (*Conn)(nil)
 	_ bmc.BiosConfigurationSetter = (*Conn)(nil)
+	_ bmc.HTTPBootURISetter       = (*Conn)(nil)
 )
 
 // Conn details for redfish client

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -24,6 +24,8 @@ const (
 	FeatureBootDeviceSet registrar.Feature = "bootdeviceset"
 	// FeatureVirtualMedia means an implementation can manage virtual media devices
 	FeatureVirtualMedia registrar.Feature = "virtualmedia"
+	// FeatureSetHTTPBootURI means an implementation can set the URI UEFI HTTP Boot fetches its boot image from
+	FeatureSetHTTPBootURI registrar.Feature = "sethttpbooturi"
 	// FeatureMountFloppyImage means an implementation uploads a floppy image for mounting as virtual media.
 	//
 	// note: This is differs from FeatureVirtualMedia which is limited to accepting a URL to download the image from.

--- a/providers/redfish/redfish.go
+++ b/providers/redfish/redfish.go
@@ -34,6 +34,7 @@ var Features = registrar.Features{
 	providers.FeatureUserDelete,
 	providers.FeatureBootDeviceSet,
 	providers.FeatureVirtualMedia,
+	providers.FeatureSetHTTPBootURI,
 	providers.FeatureInventoryRead,
 	providers.FeatureBmcReset,
 	providers.FeatureClearSystemEventLog,
@@ -51,6 +52,7 @@ var Features = registrar.Features{
 var (
 	_ bmc.BiosConfigurationGetter = (*Conn)(nil)
 	_ bmc.BiosConfigurationSetter = (*Conn)(nil)
+	_ bmc.HTTPBootURISetter       = (*Conn)(nil)
 )
 
 // Conn details for redfish client
@@ -236,6 +238,11 @@ func (c *Conn) BootDeviceOverrideGet(ctx context.Context) (bmc.BootDeviceOverrid
 // SetVirtualMedia sets the virtual media
 func (c *Conn) SetVirtualMedia(ctx context.Context, kind, mediaURL string) (ok bool, err error) {
 	return c.redfishwrapper.SetVirtualMedia(ctx, kind, mediaURL)
+}
+
+// SetHTTPBootURI sets the URI UEFI HTTP Boot fetches its boot image from
+func (c *Conn) SetHTTPBootURI(ctx context.Context, uri string) (ok bool, err error) {
+	return c.redfishwrapper.SetHTTPBootURI(ctx, uri)
 }
 
 // Inventory collects hardware inventory and install firmware information

--- a/providers/supermicro/supermicro.go
+++ b/providers/supermicro/supermicro.go
@@ -65,6 +65,7 @@ var Features = registrar.Features{
 	providers.FeatureResetSecureBootKeys,
 	providers.FeatureResetSecureBootDatabaseKeys,
 	providers.FeatureImportSecureBootCertificate,
+	providers.FeatureSetHTTPBootURI,
 }
 
 // supports
@@ -119,6 +120,7 @@ var (
 	_ bmc.BiosConfigurationGetter     = (*Client)(nil)
 	_ bmc.BiosConfigurationSetter     = (*Client)(nil)
 	_ bmc.BiosConfigurationFileSetter = (*Client)(nil)
+	_ bmc.HTTPBootURISetter           = (*Client)(nil)
 )
 
 // Client is a Supermicro BMC connection.
@@ -688,6 +690,15 @@ func hostIP(hostURL string) (string, error) {
 	}
 
 	return hostURLParsed.Host, nil
+}
+
+// SetHTTPBootURI sets the URI UEFI HTTP Boot fetches its boot image from
+func (c *Client) SetHTTPBootURI(ctx context.Context, uri string) (ok bool, err error) {
+	if c.serviceClient == nil || c.serviceClient.redfish == nil {
+		return false, errors.Wrap(bmclibErrs.ErrLoginFailed, "client not initialized")
+	}
+
+	return c.serviceClient.redfish.SetHTTPBootURI(ctx, uri)
 }
 
 // GetSecureBoot returns whether UEFI Secure Boot is currently enabled


### PR DESCRIPTION
Adds a new `HTTPBootURISetter` interface/dispatcher for setting the URI
UEFI HTTP Boot fetches its boot image from, wired for the generic Redfish,
Dell, and Supermicro providers.

- `bmc.SetHTTPBootURIFromInterfaces` / `Client.SetHTTPBootURI`: new
  dispatcher, following the existing SetVirtualMedia pattern.
- `internal/redfishwrapper`: PATCHes the standard Redfish
  ComputerSystem.Boot.HttpBootUri property (schema v1.9.0+). Setting the
  URI does not select UEFI HTTP Boot as the boot target -
  BootSourceOverrideTarget/Enabled/Mode are left untouched; use
  SetBootDevice(..., "uefi_http", ...) for that.
- `providers/redfish`, `providers/supermicro`: delegate to the above -
  both vendors expose the standard property.
- `providers/dell`: Dell's iDRAC does not populate
  ComputerSystem.Boot.HttpBootUri at all (confirmed live, absent from the
  Boot object entirely, not just empty, on iDRAC firmware 1.5.3). Dell
  instead models the URI as a per-NIC BIOS Setup attribute (HttpDevNUri),
  so this PATCHes that attribute via SetBiosConfiguration instead,
  targeting device slot 1 (there's no field yet to select a NIC).

Independent of the HTTP Boot enable/disable toggle (see the companion
SetNetworkBootEnabled PR) - setting the URI doesn't enable the capability,
and enabling the capability doesn't require a URI.

Tested live end-to-end via Tinkerbell workflows: Dell PowerEdge R6715
(iDRAC 1.5.3) and a Supermicro H12SSW-NTR board, both successfully
UEFI-HTTP-booting an iPXE binary using the URI this sets.