### PR TITLE
feat: add SetNetworkBootEnabled support

### DIFF
--- a/bmc/network_boot.go
+++ b/bmc/network_boot.go
@@ -1,0 +1,77 @@
+package bmc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+)
+
+// NetworkBootEnabledSetter enables/disables UEFI HTTP Boot and/or legacy PXE boot capability in
+// BIOS/UEFI firmware. Unlike BootDeviceSetter (which selects among existing boot options), this
+// creates or removes the boot options themselves. httpEnabled and pxeEnabled are independent: a
+// nil pointer leaves that protocol's state untouched, so either, both, or neither may be set.
+type NetworkBootEnabledSetter interface {
+	SetNetworkBootEnabled(ctx context.Context, httpEnabled, pxeEnabled *bool) (ok bool, err error)
+}
+
+// networkBootEnabledProviders is an internal struct to correlate an implementation/provider and its name
+type networkBootEnabledProviders struct {
+	name                     string
+	networkBootEnabledSetter NetworkBootEnabledSetter
+}
+
+// setNetworkBootEnabled sets the network boot enabled state.
+func setNetworkBootEnabled(ctx context.Context, httpEnabled, pxeEnabled *bool, b []networkBootEnabledProviders) (ok bool, metadata Metadata, err error) {
+	var metadataLocal Metadata
+
+	for _, elem := range b {
+		if elem.networkBootEnabledSetter == nil {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			err = multierror.Append(err, ctx.Err())
+
+			return false, metadata, err
+		default:
+			metadataLocal.ProvidersAttempted = append(metadataLocal.ProvidersAttempted, elem.name)
+			ok, setErr := elem.networkBootEnabledSetter.SetNetworkBootEnabled(ctx, httpEnabled, pxeEnabled)
+			if setErr != nil {
+				err = multierror.Append(err, errors.WithMessagef(setErr, "provider: %v", elem.name))
+				continue
+			}
+			if !ok {
+				err = multierror.Append(err, fmt.Errorf("provider: %v, failed to set network boot enabled state", elem.name))
+				continue
+			}
+			metadataLocal.SuccessfulProvider = elem.name
+			return ok, metadataLocal, nil
+		}
+	}
+	return ok, metadataLocal, multierror.Append(err, errors.New("failed to set network boot enabled state"))
+}
+
+// SetNetworkBootEnabledFromInterfaces identifies implementations of the NetworkBootEnabledSetter interface and passes the found implementations to the setNetworkBootEnabled() wrapper
+func SetNetworkBootEnabledFromInterfaces(ctx context.Context, httpEnabled, pxeEnabled *bool, generic []interface{}) (ok bool, metadata Metadata, err error) {
+	setters := make([]networkBootEnabledProviders, 0)
+	for _, elem := range generic {
+		if elem == nil {
+			continue
+		}
+		temp := networkBootEnabledProviders{name: getProviderName(elem)}
+		switch p := elem.(type) {
+		case NetworkBootEnabledSetter:
+			temp.networkBootEnabledSetter = p
+			setters = append(setters, temp)
+		default:
+			e := fmt.Sprintf("not a NetworkBootEnabledSetter implementation: %T", p)
+			err = multierror.Append(err, errors.New(e))
+		}
+	}
+	if len(setters) == 0 {
+		return ok, metadata, multierror.Append(err, errors.New("no NetworkBootEnabledSetter implementations found"))
+	}
+	return setNetworkBootEnabled(ctx, httpEnabled, pxeEnabled, setters)
+}

