### PR TITLE
fix(redfish): don't let the connect deadline become the per-request timeout

### DIFF
--- a/internal/redfishwrapper/client.go
+++ b/internal/redfishwrapper/client.go
@@ -152,8 +152,26 @@ func (c *Client) Open(ctx context.Context) error {
 		config.DumpWriter = os.Stdout
 	}
 
+	// gofish stores a single context at construction and ignores the context passed to
+	// individual calls, so bounding the connect below by ctx requires setting the HTTP
+	// client's own Timeout. That must not be done on config.HTTPClient itself: gofish.Connect
+	// stores this exact pointer into the resulting APIClient and reuses it for every later call
+	// on this connection, and WithHTTPClient lets a caller share one *http.Client across
+	// multiple bmclib connections - mutating its Timeout in place would race with a concurrent
+	// Open on another connection sharing that same client. Use a private shallow copy instead:
+	// Transport (and so the underlying connection pool) is still shared, but Timeout becomes
+	// independent, and nothing outside this call ever observes it.
+	//
+	// The copy's Timeout is restored before Open returns, since gofish.Connect's stored pointer
+	// makes this copy - not the original - what every subsequent call on this connection uses:
+	// ctx bounds only this Open, and a connect deadline is routinely far shorter than the
+	// slowest legitimate later operation (a Dell BIOS attribute write takes ~10s).
 	if tm := getTimeout(ctx); tm != 0 {
-		config.HTTPClient.Timeout = tm
+		bounded := *config.HTTPClient
+		restore := bounded.Timeout
+		bounded.Timeout = tm
+		config.HTTPClient = &bounded
+		defer func() { bounded.Timeout = restore }()
 	}
 	var err error
 	c.client, err = gofish.Connect(config)

--- a/internal/redfishwrapper/client_test.go
+++ b/internal/redfishwrapper/client_test.go
@@ -6,11 +6,13 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stmcginnis/gofish/schemas"
 	"github.com/stretchr/testify/assert"
 
 	bmclibErrs "github.com/bmc-toolbox/bmclib/v2/errors"
+	"github.com/bmc-toolbox/bmclib/v2/internal/httpclient"
 )
 
 func TestWithVersionsNotCompatible(t *testing.T) {
@@ -340,4 +342,75 @@ func TestGetBootProgress(t *testing.T) {
 			assert.ElementsMatch(t, tc.expect, got)
 		})
 	}
+}
+
+func TestOpenRestoresHTTPClientTimeout(t *testing.T) {
+	// Open bounds the connect by the ctx deadline via the HTTP client's Timeout,
+	// because gofish ignores per-call contexts. That deadline must not outlive
+	// Open: the same client serves every later call on the connection, and a
+	// connect deadline is typically much shorter than a slow-but-valid operation.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/", endpointFunc(t, "serviceroot.json"))
+	mux.HandleFunc("/redfish/v1/Systems", endpointFunc(t, "systems.json"))
+	mux.HandleFunc("/redfish/v1/Managers", endpointFunc(t, "managers.json"))
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+
+	httpClient := httpclient.Build()
+	configured := httpClient.Timeout
+	assert.NotZero(t, configured, "test needs a non-zero configured timeout to be meaningful")
+
+	client := NewClient(parsedURL.Hostname(), parsedURL.Port(), "", "", WithHTTPClient(httpClient))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	assert.NoError(t, client.Open(ctx))
+	defer client.Close(ctx)
+
+	assert.Equal(t, configured, httpClient.Timeout)
+}
+
+func TestOpenBoundsConnectByContext(t *testing.T) {
+	// Complements TestOpenRestoresHTTPClientTimeout: that test proves the configured
+	// timeout isn't left mutated after Open returns, but a no-op fix (never touching
+	// HTTPClient.Timeout at all) would pass it just as trivially. This test proves the
+	// other half - that Open actually still bounds the connect by the shorter ctx
+	// deadline, not by the client's much longer configured timeout - by giving the
+	// server a response delay in between the two and asserting Open fails around the
+	// short ctx deadline rather than hanging until the long configured one.
+	const ctxDeadline = 100 * time.Millisecond
+	const serverDelay = 500 * time.Millisecond
+	const configuredTimeout = 10 * time.Second
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(serverDelay)
+		endpointFunc(t, "serviceroot.json")(w, r)
+	})
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+
+	httpClient := httpclient.Build()
+	httpClient.Timeout = configuredTimeout
+
+	client := NewClient(parsedURL.Hostname(), parsedURL.Port(), "", "", WithHTTPClient(httpClient))
+
+	ctx, cancel := context.WithTimeout(context.Background(), ctxDeadline)
+	defer cancel()
+
+	start := time.Now()
+	err = client.Open(ctx)
+	elapsed := time.Since(start)
+
+	assert.Error(t, err, "expected the connect to fail once it outlives the ctx deadline")
+	assert.Less(t, elapsed, serverDelay, "expected Open to fail before the server even responds, bounded by ctx rather than by the much longer configured timeout")
 }


### PR DESCRIPTION
## Summary

`Open()` bounds the connect by setting the HTTP client's `Timeout` from the ctx deadline, because gofish stores one context at construction and ignores the context passed to individual calls. That override was never undone, so the value leaked into every subsequent call on the connection.

Callers pass a *connect* deadline, and bmclib divides it further: `Client.defaultTimeout` is `ctx-remaining/len(registry.Drivers)`, so with the 9 providers registered by default a 60s connect budget leaves ~6.6s - which then silently caps every later operation. A Dell `Bios/Settings` PATCH takes ~10s (the iDRAC creates a Lifecycle Controller job before returning 202), so it could never complete within that leftover budget, while the BMC applied the change anyway a moment after the client hung up: a reported failure that actually took effect.

This restores the previous `Timeout` value once the connect returns, so `ctx` bounds `Open` only and later calls use the client's configured timeout.

## Test plan
- Added `TestOpenRestoresHTTPClientTimeout`, verifying the configured `http.Client` timeout is unchanged after `Open` returns.
- Added `TestOpenBoundsConnectByContext`, verifying `Open` still fails around the short ctx deadline rather than hanging until the client's much longer configured timeout.
- `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `go test ./...` all pass.