### PR TITLE
build: update gofish and adapt to Boot.HttpBootURI becoming a pointer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
 	github.com/sirupsen/logrus v1.9.3
-	github.com/stmcginnis/gofish v0.24.1-0.20260826144359-aa6a0d77e479
+	github.com/stmcginnis/gofish v0.25.1-0.20260910061323-82603738c3d2
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.29.0
 	go.opentelemetry.io/otel/trace v1.29.0

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/stmcginnis/gofish v0.24.1-0.20260826144359-aa6a0d77e479 h1:FuKSjxinf+dN6TrYWzB6YsIJZdCQGU5KwFhmhHGfDSM=
-github.com/stmcginnis/gofish v0.24.1-0.20260826144359-aa6a0d77e479/go.mod h1:PzF5i8ecRG9A2ol8XT64npKUunyraJ+7t0kYMpQAtqU=
+github.com/stmcginnis/gofish v0.25.1-0.20260910061323-82603738c3d2 h1:5x4FnF2mC4Z2K3Aks+sOqxaYMnMI4ZZnd21hcLnoIko=
+github.com/stmcginnis/gofish v0.25.1-0.20260910061323-82603738c3d2/go.mod h1:PzF5i8ecRG9A2ol8XT64npKUunyraJ+7t0kYMpQAtqU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/internal/redfishwrapper/http_boot.go
+++ b/internal/redfishwrapper/http_boot.go
@@ -23,7 +23,7 @@ func (c *Client) SetHTTPBootURI(_ context.Context, uri string) (ok bool, err err
 		return false, err
 	}
 
-	boot := schemas.Boot{HTTPBootURI: uri}
+	boot := schemas.Boot{HTTPBootURI: &uri}
 	if err := system.SetBoot(&boot); err != nil {
 		return false, err
 	}

--- a/providers/dell/http_boot.go
+++ b/providers/dell/http_boot.go
@@ -10,8 +10,8 @@ import (
 // slots (HttpDev1..HttpDev4), each bound to a NIC FQDD via HttpDevNInterface - unlike
 // Supermicro/AMI Aptio's single global attribute. There is no field in bmc.NetworkBootConfig to
 // select a NIC, so this always targets slot 1, the primary boot device slot - confirmed live on
-// a PowerEdge R6715 (io18-kwdtpstorzur1-03, iDRAC firmware 1.5.3) where HttpDev1Interface is
-// already bound to the same NIC as PxeDev1Interface.
+// a PowerEdge R6715 (iDRAC firmware 1.5.3) where HttpDev1Interface is already bound to the same
+// NIC as PxeDev1Interface.
 const httpBootDeviceIndex = 1
 
 // SetHTTPBootURI sets the URI UEFI HTTP Boot fetches its boot image from.


### PR DESCRIPTION
## Summary

The `gofish` pin was three commits behind upstream `main` (and two behind the `v0.25.0` tag). This picks up `stmcginnis/gofish` #566, #568 and #569.

`#569` made `ComputerSystem.Boot`'s `HttpBootURI` a `*string` so it can be cleared by setting it to `nil`. That's a compile break for `SetHTTPBootURI`'s struct literal, hence the one-line adaptation.

The second commit is unrelated housekeeping: the comment on `networkBootDeviceIndex` cited the specific machine the behaviour was confirmed on. The hardware model and firmware version are the useful part and stay; the hostname only meant something inside one fleet.

A note on the pin: this is a pseudo-version rather than a tag because no tagged gofish release contains #569 yet - `v0.25.0` predates it. Happy to switch to the next tagged release once gofish cuts one.

## Test plan
- `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 new issues), `go test ./...` all pass.
- Both commits build and pass tests independently.