--- a/bmc/network_boot_test.go
+++ b/bmc/network_boot_test.go
@@ -1,0 +1,121 @@
+package bmc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-multierror"
+)
+
+func networkBootBoolPtr(b bool) *bool { return &b }
+
+type networkBootEnabledTester struct {
+	MakeNotOK    bool
+	MakeErrorOut bool
+}
+
+func (r *networkBootEnabledTester) SetNetworkBootEnabled(ctx context.Context, httpEnabled, pxeEnabled *bool) (ok bool, err error) {
+	if r.MakeErrorOut {
+		return ok, errors.New("setting network boot enabled state failed")
+	}
+	if r.MakeNotOK {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (r *networkBootEnabledTester) Name() string {
+	return "test provider"
+}
+
+func TestSetNetworkBootEnabled(t *testing.T) {
+	httpEnabled := networkBootBoolPtr(true)
+	testCases := map[string]struct {
+		makeErrorOut bool
+		makeNotOk    bool
+		want         bool
+		err          error
+		ctxTimeout   time.Duration
+	}{
+		"success":               {want: true},
+		"not ok return":         {want: false, makeNotOk: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider, failed to set network boot enabled state"), errors.New("failed to set network boot enabled state")}}},
+		"error":                 {want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("provider: test provider: setting network boot enabled state failed"), errors.New("failed to set network boot enabled state")}}},
+		"error context timeout": {want: false, makeErrorOut: true, err: &multierror.Error{Errors: []error{errors.New("context deadline exceeded")}}, ctxTimeout: time.Nanosecond * 1},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			testImplementation := networkBootEnabledTester{MakeErrorOut: tc.makeErrorOut, MakeNotOK: tc.makeNotOk}
+			expectedResult := tc.want
+			if tc.ctxTimeout == 0 {
+				tc.ctxTimeout = time.Second * 3
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
+			defer cancel()
+			result, _, err := setNetworkBootEnabled(ctx, httpEnabled, nil, []networkBootEnabledProviders{{"test provider", &testImplementation}})
+			if err != nil {
+				diff := cmp.Diff(err.Error(), tc.err.Error())
+				if diff != "" {
+					t.Fatal(diff)
+				}
+			} else {
+				diff := cmp.Diff(result, expectedResult)
+				if diff != "" {
+					t.Fatal(diff)
+				}
+			}
+		})
+	}
+}
+
+func TestSetNetworkBootEnabledFromInterfaces(t *testing.T) {
+	httpEnabled := networkBootBoolPtr(true)
+	testCases := map[string]struct {
+		err               error
+		badImplementation bool
+		want              bool
+		withName          bool
+	}{
+		"success":                  {want: true},
+		"success with metadata":    {want: true, withName: true},
+		"no implementations found": {want: false, badImplementation: true, err: &multierror.Error{Errors: []error{errors.New("not a NetworkBootEnabledSetter implementation: *struct {}"), errors.New("no NetworkBootEnabledSetter implementations found")}}},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var generic []interface{}
+			if tc.badImplementation {
+				badImplementation := struct{}{}
+				generic = []interface{}{&badImplementation}
+			} else {
+				testImplementation := networkBootEnabledTester{}
+				generic = []interface{}{&testImplementation}
+			}
+			expectedResult := tc.want
+			result, metadata, err := SetNetworkBootEnabledFromInterfaces(context.Background(), httpEnabled, nil, generic)
+			if err != nil {
+				if tc.err != nil {
+					diff := cmp.Diff(err.Error(), tc.err.Error())
+					if diff != "" {
+						t.Fatal(diff)
+					}
+				} else {
+					t.Fatal(err)
+				}
+			} else {
+				diff := cmp.Diff(result, expectedResult)
+				if diff != "" {
+					t.Fatal(diff)
+				}
+			}
+			if tc.withName {
+				if diff := cmp.Diff(metadata.SuccessfulProvider, "test provider"); diff != "" {
+					t.Fatal(diff)
+				}
+			}
+		})
+	}
+}

--- a/client.go
+++ b/client.go
@@ -604,6 +604,18 @@ func (c *Client) SetHTTPBootURI(ctx context.Context, uri string) (ok bool, err e
 	return ok, err
 }
 
+// SetNetworkBootEnabled enables/disables UEFI HTTP Boot and/or legacy PXE boot capability.
+func (c *Client) SetNetworkBootEnabled(ctx context.Context, httpEnabled, pxeEnabled *bool) (ok bool, err error) {
+	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "SetNetworkBootEnabled")
+	defer span.End()
+
+	ok, metadata, err := bmc.SetNetworkBootEnabledFromInterfaces(ctx, httpEnabled, pxeEnabled, c.registry().GetDriverInterfaces())
+	c.setMetadata(metadata)
+	metadata.RegisterSpanAttributes(c.Auth.Host, span)
+
+	return ok, err
+}
+
 // ResetBMC pass through to library function
 func (c *Client) ResetBMC(ctx context.Context, resetType string) (ok bool, err error) {
 	ctx, span := c.traceprovider.Tracer(pkgName).Start(ctx, "ResetBMC")

--- a/internal/redfishwrapper/network_boot.go
+++ b/internal/redfishwrapper/network_boot.go
@@ -1,0 +1,117 @@
+package redfishwrapper
+
+import (
+	"context"
+	"fmt"
+)
+
+const (
+	attrEnabled  = "Enabled"
+	attrDisabled = "Disabled"
+	attrUEFI     = "UEFI"
+)
+
+// networkBootFingerprintTables resolves the BIOS attribute PATCH body needed to enable or
+// disable UEFI HTTP Boot and/or legacy PXE boot capability, based on a fingerprint match against
+// a machine's current BIOS configuration.
+//
+// fingerprint keys are attribute names that, if present in a GetBiosConfiguration() result,
+// identify this table as applicable. Extend with one entry per additional vendor/board as
+// fleets need them — do not attempt to support unknown BIOS/vendor combinations silently.
+//
+// httpEnabled/httpDisabled and pxeEnabled/pxeDisabled are independent attribute sets: HTTP Boot
+// and legacy PXE are separate capabilities that can be on or off in any combination. NetworkStack
+// and BootModeSelect are prerequisites shared by both protocols, so they're only asserted on the
+// enabled side of each set — disabling one protocol must not turn off the network stack the
+// other protocol may still depend on.
+var networkBootFingerprintTables = []struct {
+	fingerprint  string // attribute name unique enough to identify this BIOS/vendor
+	httpEnabled  map[string]string
+	httpDisabled map[string]string
+	pxeEnabled   map[string]string
+	pxeDisabled  map[string]string
+}{
+	{
+		fingerprint: "IPv4HTTPSupport", // Supermicro H12SSW-NTR / AMI Aptio, confirmed live
+		httpEnabled: map[string]string{
+			"NetworkStack":    attrEnabled,
+			"BootModeSelect":  attrUEFI,
+			"IPv4HTTPSupport": attrEnabled,
+			"IPv6HTTPSupport": attrEnabled,
+		},
+		httpDisabled: map[string]string{
+			"IPv4HTTPSupport": attrDisabled,
+			"IPv6HTTPSupport": attrDisabled,
+		},
+		pxeEnabled: map[string]string{
+			"NetworkStack":   attrEnabled,
+			"BootModeSelect": attrUEFI,
+			"IPv4PXESupport": attrEnabled,
+		},
+		pxeDisabled: map[string]string{
+			"IPv4PXESupport": attrDisabled,
+		},
+	},
+}
+
+// SetNetworkBootEnabled enables/disables UEFI HTTP Boot and/or legacy PXE boot capability by
+// PATCHing the BIOS attributes resolved from the machine's current BIOS configuration via a
+// fingerprint match (see networkBootFingerprintTables). httpEnabled and pxeEnabled are
+// independent: a nil pointer leaves that protocol's attributes untouched, so either, both, or
+// neither may be set.
+func (c *Client) SetNetworkBootEnabled(ctx context.Context, httpEnabled, pxeEnabled *bool) (ok bool, err error) {
+	if httpEnabled == nil && pxeEnabled == nil {
+		return false, fmt.Errorf("at least one of httpEnabled or pxeEnabled must be set")
+	}
+
+	current, err := c.GetBiosConfiguration(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to read current BIOS configuration: %w", err)
+	}
+
+	attrs, err := networkBootAttributes(httpEnabled, pxeEnabled, current)
+	if err != nil {
+		return false, err
+	}
+
+	if err := c.SetBiosConfiguration(ctx, attrs); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// networkBootAttributes returns the BIOS attribute PATCH body for the requested HTTP Boot / PXE
+// Boot enabled states, selecting the table whose fingerprint attribute is present in current
+// (the machine's live GetBiosConfiguration result). Returns an error if no known table matches —
+// silently no-op'ing on an unrecognized BIOS is worse than a clear, actionable failure.
+func networkBootAttributes(httpEnabled, pxeEnabled *bool, current map[string]string) (map[string]string, error) {
+	for _, t := range networkBootFingerprintTables {
+		if _, ok := current[t.fingerprint]; !ok {
+			continue
+		}
+
+		attrs := map[string]string{}
+		if httpEnabled != nil {
+			mergeNetworkBootAttrs(attrs, pickNetworkBootAttrs(*httpEnabled, t.httpEnabled, t.httpDisabled))
+		}
+		if pxeEnabled != nil {
+			mergeNetworkBootAttrs(attrs, pickNetworkBootAttrs(*pxeEnabled, t.pxeEnabled, t.pxeDisabled))
+		}
+		return attrs, nil
+	}
+	return nil, fmt.Errorf("no known BIOS attribute mapping for this machine (fingerprint attributes not found in GetBiosConfiguration result)")
+}
+
+func pickNetworkBootAttrs(enabled bool, onTrue, onFalse map[string]string) map[string]string {
+	if enabled {
+		return onTrue
+	}
+	return onFalse
+}
+
+func mergeNetworkBootAttrs(dst, src map[string]string) {
+	for k, v := range src {
+		dst[k] = v
+	}
+}

--- a/internal/redfishwrapper/network_boot_test.go
+++ b/internal/redfishwrapper/network_boot_test.go
@@ -1,0 +1,170 @@
+package redfishwrapper
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func networkBootBoolPtr(b bool) *bool { return &b }
+
+func TestNetworkBootAttributes(t *testing.T) {
+	tests := map[string]struct {
+		httpEnabled *bool
+		pxeEnabled  *bool
+		current     map[string]string
+		want        map[string]string
+		wantError   bool
+	}{
+		"enable http only, pxe untouched": {
+			httpEnabled: networkBootBoolPtr(true),
+			current:     map[string]string{"IPv4HTTPSupport": "Disabled", "IPv4PXESupport": "Enabled"},
+			want: map[string]string{
+				"NetworkStack":    "Enabled",
+				"BootModeSelect":  "UEFI",
+				"IPv4HTTPSupport": "Enabled",
+				"IPv6HTTPSupport": "Enabled",
+			},
+		},
+		"disable http only, pxe untouched": {
+			httpEnabled: networkBootBoolPtr(false),
+			current:     map[string]string{"IPv4HTTPSupport": "Enabled"},
+			want: map[string]string{
+				"IPv4HTTPSupport": "Disabled",
+				"IPv6HTTPSupport": "Disabled",
+			},
+		},
+		"enable pxe only, http untouched": {
+			pxeEnabled: networkBootBoolPtr(true),
+			current:    map[string]string{"IPv4HTTPSupport": "Enabled", "IPv4PXESupport": "Disabled"},
+			want: map[string]string{
+				"NetworkStack":   "Enabled",
+				"BootModeSelect": "UEFI",
+				"IPv4PXESupport": "Enabled",
+			},
+		},
+		"disable pxe only, http untouched": {
+			pxeEnabled: networkBootBoolPtr(false),
+			current:    map[string]string{"IPv4HTTPSupport": "Enabled"},
+			want: map[string]string{
+				"IPv4PXESupport": "Disabled",
+			},
+		},
+		"enable both http and pxe": {
+			httpEnabled: networkBootBoolPtr(true),
+			pxeEnabled:  networkBootBoolPtr(true),
+			current:     map[string]string{"IPv4HTTPSupport": "Disabled"},
+			want: map[string]string{
+				"NetworkStack":    "Enabled",
+				"BootModeSelect":  "UEFI",
+				"IPv4HTTPSupport": "Enabled",
+				"IPv6HTTPSupport": "Enabled",
+				"IPv4PXESupport":  "Enabled",
+			},
+		},
+		"disable http while enabling pxe": {
+			httpEnabled: networkBootBoolPtr(false),
+			pxeEnabled:  networkBootBoolPtr(true),
+			current:     map[string]string{"IPv4HTTPSupport": "Enabled"},
+			want: map[string]string{
+				"NetworkStack":    "Enabled",
+				"BootModeSelect":  "UEFI",
+				"IPv4HTTPSupport": "Disabled",
+				"IPv6HTTPSupport": "Disabled",
+				"IPv4PXESupport":  "Enabled",
+			},
+		},
+		"unknown fingerprint returns error": {
+			httpEnabled: networkBootBoolPtr(true),
+			current:     map[string]string{"SomeUnrelatedAttribute": "value"},
+			wantError:   true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := networkBootAttributes(tt.httpEnabled, tt.pxeEnabled, tt.current)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected nil err, got: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("unexpected attributes (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSetNetworkBootEnabled(t *testing.T) {
+	var patchBody map[string]string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/", endpointFunc(t, "/dell/serviceroot.json"))
+	mux.HandleFunc("/redfish/v1/Systems", endpointFunc(t, "/dell/systems.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1", endpointFunc(t, "/dell/system.embedded.1.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/Bios", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{
+				"@odata.type": "#Bios.v1_2_3.Bios",
+				"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios",
+				"Id": "Bios",
+				"Name": "BIOS Configuration",
+				"AttributeRegistry": "BiosAttributeRegistryU32.v1_0_0",
+				"Attributes": {
+					"IPv4HTTPSupport": "Disabled"
+				}
+			}`))
+		case http.MethodPatch:
+			var body struct {
+				Attributes map[string]string `json:"Attributes"`
+			}
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			patchBody = body.Attributes
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	client := NewClient(parsedURL.Hostname(), parsedURL.Port(), "", "", WithBasicAuthEnabled(true))
+	require.NoError(t, client.Open(ctx))
+	defer client.Close(ctx)
+
+	ok, err := client.SetNetworkBootEnabled(ctx, networkBootBoolPtr(true), nil)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, map[string]string{
+		"NetworkStack":    "Enabled",
+		"BootModeSelect":  "UEFI",
+		"IPv4HTTPSupport": "Enabled",
+		"IPv6HTTPSupport": "Enabled",
+	}, patchBody)
+}
+
+func TestSetNetworkBootEnabled_NeitherSet(t *testing.T) {
+	client := NewClient("unused", "", "", "")
+
+	ok, err := client.SetNetworkBootEnabled(context.Background(), nil, nil)
+	assert.False(t, ok)
+	assert.ErrorContains(t, err, "at least one of httpEnabled or pxeEnabled must be set")
+}

--- a/providers/dell/idrac.go
+++ b/providers/dell/idrac.go
@@ -42,6 +42,7 @@ var (
 		providers.FeaturePowerSet,
 		providers.FeatureBootDeviceSet,
 		providers.FeatureSetHTTPBootURI,
+		providers.FeatureSetNetworkBootEnabled,
 		providers.FeatureFirmwareInstallSteps,
 		providers.FeatureFirmwareUploadInitiateInstall,
 		providers.FeatureFirmwareTaskStatus,
@@ -109,9 +110,10 @@ func WithUseBasicAuth(useBasicAuth bool) Option {
 
 // compile-time assertions that the provider implements the BIOS configuration interfaces.
 var (
-	_ bmc.BiosConfigurationGetter = (*Conn)(nil)
-	_ bmc.BiosConfigurationSetter = (*Conn)(nil)
-	_ bmc.HTTPBootURISetter       = (*Conn)(nil)
+	_ bmc.BiosConfigurationGetter  = (*Conn)(nil)
+	_ bmc.BiosConfigurationSetter  = (*Conn)(nil)
+	_ bmc.HTTPBootURISetter        = (*Conn)(nil)
+	_ bmc.NetworkBootEnabledSetter = (*Conn)(nil)
 )
 
 // Conn details for redfish client

--- a/providers/dell/network_boot.go
+++ b/providers/dell/network_boot.go
@@ -1,0 +1,53 @@
+package dell
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// networkBootDeviceIndex is the Dell "device" slot (HttpDevN / PxeDevN in the BIOS attribute
+// registry) this file manages. Dell models HTTP Boot and PXE as up to 4 and 16 independently
+// enable/disable-able per-NIC device slots respectively (HttpDev1..HttpDev4,
+// PxeDev1..PxeDev16), each bound to a NIC FQDD via HttpDevNInterface/PxeDevNInterface - unlike
+// Supermicro/AMI Aptio's single global attribute pair. There is no field in bmc.NetworkBootConfig
+// to select a NIC, so this always targets slot 1, the primary boot device slot - confirmed live
+// on a PowerEdge R6715 (iDRAC firmware 1.5.3) where both HttpDev1Interface and PxeDev1Interface
+// are already bound to the same NIC (NIC.Slot.5-1-1).
+const networkBootDeviceIndex = 1
+
+const (
+	attrEnabled  = "Enabled"
+	attrDisabled = "Disabled"
+)
+
+// SetNetworkBootEnabled enables/disables UEFI HTTP Boot and/or legacy PXE boot capability by
+// PATCHing Dell's per-NIC HttpDevNEnDis/PxeDevNEnDis BIOS Setup attributes (see
+// networkBootDeviceIndex). httpEnabled and pxeEnabled are independent: a nil pointer leaves that
+// protocol's attribute untouched, so either, both, or neither may be set.
+func (c *Conn) SetNetworkBootEnabled(ctx context.Context, httpEnabled, pxeEnabled *bool) (ok bool, err error) {
+	if httpEnabled == nil && pxeEnabled == nil {
+		return false, errors.New("at least one of httpEnabled or pxeEnabled must be set")
+	}
+
+	attrs := map[string]string{}
+	if httpEnabled != nil {
+		attrs[fmt.Sprintf("HttpDev%dEnDis", networkBootDeviceIndex)] = enDis(*httpEnabled)
+	}
+	if pxeEnabled != nil {
+		attrs[fmt.Sprintf("PxeDev%dEnDis", networkBootDeviceIndex)] = enDis(*pxeEnabled)
+	}
+
+	if err := c.redfishwrapper.SetBiosConfiguration(ctx, attrs); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func enDis(enabled bool) string {
+	if enabled {
+		return attrEnabled
+	}
+	return attrDisabled
+}

--- a/providers/dell/network_boot_test.go
+++ b/providers/dell/network_boot_test.go
@@ -1,0 +1,98 @@
+package dell
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func networkBootBoolPtr(b bool) *bool { return &b }
+
+// newNetworkBootTestClient wires a mux to a fresh Conn, capturing every PATCH to the Bios
+// resource's body into patchedBodies.
+func newNetworkBootTestClient(t *testing.T, patchedBodies *[]string) *Conn {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/", endpointFunc("/serviceroot.json"))
+	mux.HandleFunc("/redfish/v1/Systems", endpointFunc("/systems.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1", endpointFunc("/systems_embedded.1.json"))
+	mux.HandleFunc("/redfish/v1/Systems/System.Embedded.1/Bios", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Bios","Attributes":{}}`))
+		case http.MethodPatch:
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			*patchedBodies = append(*patchedBodies, string(body))
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	server := httptest.NewTLSServer(mux)
+	t.Cleanup(server.Close)
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := New(parsedURL.Hostname(), "", "", logr.Discard(), WithPort(parsedURL.Port()), WithUseBasicAuth(true))
+	require.NoError(t, client.Open(context.Background()))
+	t.Cleanup(func() { _ = client.Close(context.Background()) })
+
+	return client
+}
+
+// TestSetNetworkBootEnabled verifies SetNetworkBootEnabled PATCHes Dell's per-NIC
+// HttpDev1EnDis/PxeDev1EnDis BIOS Setup attributes (device slot 1, see networkBootDeviceIndex),
+// and that httpEnabled/pxeEnabled are independent: only the non-nil one is included in the PATCH.
+func TestSetNetworkBootEnabled(t *testing.T) {
+	testCases := map[string]struct {
+		httpEnabled *bool
+		pxeEnabled  *bool
+		want        string
+		notWant     string
+	}{
+		"http only": {httpEnabled: networkBootBoolPtr(true), want: `"HttpDev1EnDis":"Enabled"`, notWant: "PxeDev1EnDis"},
+		"pxe only":  {pxeEnabled: networkBootBoolPtr(false), want: `"PxeDev1EnDis":"Disabled"`, notWant: "HttpDev1EnDis"},
+		"both, http on pxe off": {
+			httpEnabled: networkBootBoolPtr(true),
+			pxeEnabled:  networkBootBoolPtr(false),
+			want:        `"HttpDev1EnDis":"Enabled"`,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var patchedBodies []string
+			client := newNetworkBootTestClient(t, &patchedBodies)
+
+			ok, err := client.SetNetworkBootEnabled(context.Background(), tc.httpEnabled, tc.pxeEnabled)
+			require.NoError(t, err)
+			assert.True(t, ok)
+			require.Len(t, patchedBodies, 1)
+			assert.Contains(t, patchedBodies[0], tc.want)
+			if tc.notWant != "" {
+				assert.NotContains(t, patchedBodies[0], tc.notWant)
+			}
+		})
+	}
+}
+
+func TestSetNetworkBootEnabled_NeitherSet(t *testing.T) {
+	var patchedBodies []string
+	client := newNetworkBootTestClient(t, &patchedBodies)
+
+	ok, err := client.SetNetworkBootEnabled(context.Background(), nil, nil)
+	assert.False(t, ok)
+	assert.ErrorContains(t, err, "at least one of httpEnabled or pxeEnabled must be set")
+	assert.Empty(t, patchedBodies, "expected no PATCH when neither httpEnabled nor pxeEnabled is set")
+}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -26,6 +26,8 @@ const (
 	FeatureVirtualMedia registrar.Feature = "virtualmedia"
 	// FeatureSetHTTPBootURI means an implementation can set the URI UEFI HTTP Boot fetches its boot image from
 	FeatureSetHTTPBootURI registrar.Feature = "sethttpbooturi"
+	// FeatureSetNetworkBootEnabled means an implementation can enable/disable UEFI HTTP Boot and/or legacy PXE boot capability
+	FeatureSetNetworkBootEnabled registrar.Feature = "setnetworkbootenabled"
 	// FeatureMountFloppyImage means an implementation uploads a floppy image for mounting as virtual media.
 	//
 	// note: This is differs from FeatureVirtualMedia which is limited to accepting a URL to download the image from.

--- a/providers/redfish/redfish.go
+++ b/providers/redfish/redfish.go
@@ -35,6 +35,7 @@ var Features = registrar.Features{
 	providers.FeatureBootDeviceSet,
 	providers.FeatureVirtualMedia,
 	providers.FeatureSetHTTPBootURI,
+	providers.FeatureSetNetworkBootEnabled,
 	providers.FeatureInventoryRead,
 	providers.FeatureBmcReset,
 	providers.FeatureClearSystemEventLog,
@@ -50,9 +51,10 @@ var Features = registrar.Features{
 
 // compile-time assertions that the provider implements the BIOS configuration interfaces.
 var (
-	_ bmc.BiosConfigurationGetter = (*Conn)(nil)
-	_ bmc.BiosConfigurationSetter = (*Conn)(nil)
-	_ bmc.HTTPBootURISetter       = (*Conn)(nil)
+	_ bmc.BiosConfigurationGetter  = (*Conn)(nil)
+	_ bmc.BiosConfigurationSetter  = (*Conn)(nil)
+	_ bmc.HTTPBootURISetter        = (*Conn)(nil)
+	_ bmc.NetworkBootEnabledSetter = (*Conn)(nil)
 )
 
 // Conn details for redfish client
@@ -243,6 +245,11 @@ func (c *Conn) SetVirtualMedia(ctx context.Context, kind, mediaURL string) (ok b
 // SetHTTPBootURI sets the URI UEFI HTTP Boot fetches its boot image from
 func (c *Conn) SetHTTPBootURI(ctx context.Context, uri string) (ok bool, err error) {
 	return c.redfishwrapper.SetHTTPBootURI(ctx, uri)
+}
+
+// SetNetworkBootEnabled enables/disables UEFI HTTP Boot and/or legacy PXE boot capability
+func (c *Conn) SetNetworkBootEnabled(ctx context.Context, httpEnabled, pxeEnabled *bool) (ok bool, err error) {
+	return c.redfishwrapper.SetNetworkBootEnabled(ctx, httpEnabled, pxeEnabled)
 }
 
 // Inventory collects hardware inventory and install firmware information

--- a/providers/supermicro/supermicro.go
+++ b/providers/supermicro/supermicro.go
@@ -66,6 +66,7 @@ var Features = registrar.Features{
 	providers.FeatureResetSecureBootDatabaseKeys,
 	providers.FeatureImportSecureBootCertificate,
 	providers.FeatureSetHTTPBootURI,
+	providers.FeatureSetNetworkBootEnabled,
 }
 
 // supports
@@ -121,6 +122,7 @@ var (
 	_ bmc.BiosConfigurationSetter     = (*Client)(nil)
 	_ bmc.BiosConfigurationFileSetter = (*Client)(nil)
 	_ bmc.HTTPBootURISetter           = (*Client)(nil)
+	_ bmc.NetworkBootEnabledSetter    = (*Client)(nil)
 )
 
 // Client is a Supermicro BMC connection.
@@ -699,6 +701,15 @@ func (c *Client) SetHTTPBootURI(ctx context.Context, uri string) (ok bool, err e
 	}
 
 	return c.serviceClient.redfish.SetHTTPBootURI(ctx, uri)
+}
+
+// SetNetworkBootEnabled enables/disables UEFI HTTP Boot and/or legacy PXE boot capability
+func (c *Client) SetNetworkBootEnabled(ctx context.Context, httpEnabled, pxeEnabled *bool) (ok bool, err error) {
+	if c.serviceClient == nil || c.serviceClient.redfish == nil {
+		return false, errors.Wrap(bmclibErrs.ErrLoginFailed, "client not initialized")
+	}
+
+	return c.serviceClient.redfish.SetNetworkBootEnabled(ctx, httpEnabled, pxeEnabled)
 }
 
 // GetSecureBoot returns whether UEFI Secure Boot is currently enabled


### PR DESCRIPTION
Adds a new `NetworkBootEnabledSetter` interface/dispatcher for
enabling/disabling UEFI HTTP Boot and/or legacy PXE boot capability in
BIOS/UEFI firmware - independent of SetHTTPBootURI (see the companion PR):
enabling/disabling the capability and pointing it at a boot image are
separate concerns with no reason to be coupled.

- `bmc.SetNetworkBootEnabledFromInterfaces` / `Client.SetNetworkBootEnabled`:
  new dispatcher. httpEnabled/pxeEnabled are independent - a nil pointer
  leaves that protocol untouched, so either, both, or neither may be set.
- `internal/redfishwrapper`: carries a BIOS-attribute fingerprint table
  (currently one entry: Supermicro/AMI Aptio, confirmed live on an
  AS-1114S-WN10RT-EU) that resolves the right PATCH body from a machine's
  current GetBiosConfiguration result. This previously lived in a
  downstream consumer (tinkerbell/rufio) - per-vendor BIOS attribute
  knowledge belongs in bmclib so any caller gets it, not just the one
  that happened to need it first. Returns a clear error rather than
  silently no-op'ing on an unrecognized BIOS.
- `providers/redfish`, `providers/supermicro`: delegate to the above.
- `providers/dell`: targets Dell's per-NIC HttpDevNEnDis/PxeDevNEnDis BIOS
  Setup attributes instead, which the generic fingerprint table doesn't
  recognize - device slot 1, same as the companion SetHTTPBootURI PR.

Tested live end-to-end via Tinkerbell workflows on the same two boards as
the companion PR - the fingerprint table applies and takes effect
(confirmed via a real reboot and UEFI HTTP Boot attempt), and the Dell
attributes were confirmed via a live PATCH against a PowerEdge R6715.